### PR TITLE
ARTEMIS-5437 Add a bridging feature to AMQP broker connections

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionManager.java
@@ -102,7 +102,6 @@ public class AMQPBrokerConnectionManager implements ActiveMQComponent, ClientCon
     *
     * @param configurations A list of broker connection configurations after a broker configuration update.
     */
-   @SuppressWarnings("unchecked")
    public void updateConfiguration(List<AMQPBrokerConnectConfiguration> configurations) throws Exception {
       final List<AMQPBrokerConnectConfiguration> updatedConfigurations =
          configurations != null ? configurations : Collections.emptyList();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeAddressPolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeAddressPolicy.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.settings.impl.Match;
+import org.apache.qpid.proton.amqp.Symbol;
+
+/**
+ * Policy used for bridging addresses between peers.
+ */
+public final class AMQPBridgeAddressPolicy extends AMQPBridgePolicy implements BiPredicate<String, RoutingType> {
+
+   private final Set<AddressMatcher> includesMatchers = new LinkedHashSet<>();
+   private final Set<AddressMatcher> excludesMatchers = new LinkedHashSet<>();
+
+   private final Collection<String> includes;
+   private final Collection<String> excludes;
+
+   private final boolean includeDivertBindings;
+
+   public AMQPBridgeAddressPolicy(String policyName, boolean includeDivertBindings,
+                                  Integer priority, String filter, String remoteAddress,
+                                  String remoteAddressPrefix, String remoteAddressSuffix,
+                                  Collection<Symbol> remoteTerminusCapabilities,
+                                  Collection<String> includeAddresses,
+                                  Collection<String> excludeAddresses,
+                                  Map<String, Object> properties,
+                                  TransformerConfiguration transformerConfig,
+                                  WildcardConfiguration wildcardConfig) {
+      super(policyName, priority, filter, remoteAddress, remoteAddressPrefix, remoteAddressSuffix,
+            remoteTerminusCapabilities, properties, transformerConfig, wildcardConfig);
+
+      this.includeDivertBindings = includeDivertBindings;
+
+      this.includes = Collections.unmodifiableCollection(includeAddresses == null ? Collections.emptyList() : includeAddresses);
+      this.excludes = Collections.unmodifiableCollection(excludeAddresses == null ? Collections.emptyList() : excludeAddresses);
+
+      // Create Matchers from configured includes and excludes for use when matching broker resources
+      includes.forEach((address) -> includesMatchers.add(new AddressMatcher(address, wildcardConfig)));
+      excludes.forEach((address) -> excludesMatchers.add(new AddressMatcher(address, wildcardConfig)));
+   }
+
+   public boolean isIncludeDivertBindings() {
+      return includeDivertBindings;
+   }
+
+   /**
+    * Convenience test method for those who have an {@link AddressInfo} object
+    * but don't want to deal with the {@link SimpleString} object or any null
+    * checks.
+    *
+    * @param addressInfo
+    *    The address info to check which if null will result in a negative result.
+    *
+    * @return <code>true</code> if the address value matches this configured policy.
+    */
+   public boolean test(AddressInfo addressInfo) {
+      if (addressInfo != null) {
+         return test(addressInfo.getName().toString(), addressInfo.getRoutingType());
+      } else {
+         return false;
+      }
+   }
+
+   @Override
+   public boolean test(String address, RoutingType type) {
+      if (RoutingType.MULTICAST.equals(type)) {
+         for (AddressMatcher matcher : excludesMatchers) {
+            if (matcher.test(address)) {
+               return false;
+            }
+         }
+
+         for (AddressMatcher matcher : includesMatchers) {
+            if (matcher.test(address)) {
+               return true;
+            }
+         }
+      }
+
+      return false;
+   }
+
+   private static class AddressMatcher implements Predicate<String> {
+
+      private final Predicate<String> matcher;
+
+      AddressMatcher(String address, WildcardConfiguration wildcardConfig) {
+         if (address == null || address.isEmpty()) {
+            matcher = (target) -> true;
+         } else {
+            matcher = new Match<>(address, null, wildcardConfig).getPattern().asPredicate();
+         }
+      }
+
+      @Override
+      public boolean test(String address) {
+         return matcher.test(address);
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeAsyncCompletion.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeAsyncCompletion.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+/**
+ * An asynchronous completion type used to implement the handlers for asynchronous calls in AMQP
+ * bridge types.
+ *
+ * @param <E>
+ *    The type that defines the context provided to the completion events
+ */
+public interface AMQPBridgeAsyncCompletion<E> {
+
+   /**
+    * Called when the asynchronous operation has succeeded.
+    *
+    * @param context
+    *    The context object provided for this asynchronous event.
+    */
+   void onComplete(E context);
+
+   /**
+    * Called when the asynchronous operation has failed due to an error.
+    *
+    * @param context
+    *    The context object provided for this asynchronous event.
+    * @param error
+    *    The error that describes the failure that occurred.
+    */
+   void onException(E context, Exception error);
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConfiguration.java
@@ -1,0 +1,317 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LARGE_MESSAGE_THRESHOLD;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_CORE_MESSAGE_TUNNELING_ENABLED;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_DISABLE_RECEIVER_DEMAND_TRACKING;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_IGNNORE_QUEUE_CONSUMER_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_IGNNORE_QUEUE_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_DISABLE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_PULL_CREDIT_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_QUEUE_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_SEND_SETTLED;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+
+/**
+ * A configuration class that contains API for getting AMQP bridge specific configuration
+ * either from a {@link Map} of configuration elements or from the connection associated
+ * with the bridge instance, or possibly from a set default value.
+ */
+public class AMQPBridgeConfiguration {
+
+   private final Map<String, Object> properties;
+   private final AMQPConnectionContext connection;
+
+   public AMQPBridgeConfiguration(AMQPConnectionContext connection, Map<String, Object> properties) {
+      Objects.requireNonNull(connection, "Connection provided cannot be null");
+
+      this.connection = connection;
+
+      if (properties != null && !properties.isEmpty()) {
+         this.properties = new HashMap<>(properties);
+      } else {
+         this.properties = Collections.emptyMap();
+      }
+   }
+
+   /**
+    * {@return the credit batch size offered to a receiver link}
+    */
+   public int getReceiverCredits() {
+      final Object property = properties.get(RECEIVER_CREDITS);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return connection.getAmqpCredits();
+      }
+   }
+
+   /**
+    * {@return the number of remaining credits on a receiver before the batch is replenished}
+    */
+   public int getReceiverCreditsLow() {
+      final Object property = properties.get(RECEIVER_CREDITS_LOW);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return connection.getAmqpLowCredits();
+      }
+   }
+
+   /**
+    * {@return the credit batch size offered to a receiver link that is in pull mode}
+    */
+   public int getPullReceiverBatchSize() {
+      final Object property = properties.get(PULL_RECEIVER_BATCH_SIZE);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return DEFAULT_PULL_CREDIT_BATCH_SIZE;
+      }
+   }
+
+   /**
+    * {@return the size in bytes of an incoming message after which the receiver treats it as large}
+    */
+   public int getLargeMessageThreshold() {
+      final Object property = properties.get(LARGE_MESSAGE_THRESHOLD);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return connection.getProtocolManager().getAmqpMinLargeMessageSize();
+      }
+   }
+
+   /**
+    * {@return the timeout value to use when waiting for a corresponding link attach from the remote}
+    */
+   public int getLinkAttachTimeout() {
+      final Object property = properties.get(LINK_ATTACH_TIMEOUT);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return DEFAULT_LINK_ATTACH_TIMEOUT;
+      }
+   }
+
+   /**
+    * {@return true if the bridge is configured to tunnel core messages as AMQP custom messages}
+    */
+   public boolean isCoreMessageTunnelingEnabled() {
+      final Object property = properties.get(AmqpSupport.TUNNEL_CORE_MESSAGES);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return DEFAULT_CORE_MESSAGE_TUNNELING_ENABLED;
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if the bridge is configured to ignore filters on individual queue consumers}
+    */
+   public boolean isIgnoreSubscriptionFilters() {
+      final Object property = properties.get(IGNORE_QUEUE_CONSUMER_FILTERS);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return DEFAULT_IGNNORE_QUEUE_CONSUMER_FILTERS;
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if the bridge is configured to ignore filters on the bridged Queue}
+    */
+   public boolean isIgnoreQueueFilters() {
+      final Object property = properties.get(IGNORE_QUEUE_FILTERS);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return DEFAULT_IGNNORE_QUEUE_FILTERS;
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if bridge is configured to omit any priority properties on receiver links}
+    */
+   public boolean isReceiverPriorityDisabled() {
+      final Object property = properties.get(DISABLE_RECEIVER_PRIORITY);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return DEFAULT_DISABLE_RECEIVER_PRIORITY;
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if bridge is configured to ignore local demand and always create a receiver}
+    */
+   public boolean isReceiverDemandTrackingDisabled() {
+      final Object property = properties.get(DISABLE_RECEIVER_DEMAND_TRACKING);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return DEFAULT_DISABLE_RECEIVER_DEMAND_TRACKING;
+      }
+   }
+
+   /**
+    * {@return the receive quiesce timeout when shutting down a receiver when local demand is removed}
+    */
+   public int getReceiverQuiesceTimeout() {
+      final Object property = properties.get(RECEIVER_QUIESCE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return DEFAULT_RECEIVER_QUIESCE_TIMEOUT;
+      }
+   }
+
+   /**
+    * {@return the receive idle timeout when shutting down a address Receiver when local demand is removed}
+    */
+   public int getAddressReceiverIdleTimeout() {
+      final Object property = properties.get(ADDRESS_RECEIVER_IDLE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return DEFAULT_ADDRESS_RECEIVER_IDLE_TIMEOUT;
+      }
+   }
+
+   /**
+    * {@return the receive idle timeout when shutting down a queue Receiver when local demand is removed}
+    */
+   public int getQueueReceiverIdleTimeout() {
+      final Object property = properties.get(QUEUE_RECEIVER_IDLE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return DEFAULT_QUEUE_RECEIVER_IDLE_TIMEOUT;
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if bridge is configured to create links with the sender settle mode set to settled}
+    */
+   public boolean isUsingPresettledSenders() {
+      final Object property = properties.get(PRESETTLE_SEND_MODE);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return DEFAULT_SEND_SETTLED;
+      }
+   }
+
+   /**
+    * {@return the maximum number of link recovery attempts, or zero if no attempts allowed}
+    */
+   public int getMaxLinkRecoveryAttempts() {
+      final Object property = properties.get(MAX_LINK_RECOVERY_ATTEMPTS);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return DEFAULT_MAX_LINK_RECOVERY_ATTEMPTS;
+      }
+   }
+
+   /**
+    * {@return the initial delay before a link recovery attempt is made}
+    */
+   public long getLinkRecoveryInitialDelay() {
+      final Object property = properties.get(LINK_RECOVERY_INITIAL_DELAY);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return DEFAULT_LINK_RECOVERY_INITIAL_DELAY;
+      }
+   }
+
+   /**
+    * {@return the delay that will be used between successive link recovery attempts}
+    */
+   public long getLinkRecoveryDelay() {
+      final Object property = properties.get(LINK_RECOVERY_DELAY);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return DEFAULT_LINK_RECOVERY_DELAY;
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConstants.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Map;
+import org.apache.qpid.proton.amqp.Symbol;
+
+/**
+ * Constants class for values used in the AMQP Bridge implementation.
+ */
+public final class AMQPBridgeConstants {
+
+   /**
+    * Property value that can be applied to bridge configuration that controls the timeout value
+    * for a link attach to complete before the attach attempt is considered to have failed. The value
+    * is configured in seconds (default is 30 seconds).
+    */
+   public static final String LINK_ATTACH_TIMEOUT = "attach-timeout";
+
+   /**
+    * Default timeout value (in seconds) used to control when a link attach is considered to have
+    * failed due to not responding to an attach request.
+    */
+   public static final int DEFAULT_LINK_ATTACH_TIMEOUT = 30;
+
+   /**
+    * Configuration property that defines the amount of credits to batch to an AMQP receiver link
+    * and the top up limit when sending more credit once the credits are determined to be running
+    * low. Overrides the credits value configured on the connector URI and can also override the
+    * value assigned to a parent bridge configuration in an receiver from address or queue policy.
+    */
+   public static final String RECEIVER_CREDITS = "amqpCredits";
+
+   /**
+    * A low water mark for receiver credits that indicates more should be sent to top it up to the
+    * original credit batch size. Overrides the low credits value configured on the connector URI and
+    * can also override the value assigned to a parent bridge configuration in an receiver from address
+    * or queue policy. If the receiver credits is set to zero this configuration value is ignored.
+    */
+   public static final String RECEIVER_CREDITS_LOW = "amqpLowCredits";
+
+   /**
+    * Configuration property that defines the amount of credits to batch to an AMQP receiver link
+    * and the top up value when sending more credit once the broker has capacity available for
+    * them. This value is set of the bridge connection configuration or can override the parent
+    * bridge connection value if set on a bridge from queue configuration
+    */
+   public static final String PULL_RECEIVER_BATCH_SIZE = "amqpPullConsumerCredits";
+
+   /**
+    * Default credits granted to a receiver that is in pull mode.
+    */
+   public static final int DEFAULT_PULL_CREDIT_BATCH_SIZE = 10;
+
+   /**
+    * Configuration property used to override the value set on the connector to use when considering
+    * if an incoming message is a large message,
+    */
+   public static final String LARGE_MESSAGE_THRESHOLD = "minLargeMessageSize";
+
+   /**
+    * Configuration property used to set the value to use when considering if bridged queue consumers
+    * should filter using the filters defined on individual queue subscriptions. This can be used to prevent
+    * multiple subscriptions on the same queue based on local demand with differing subscription filters
+    * but does imply that message that don't match those filters would be bridged to the local broker. The
+    * filters applied would be JMS filters which implies the remote needs to support JMS filters to apply
+    * them to the created receiver instance.
+    */
+   public static final String IGNORE_QUEUE_CONSUMER_FILTERS = "ignoreQueueConsumerFilters";
+
+   /**
+    * Default value for the filtering applied to bridge Queue consumers that controls if
+    * the filter specified by a consumer subscription is used or if the higher level Queue
+    * filter only is applied when creating a bridge Queue consumer.
+    */
+   public static final boolean DEFAULT_IGNNORE_QUEUE_CONSUMER_FILTERS = false;
+
+   /**
+    * Configuration property used to set the value to use when considering if bridged queue consumers
+    * should filter using the filters defined on individual queue definitions. The filters applied would
+    * be JMS filters which implies the remote needs to support JMS filters to apply them to the created
+    * receiver instance. This value would be checked only after checking the initiating queue subscription
+    * for a filter and it either had none, or the ignore subscription option was set to <code>true</code>.
+    */
+   public static final String IGNORE_QUEUE_FILTERS = "ignoreQueueFilters";
+
+   /**
+    * Default value for the filtering applied to bridge Queue consumers that controls if
+    * the filter specified by a Queue is applied when creating a bridge Queue consumer.
+    */
+   public static final boolean DEFAULT_IGNNORE_QUEUE_FILTERS = false;
+
+   /**
+    * Configuration property used to set whether the bridging receiver links should omit any priority
+    * values in the link properties of receivers created to bridge addresses or queues from a remote peer.
+    * This can be used to omit this value if the remote does not support it and reacts badly to its
+    * presence in the link properties.
+    */
+   public static final String DISABLE_RECEIVER_PRIORITY = "disableReceiverPriority";
+
+   /**
+    * Default value for ignoring the addition of a link property indicating the priority to
+    * assign to a receiver link either for address or queue policy managers.
+    */
+   public static final boolean DEFAULT_DISABLE_RECEIVER_PRIORITY = false;
+
+   /**
+    * Configuration property used to set whether the bridging receiver links should track local demand
+    * on the bridged resource and simply always create a remote receiver regardless of local demand for
+    * bridged messages. This can still be combined with pull receiver functionality but due to the possibility
+    * that there are no active consumers of pulled messages the bridge receiver would only ever grant at most
+    * one batch of credit until local backlog is removed by the addition of a local consumer or a purge of the
+    * bridged resource.
+    */
+   public static final String DISABLE_RECEIVER_DEMAND_TRACKING = "disableReceiverDemandTracking";
+
+   /**
+    * Default value for ignoring local demand as the trigger for bridging an address or queue and
+    * simple always creating a receiver if the address or queue that matches the policy exists.
+    */
+   public static final boolean DEFAULT_DISABLE_RECEIVER_DEMAND_TRACKING = false;
+
+   /**
+    * Link Property added to the receiver properties when opening an AMQP bridge address or queue consumer
+    * that indicates the consumer priority that should be used when creating the remote consumer. The
+    * value assign to the properties {@link Map} is a signed integer value. This value is set on each bridge
+    * receiver so long as the option to disable receiver priority is not set to <code>true</code>.
+    */
+   public static final Symbol BRIDGE_RECEIVER_PRIORITY = Symbol.getSymbol("priority");
+
+   /**
+    * Property added to the bridge policies which controls if senders are marked as presettled meaning
+    * the messages are sent as settled before dispatch which can improve performance at the cost of
+    * reliability.
+    */
+   public static final String PRESETTLE_SEND_MODE = "presettle";
+
+   /**
+    * Default value for link sender settle mode on send to and receiver from bridge policy created
+    * links.
+    */
+   public static final boolean DEFAULT_SEND_SETTLED = false;
+
+   /**
+    * Configuration options that controls the maximum number of retires that are attempted when a bridge
+    * link is rejected or closed due to a recoverable error such as not-found or remote forced close.
+    * A negative value indicates there is no retry limit and a value of zero indicates retries are disabled.
+    * The link recoveries stop after this value or for demand dependent links the recoveries stop if local
+    * demand is removed.
+    */
+   public static final String MAX_LINK_RECOVERY_ATTEMPTS = "maxLinkRecoveryAttempts";
+
+   /**
+    * Default value for the number of link recovery attempts that will be made for a link that failed to
+    * attach or was closed later due to some remote condition, negative values mean try forever.
+    */
+   public static final int DEFAULT_MAX_LINK_RECOVERY_ATTEMPTS = -1;
+
+   /**
+    * Configuration options that controls the initial delay (in milliseconds) before the first link recovery
+    * attempt is made when a remote link is closed or rejected.
+    */
+   public static final String LINK_RECOVERY_INITIAL_DELAY = "linkRecoveryInitialDelay";
+
+   /**
+    * Default delay in that will be used on the first link recovery attempt.
+    */
+   public static final long DEFAULT_LINK_RECOVERY_INITIAL_DELAY = 1_000;
+
+   /**
+    * Configuration options that controls the delay (in milliseconds) that will be used as successive link
+    * recovery attempts are made.
+    */
+   public static final String LINK_RECOVERY_DELAY = "linkRecoveryDelay";
+
+   /**
+    * Default delay in that will be used as successive link recovery attempts are made.
+    */
+   public static final long DEFAULT_LINK_RECOVERY_DELAY = 60_000;
+
+   /**
+    * Default value for the core message tunneling feature that indicates if core protocol messages
+    * should be streamed as binary blobs as the payload of an custom AMQP message which avoids any
+    * conversions of the messages to / from AMQP.
+    */
+   public static final boolean DEFAULT_CORE_MESSAGE_TUNNELING_ENABLED = true;
+
+   /**
+    * Default priority adjustment used for a bridge queue policy if no value was specific in the
+    * broker configuration file.
+    */
+   public static final int DEFAULT_PRIORITY_ADJUSTMENT_VALUE = -1;
+
+   /**
+    * When a bridge receiver link is being closed due to removal of local demand this timeout
+    * value enforces a maximum wait for drain and processing of in-flight messages before the link
+    * is forcibly terminated with the assumption that the remote is no longer responding.
+    */
+   public static final String RECEIVER_QUIESCE_TIMEOUT = "receiverQuiesceTimeout";
+
+   /**
+    * Default timeout (milliseconds) applied to bridge receivers that are being closed due to removal
+    * of local demand and need to drain link credit and process any in-flight deliveries before closure.
+    * If the timeout elapses before the link has quiesced the link is forcibly closed.
+    */
+   public static final int DEFAULT_RECEIVER_QUIESCE_TIMEOUT = 60_000;
+
+   /**
+    * When a bridge address receiver link has been successfully drained after demand was removed
+    * from the bridged resource, this value controls how long the link can remain in an attached but
+    * idle state before it is closed.
+    */
+   public static final String ADDRESS_RECEIVER_IDLE_TIMEOUT = "addressReceiverIdleTimeout";
+
+   /**
+    * Default timeout (milliseconds) applied to bridge address receivers that have been stopped due to
+    * lack of local demand. The close delay prevent a link from detaching in cases where demand drops and
+    * returns in quick succession allowing for faster recovery. The idle timeout kicks in once the link has
+    * completed its drain of outstanding credit.
+    */
+   public static final int DEFAULT_ADDRESS_RECEIVER_IDLE_TIMEOUT = 5_000;
+
+   /**
+    * When a bridge queue receiver link has been successfully drained after demand was removed
+    * from the bridged resource, this value controls how long the link can remain in an attached but
+    * idle state before it is closed.
+    */
+   public static final String QUEUE_RECEIVER_IDLE_TIMEOUT = "queueReceiverIdleTimeout";
+
+   /**
+    * Default timeout (milliseconds) applied to bridge queue receivers that have been stopped due to
+    * lack of local demand. The close delay prevent a link from detaching in cases where demand drops and
+    * returns in quick succession allowing for faster recovery. The idle timeout kicks in once the link has
+    * completed its drain of outstanding credit.
+    */
+   public static final int DEFAULT_QUEUE_RECEIVER_IDLE_TIMEOUT = 60_000;
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressPolicyManager.java
@@ -1,0 +1,445 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.postoffice.impl.DivertBinding;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerAddressPlugin;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeReceiverInfo.ReceiverRole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AMQP Bridge policy manager that tracks local addresses that match the policy configurations
+ * for local demand and creates receivers to the remote peer.
+ */
+public final class AMQPBridgeFromAddressPolicyManager extends AMQPBridgeFromPolicyManager implements ActiveMQServerAddressPlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final AMQPBridgeAddressPolicy policy;
+   private final Map<String, AMQPBridgeAddressReceiverManager> bridgeReceivers = new HashMap<>();
+   private final Map<DivertBinding, Set<QueueBinding>> divertsTracking = new HashMap<>();
+
+   public AMQPBridgeFromAddressPolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metrics, AMQPBridgeAddressPolicy addressPolicy) {
+      super(bridge, metrics, addressPolicy.getPolicyName(), AMQPBridgeType.BRIDGE_FROM_ADDRESS);
+
+      Objects.requireNonNull(addressPolicy, "The Address match policy cannot be null");
+
+      this.policy = addressPolicy;
+   }
+
+   @Override
+   public AMQPBridgeAddressPolicy getPolicy() {
+      return policy;
+   }
+
+   @Override
+   protected void scanManagedResources() {
+      if (configuration.isReceiverDemandTrackingDisabled()) {
+         scanAllAddresses();
+      } else {
+         scanAllBindings();
+      }
+   }
+
+   @Override
+   protected void safeCleanupManagerResources(boolean force) {
+      try {
+         bridgeReceivers.values().forEach((manager) -> {
+            if (manager != null) {
+               if (isConnected() && !force) {
+                  manager.shutdown();
+               } else {
+                  manager.shutdownNow();
+               }
+            }
+         });
+      } finally {
+         bridgeReceivers.clear();
+         divertsTracking.clear();
+      }
+   }
+
+   @Override
+   public synchronized void afterRemoveAddress(SimpleString address, AddressInfo addressInfo) throws ActiveMQException {
+      if (isActive()) {
+         final AMQPBridgeAddressReceiverManager manager = bridgeReceivers.remove(address.toString());
+
+         if (manager != null) {
+            // Demand is gone because the Address is gone and any in-flight messages can be
+            // allowed to be released back to the remote as they will not be processed.
+            // We removed the receiver information from demand tracking to prevent build up
+            // of data for entries that may never return and to prevent interference from the
+            // next set of events which will be the close of all local receivers for this now
+            // removed Address.
+            manager.shutdownNow();
+         }
+      }
+   }
+
+   @Override
+   public synchronized void afterRemoveBinding(Binding binding, Transaction tx, boolean deleteData) throws ActiveMQException {
+      if (isActive() && !configuration.isReceiverDemandTrackingDisabled()) {
+         if (binding instanceof QueueBinding) {
+            final AMQPBridgeAddressReceiverManager manager = bridgeReceivers.get(binding.getAddress().toString());
+
+            if (manager != null) {
+               // This is QueueBinding that was mapped to a bridged address so we can directly remove
+               // demand from the bridge receiver and close it if demand is now gone.
+               tryRemoveDemandOnAddress(manager, binding);
+            } else if (policy.isIncludeDivertBindings()) {
+               // See if there is any matching diverts that are forwarding to an address where this QueueBinding
+               // is bound and remove the mapping for any matches, diverts can have a composite set of address
+               // forwards so each divert must be checked in turn to see if it contains the address the removed
+               // binding was bound to.
+               divertsTracking.entrySet().forEach(divertEntry -> {
+                  final String sourceAddress = divertEntry.getKey().getAddress().toString();
+                  final SimpleString forwardAddress = divertEntry.getKey().getDivert().getForwardAddress();
+
+                  if (isAddressInDivertForwards(binding.getAddress(), forwardAddress)) {
+                     // Try and remove the queue binding from the set of registered bindings
+                     // for the divert and if that removes all mapped bindings then we can
+                     // remove the divert from the bridged address entry and check if that
+                     // removed all local demand which means we can close the receiver.
+                     divertEntry.getValue().remove(binding);
+
+                     if (divertEntry.getValue().isEmpty()) {
+                        tryRemoveDemandOnAddress(bridgeReceivers.get(sourceAddress), divertEntry.getKey());
+                     }
+                  }
+               });
+            }
+         } else if (policy.isIncludeDivertBindings() && binding instanceof DivertBinding divert) {
+
+            if (divertsTracking.remove(divert) != null) {
+               // The divert binding is treated as one unit of demand on a bridged address and when
+               // the divert is removed that unit of demand is removed regardless of existing bindings
+               // still remaining on the divert forwards. If the divert demand was the only thing
+               // keeping the bridge address receiver open this will result in it bring closed.
+               try {
+                  tryRemoveDemandOnAddress(bridgeReceivers.get(divert.getAddress().toString()), divert);
+               } catch (Exception e) {
+                  logger.warn("Error looking up binding for divert forward address {}", divert.getDivert().getForwardAddress(), e);
+               }
+            }
+         }
+      }
+   }
+
+   private void tryRemoveDemandOnAddress(AMQPBridgeAddressReceiverManager manager, Binding binding) {
+      if (manager != null) {
+         logger.trace("Reducing demand on bridged address {}", manager.getAddress());
+         manager.removeDemand(binding);
+      }
+   }
+
+   /**
+    * When address demand tracking is disabled we just scan for any address the matches the policy and
+    * create a receiver for that address, we don't monitor any other demand as we just want to receive
+    * for as long as the lifetime of the address.
+    */
+   private void scanAllAddresses() {
+      server.getPostOffice()
+            .getAddresses()
+            .stream()
+            .map(address -> server.getAddressInfo(address))
+            .filter(addressInfo -> testIfAddressMatchesPolicy(addressInfo))
+            .forEach(addressInfo -> createOrUpdateAddressReceiverForUnboundDemand(addressInfo));
+   }
+
+   /**
+    * Scans all bindings and push them through the normal bindings checks that
+    * would be done on an add. We filter here based on whether diverts are enabled
+    * just to reduce the result set but the check call should also filter as
+    * during normal operations divert bindings could be added.
+    */
+   private void scanAllBindings() {
+      server.getPostOffice()
+            .getAllBindings()
+            .filter(binding -> binding instanceof QueueBinding || (policy.isIncludeDivertBindings() && binding instanceof DivertBinding))
+            .forEach(binding -> afterAddBinding(binding));
+   }
+
+   @Override
+   public synchronized void afterAddAddress(AddressInfo addressInfo, boolean reload) {
+      if (isActive() && policy.test(addressInfo)) {
+         // If demand tracking is disabled we create a receiver regardless of other demand
+         if (configuration.isReceiverDemandTrackingDisabled()) {
+            createOrUpdateAddressReceiverForUnboundDemand(addressInfo);
+         } else if (policy.isIncludeDivertBindings()) {
+            try {
+               // A Divert can exist in configuration prior to the address having been auto created etc so
+               // upon address add this check needs to be run to capture addresses that now match the divert.
+               server.getPostOffice()
+                     .getDirectBindings(addressInfo.getName())
+                     .stream()
+                     .filter(binding -> binding instanceof DivertBinding)
+                     .forEach(this::checkBindingForMatch);
+            } catch (Exception e) {
+               ActiveMQServerLogger.LOGGER.bridgeBindingsLookupError(addressInfo.getName(), e);
+            }
+         }
+      }
+   }
+
+   @Override
+   public synchronized void afterAddBinding(Binding binding) {
+      if (isActive() && !configuration.isReceiverDemandTrackingDisabled()) {
+         checkBindingForMatch(binding);
+      }
+   }
+
+   /**
+    * Called under lock this method should check if the given {@link Binding} matches the
+    * configured address bridging policy and bridge the address if so. The incoming
+    * {@link Binding} can be either a {@link QueueBinding} or a {@link DivertBinding} so
+    * the code should check both.
+    *
+    * @param binding
+    *       The binding that should be checked against the bridge from address policy,
+    */
+   private void checkBindingForMatch(Binding binding) {
+      if (binding instanceof QueueBinding queueBinding) {
+         final AddressInfo addressInfo = server.getPostOffice().getAddressInfo(binding.getAddress());
+
+         if (testIfAddressMatchesPolicy(addressInfo)) {
+            createOrUpdateAddressReceiverForBinding(addressInfo, queueBinding);
+         } else {
+            reactIfQueueBindingMatchesAnyDivertTarget(queueBinding);
+         }
+      } else if (binding instanceof DivertBinding divertBinding) {
+         reactIfAnyQueueBindingMatchesDivertTarget(divertBinding);
+      }
+   }
+
+   private void reactIfAnyQueueBindingMatchesDivertTarget(DivertBinding divertBinding) {
+      if (!policy.isIncludeDivertBindings()) {
+         return;
+      }
+
+      final AddressInfo addressInfo = server.getPostOffice().getAddressInfo(divertBinding.getAddress());
+
+      if (!testIfAddressMatchesPolicy(addressInfo)) {
+         return;
+      }
+
+      // We only need to check if we've never seen the divert before, afterwards we will
+      // be checking it any time a new QueueBinding is added instead.
+      if (divertsTracking.get(divertBinding) == null) {
+         final Set<QueueBinding> matchingQueues = new HashSet<>();
+         divertsTracking.put(divertBinding, matchingQueues);
+
+         // We must account for the composite divert case by splitting the address and
+         // getting the bindings on each one.
+         final SimpleString forwardAddress = divertBinding.getDivert().getForwardAddress();
+         final SimpleString[] forwardAddresses = forwardAddress.split(',');
+
+         try {
+            for (SimpleString forward : forwardAddresses) {
+               server.getPostOffice().getBindingsForAddress(forward).getBindings()
+                     .stream()
+                     .filter(b -> b instanceof QueueBinding)
+                     .map(b -> (QueueBinding) b)
+                     .forEach(queueBinding -> {
+                        matchingQueues.add(queueBinding);
+                        createOrUpdateAddressReceiverForBinding(addressInfo, divertBinding);
+                     });
+            }
+         } catch (Exception e) {
+            ActiveMQServerLogger.LOGGER.bridgeBindingsLookupError(forwardAddress, e);
+         }
+      }
+   }
+
+   private void reactIfQueueBindingMatchesAnyDivertTarget(QueueBinding queueBinding) {
+      if (!policy.isIncludeDivertBindings()) {
+         return;
+      }
+
+      final SimpleString queueAddress = queueBinding.getAddress();
+
+      divertsTracking.entrySet().forEach((e) -> {
+         final SimpleString forwardAddress = e.getKey().getDivert().getForwardAddress();
+         final DivertBinding divertBinding = e.getKey();
+
+         // Check matched diverts to see if the QueueBinding address matches the address or
+         // addresses (composite diverts) of the Divert and if so then we can check if we need
+         // to create demand on the source address on the remote if we haven't done so already.
+
+         if (!e.getValue().contains(queueBinding) && isAddressInDivertForwards(queueAddress, forwardAddress)) {
+            // Each divert that forwards to the address the queue is bound to we add demand
+            // in the diverts tracker.
+            e.getValue().add(queueBinding);
+
+            final AddressInfo addressInfo = server.getPostOffice().getAddressInfo(divertBinding.getAddress());
+
+            createOrUpdateAddressReceiverForBinding(addressInfo, divertBinding);
+         }
+      });
+   }
+
+   private static boolean isAddressInDivertForwards(final SimpleString targetAddress, final SimpleString forwardAddress) {
+      final SimpleString[] forwardAddresses = forwardAddress.split(',');
+
+      for (SimpleString forward : forwardAddresses) {
+         if (targetAddress.equals(forward)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private void createOrUpdateAddressReceiverForUnboundDemand(AddressInfo addressInfo) {
+      logger.trace("AMQP Bridge Address Policy matched on address: {} when demand tracking disabled", addressInfo);
+      createOrUpdateAddressReceiver(addressInfo, null, true);
+   }
+
+   private void createOrUpdateAddressReceiverForBinding(AddressInfo addressInfo, Binding binding) {
+      logger.trace("AMQP Bridge Address Policy matched on for demand on address: {} : binding: {}", addressInfo, binding);
+      createOrUpdateAddressReceiver(addressInfo, binding, false);
+   }
+
+   private void createOrUpdateAddressReceiver(AddressInfo addressInfo, Binding binding, boolean forceDemand) {
+      final String addressName = addressInfo.getName().toString();
+      final AMQPBridgeAddressReceiverManager manager;
+
+      // Check for existing receiver add demand from a additional local consumer to ensure
+      // the remote receiver remains active until all local demand is withdrawn.
+      if (bridgeReceivers.containsKey(addressName)) {
+         manager = bridgeReceivers.get(addressName);
+      } else {
+         manager = new AMQPBridgeAddressReceiverManager(this, configuration, addressInfo);
+         bridgeReceivers.put(addressName, manager);
+      }
+
+      if (forceDemand) {
+         manager.forceDemand();
+      } else {
+         manager.addDemand(binding);
+      }
+   }
+
+   private AMQPBridgeReceiverInfo createReceiverInfo(AddressInfo address) {
+      final String addressName = address.getName().toString();
+      final StringBuilder remoteAddressBuilder = new StringBuilder();
+
+      if (policy.getRemoteAddressPrefix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressPrefix());
+      }
+
+      if (policy.getRemoteAddress() != null && !policy.getRemoteAddress().isBlank()) {
+         remoteAddressBuilder.append(policy.getRemoteAddress());
+      } else {
+         remoteAddressBuilder.append(addressName);
+      }
+
+      if (policy.getRemoteAddressSuffix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressSuffix());
+      }
+
+      return new AMQPBridgeReceiverInfo(ReceiverRole.ADDRESS_RECEIVER,
+                                        addressName,
+                                        null,
+                                        address.getRoutingType(),
+                                        remoteAddressBuilder.toString(),
+                                        policy.getFilter(),
+                                        configuration.isReceiverPriorityDisabled() ? null : policy.getPriority());
+   }
+
+   private AMQPBridgeReceiver createBridgeReceiver(AMQPBridgeReceiverInfo receiverInfo) {
+      Objects.requireNonNull(receiverInfo, "AMQP Bridge Address receiver information object was null");
+
+      if (logger.isTraceEnabled()) {
+         logger.trace("AMQP Bridge {} creating address receiver: {} for policy: {}", bridge.getName(), receiverInfo, policy.getPolicyName());
+      }
+
+      // Don't initiate anything yet as the caller might need to register error handlers etc
+      // before the attach is sent otherwise they could miss the failure case.
+      return new AMQPBridgeFromAddressReceiver(this, configuration, session, receiverInfo, policy, metrics.newReceiverMetrics());
+   }
+
+   private boolean testIfAddressMatchesPolicy(AddressInfo addressInfo) {
+      if (!policy.test(addressInfo)) {
+         return false;
+      }
+
+      // Address receivers can't pull as we have no real metric to indicate when / how much
+      // we should pull so instead we refuse to match if credit set to zero.
+      if (configuration.getReceiverCredits() <= 0) {
+         logger.debug("AMQP Bridge address policy rejecting match on {} because credit is set to zero:", addressInfo.getName());
+         return false;
+      } else {
+         return true;
+      }
+   }
+
+   private static class AMQPBridgeAddressReceiverManager extends AMQPBridgeReceiverManager<Binding> {
+
+      private final AMQPBridgeFromAddressPolicyManager manager;
+      private final AddressInfo addressInfo;
+
+      AMQPBridgeAddressReceiverManager(AMQPBridgeFromAddressPolicyManager manager, AMQPBridgeReceiverConfiguration configuration, AddressInfo addressInfo) {
+         super(manager, configuration);
+
+         this.manager = manager;
+         this.addressInfo = addressInfo;
+      }
+
+      /**
+       * @return the address information that this entry is acting to bridge.
+       */
+      public AddressInfo getAddressInfo() {
+         return addressInfo;
+      }
+
+      /**
+       * @return the address that this entry is acting to bridge.
+       */
+      public String getAddress() {
+         return getAddressInfo().getName().toString();
+      }
+
+      @Override
+      protected AMQPBridgeReceiver createBridgeReceiver() {
+         return manager.createBridgeReceiver(manager.createReceiverInfo(addressInfo));
+      }
+
+      @Override
+      protected void whenDemandTrackingEntryAdded(Binding entry) {
+         // Nothing to do for this implementation
+      }
+
+      @Override
+      protected void whenDemandTrackingEntryRemoved(Binding entry) {
+         // Nothing to do for this implementation
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressReceiver.java
@@ -1,0 +1,331 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.verifyDesiredCapability;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.AddressQueryResult;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.ReceiverMetrics;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPNotFoundException;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpJmsSelectorFilter;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerReceiverContext;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.DeliveryAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Receiver implementation for Bridged Addresses that receives from a remote
+ * AMQP peer and forwards those messages onto the internal broker Address for
+ * consumption by an attached consumers.
+ */
+public class AMQPBridgeFromAddressReceiver extends AMQPBridgeReceiver {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public AMQPBridgeFromAddressReceiver(AMQPBridgeFromPolicyManager policyManager, AMQPBridgeReceiverConfiguration configuration,
+                                        AMQPSessionContext session, AMQPBridgeReceiverInfo receiverInfo,
+                                        AMQPBridgeAddressPolicy policy, ReceiverMetrics metrics) {
+      super(policyManager, configuration, session, receiverInfo, policy, metrics);
+   }
+
+   @Override
+   public int getReceiverIdleTimeout() {
+      return configuration.getAddressReceiverIdleTimeout();
+   }
+
+   @Override
+   protected void doCreateReceiver() {
+      try {
+         final Receiver protonReceiver = session.getSession().receiver(generateLinkName());
+         final Target target = new Target();
+         final Source source = new Source();
+         final String address = receiverInfo.getRemoteAddress();
+         final String filterString = receiverInfo.getFilterString();
+
+         source.setOutcomes(Arrays.copyOf(OUTCOMES, OUTCOMES.length));
+         source.setDefaultOutcome(DEFAULT_OUTCOME);
+         source.setDurable(TerminusDurability.NONE);
+         source.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
+         source.setAddress(address);
+         source.setCapabilities(getRemoteTerminusCapabilities());
+
+         if (filterString != null && !filterString.isBlank()) {
+            final AmqpJmsSelectorFilter jmsFilter = new AmqpJmsSelectorFilter(filterString);
+            final Map<Symbol, Object> filtersMap = new HashMap<>();
+            filtersMap.put(AmqpSupport.JMS_SELECTOR_KEY, jmsFilter);
+
+            source.setFilter(filtersMap);
+         }
+
+         target.setAddress(receiverInfo.getLocalAddress());
+
+         final Map<Symbol, Object> receiverProperties;
+         if (receiverInfo.getPriority() != null) {
+            receiverProperties = new HashMap<>();
+            receiverProperties.put(RECEIVER_PRIORITY, receiverInfo.getPriority().intValue());
+         } else {
+            receiverProperties = null;
+         }
+
+         protonReceiver.setSenderSettleMode(configuration.isUsingPresettledSenders() ? SenderSettleMode.SETTLED : SenderSettleMode.UNSETTLED);
+         protonReceiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+         // If enabled offer core tunneling which we prefer to AMQP conversions of core as
+         // the large ones will be converted to standard AMQP messages in memory. When not
+         // offered the remote must not use core tunneling and AMQP conversion will be the
+         // fallback.
+         if (configuration.isCoreMessageTunnelingEnabled()) {
+            protonReceiver.setOfferedCapabilities(new Symbol[] {AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT});
+         }
+         protonReceiver.setProperties(receiverProperties);
+         protonReceiver.setTarget(target);
+         protonReceiver.setSource(source);
+         protonReceiver.open();
+
+         final ScheduledFuture<?> openTimeoutTask;
+         final AtomicBoolean openTimedOut = new AtomicBoolean(false);
+
+         if (configuration.getLinkAttachTimeout() > 0) {
+            openTimeoutTask = bridgeManager.getServer().getScheduledPool().schedule(() -> {
+               openTimedOut.set(true);
+               bridgeManager.signalResourceCreateError(ActiveMQAMQPProtocolMessageBundle.BUNDLE.brokerConnectionTimeout());
+            }, configuration.getLinkAttachTimeout(), TimeUnit.SECONDS);
+         } else {
+            openTimeoutTask = null;
+         }
+
+         this.protonReceiver = protonReceiver;
+
+         protonReceiver.attachments().set(AMQP_LINK_INITIALIZER_KEY, Runnable.class, () -> {
+            try {
+               if (openTimeoutTask != null) {
+                  openTimeoutTask.cancel(false);
+               }
+
+               if (openTimedOut.get()) {
+                  return;
+               }
+
+               final boolean linkOpened = protonReceiver.getRemoteSource() != null;
+
+               // Intercept remote close and check for valid reasons for remote closure such as
+               // the remote peer not having a matching node for this subscription or from an
+               // operator manually closing the link etc.
+               bridgeManager.addLinkClosedInterceptor(receiverInfo.getId(), this::remoteLinkClosedInterceptor);
+
+               receiver = new AMQPBridgeAddressDeliveryReceiver(session, receiverInfo, protonReceiver);
+
+               if (linkOpened) {
+                  logger.debug("AMQP Bridge {} address receiver {} completed open", bridgeManager.getName(), receiverInfo);
+               } else {
+                  logger.debug("AMQP Bridge {} address receiver {} rejected by remote", bridgeManager.getName(), receiverInfo);
+               }
+
+               session.addReceiver(protonReceiver, (session, protonRcvr) -> {
+                  return this.receiver;
+               });
+
+               if (linkOpened && remoteOpenHandler != null) {
+                  remoteOpenHandler.accept(this);
+               }
+            } catch (Exception e) {
+               bridgeManager.signalError(e);
+            }
+         });
+      } catch (Exception e) {
+         bridgeManager.signalError(e);
+      }
+
+      connection.flush();
+   }
+
+   private String generateLinkName() {
+      return "amqp-bridge-" + bridgeManager.getName() +
+             "-policy-" + policy.getPolicyName() +
+             "-address-receiver-" + receiverInfo.getRemoteAddress() +
+             "-" + bridgeManager.getServer().getNodeID() +
+             "-" + LINK_SEQUENCE_ID.incrementAndGet();
+   }
+
+   /**
+    * Wrapper around the standard receiver context that provides bridge specific entry
+    * points and customizes inbound delivery handling for this Address receiver.
+    */
+   private class AMQPBridgeAddressDeliveryReceiver extends ProtonServerReceiverContext {
+
+      private final SimpleString cachedAddress;
+      private boolean closed;
+
+      /**
+       * Creates the AMQP bridge receiver instance.
+       *
+       * @param session
+       *    The server session context bound to the receiver instance.
+       * @param receiver
+       *    The proton receiver that will be wrapped in this server context instance.
+       */
+      AMQPBridgeAddressDeliveryReceiver(AMQPSessionContext session, AMQPBridgeReceiverInfo receiverInfo, Receiver receiver) {
+         super(session.getSessionSPI(), session.getAMQPConnectionContext(), session, receiver);
+
+         this.cachedAddress = SimpleString.of(receiverInfo.getLocalAddress());
+      }
+
+      @Override
+      public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
+         super.close(remoteLinkClose);
+
+         if (!closed) {
+            closed = true;
+
+            try {
+               AMQPBridgeManagementSupport.unregisterBridgeReceiver(AMQPBridgeFromAddressReceiver.this);
+            } catch (Exception e) {
+               logger.debug("Error caught when trying to remove bridge address consumer from management", e);
+            }
+
+            if (remoteLinkClose && remoteCloseHandler != null) {
+               try {
+                  remoteCloseHandler.accept(AMQPBridgeFromAddressReceiver.this);
+               } catch (Exception e) {
+                  logger.debug("User remote closed handler threw error: ", e);
+               } finally {
+                  remoteCloseHandler = null;
+               }
+            }
+         }
+      }
+
+      @Override
+      protected Runnable createCreditRunnable(AMQPConnectionContext connection) {
+         // We defer to the configuration instance as opposed to the base class version that reads
+         // from the connection this allows us to defer to configured policy properties that specify
+         // credit over those in the bridge configuration or on the connector URI.
+         return createCreditRunnable(configuration.getReceiverCredits(), configuration.getReceiverCreditsLow(), receiver, connection, this);
+      }
+
+      @Override
+      protected int getConfiguredMinLargeMessageSize(AMQPConnectionContext connection) {
+         // Looks at policy properties first before looking at receiver configuration and finally
+         // going to the base connection context to read the URI configuration.
+         return configuration.getLargeMessageThreshold();
+      }
+
+      @Override
+      public void initialize() throws Exception {
+         initialized = true;
+
+         final Target target = (Target) receiver.getRemoteTarget();
+
+         // Match the settlement mode of the remote instead of relying on the default of MIXED.
+         receiver.setSenderSettleMode(receiver.getRemoteSenderSettleMode());
+
+         // We don't currently support SECOND so enforce that the answer is always FIRST
+         receiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+
+         // the target will have an address and it will naturally have a Target otherwise
+         // the remote is misbehaving and we close it.
+         if (target == null || target.getAddress() == null || target.getAddress().isEmpty()) {
+            throw new ActiveMQAMQPInternalErrorException("Remote should have sent a valid Target but we got: " + target);
+         }
+
+         if (!target.getAddress().equals(receiverInfo.getLocalAddress())) {
+            throw new ActiveMQAMQPInternalErrorException("Remote should have sent a matching Target address but we got: " + target.getAddress());
+         }
+
+         address = SimpleString.of(receiverInfo.getLocalAddress());
+         defRoutingType = receiverInfo.getRoutingType();
+
+         try {
+            final AddressQueryResult result = sessionSPI.addressQuery(address, defRoutingType, false);
+
+            // We initiated this link so the settings should refer to an address that definitely exists
+            // however there is a chance the address was removed in the interim.
+            if (!result.isExists()) {
+               throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist(address.toString());
+            }
+         } catch (ActiveMQAMQPNotFoundException e) {
+            throw e;
+         } catch (Exception e) {
+            logger.debug(e.getMessage(), e);
+            throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
+         }
+
+         // If we offered core tunneling then check if the remote indicated support and enabled the readers
+         if (configuration.isCoreMessageTunnelingEnabled() && verifyDesiredCapability(protonReceiver, CORE_MESSAGE_TUNNELING_SUPPORT)) {
+            enableCoreTunneling();
+         }
+
+         try {
+            AMQPBridgeManagementSupport.registerBridgeReceiver(AMQPBridgeFromAddressReceiver.this);
+         } catch (Exception e) {
+            logger.debug("Error caught when trying to add bridge address consumer to management", e);
+         }
+
+         topUpCreditIfNeeded();
+      }
+
+      @Override
+      protected void actualDelivery(Message message, Delivery delivery, DeliveryAnnotations deliveryAnnotations, Receiver receiver, Transaction tx) {
+         try {
+            if (logger.isTraceEnabled()) {
+               logger.trace("AMQP Bridge {} address receiver {} dispatching incoming message: {}", bridgeManager.getName(), receiverInfo, message);
+            }
+
+            final Message theMessage = transformer.transform(message);
+
+            if (theMessage != message && logger.isTraceEnabled()) {
+               logger.trace("The transformer {} replaced the original message {} with a new instance {}",
+                            transformer, message, theMessage);
+            }
+
+            sessionSPI.serverSend(this, tx, receiver, delivery, cachedAddress, routingContext, theMessage);
+         } catch (Exception e) {
+            logger.warn("Inbound delivery for {} encountered an error: {}", receiverInfo, e.getMessage(), e);
+            deliveryFailed(delivery, receiver, e);
+         } finally {
+            recordMessageReceived(message);
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromPolicyManager.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBindingPlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for AMQP bridge policy managers that bridge from the remote peer back to
+ * this peer for some configured resource.
+ */
+public abstract class AMQPBridgeFromPolicyManager extends AMQPBridgePolicyManager implements ActiveMQServerBindingPlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   protected volatile AMQPBridgeReceiverConfiguration configuration;
+
+   public AMQPBridgeFromPolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metrics, String policyName, AMQPBridgeType policyType) {
+      super(bridge, metrics, policyName, policyType);
+   }
+
+   @Override
+   protected void handleManagerInitialized() {
+      server.registerBrokerPlugin(this);
+
+      try {
+         AMQPBridgeManagementSupport.registerBridgePolicyManager(this);
+      } catch (Exception e) {
+         logger.trace("Error while attempting to add receiver policy control to management", e);
+      }
+   }
+
+   @Override
+   protected void handleManagerStarted() {
+      if (isActive()) {
+         scanManagedResources();
+      }
+   }
+
+   @Override
+   protected void handleManagerStopped() {
+      safeCleanupManagerResources(false);
+   }
+
+   @Override
+   protected void handleManagerShutdown() {
+      server.unRegisterBrokerPlugin(this);
+
+      try {
+         AMQPBridgeManagementSupport.unregisterBridgePolicyManager(this);
+      } catch (Exception e) {
+         logger.trace("Error while attempting to remove receiver policy control from management", e);
+      }
+
+      safeCleanupManagerResources(false);
+   }
+
+   @Override
+   protected void handleConnectionInterrupted() {
+      safeCleanupManagerResources(true);
+   }
+
+   @Override
+   protected void handleConnectionRestored(AMQPBridgeConfiguration configuration) {
+      // Capture state for the current connection on each connection as different URIs could have
+      // different options we need to capture in the current configuration state.
+      this.configuration = new AMQPBridgeReceiverConfiguration(configuration, getPolicy().getProperties());
+
+      if (isActive()) {
+         scanManagedResources();
+      }
+   }
+
+   /**
+    * Scans all server resources and push them through the normal checks that
+    * would be done on an add. This allows for checks on demand after a start or
+    * after a connection is restored.
+    */
+   protected abstract void scanManagedResources();
+
+   /**
+    * The subclass implements this method and should remove all tracked AMQP bridge
+    * resource data and also close all links either by first safely stopping the link
+    * or if offline simply closing the links immediately. If the force flag is set to
+    * true the implementation should close the link without attempting to stop it
+    * by draining link credit before the close.
+    *
+    * @param force
+    *    Should the implementation simply close the managed links without attempting a stop.
+    */
+   protected abstract void safeCleanupManagerResources(boolean force);
+
+   /**
+    * Attempts to close a bridge receiver. The method will not double close a receiver as it
+    * checks the closed state. The method is synchronized to allow for use in asynchronous
+    * call backs from bridge receivers.
+    *
+    * @param bridgeReceiver
+    *    A bridge receiver to close, or null in which case no action is taken.
+    */
+   protected synchronized void tryCloseBridgeReceiver(AMQPBridgeReceiver bridgeReceiver) {
+      if (bridgeReceiver != null) {
+         try {
+            if (!bridgeReceiver.isClosed()) {
+               bridgeReceiver.close();
+            }
+         } catch (Exception ignore) {
+            logger.trace("Caught error on attempted close of existing bridge receiver", ignore);
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueuePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueuePolicyManager.java
@@ -1,0 +1,314 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.core.filter.Filter;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerConsumerPlugin;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeReceiverInfo.ReceiverRole;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AMQP Bridge policy manager that tracks local queues that match the policy configurations
+ * for local demand and creates consumers to the remote peer configured.
+ */
+public final class AMQPBridgeFromQueuePolicyManager extends AMQPBridgeFromPolicyManager implements ActiveMQServerConsumerPlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final AMQPBridgeQueuePolicy policy;
+   private final Map<AMQPBridgeReceiverInfo, AMQPBridgeQueueReceiverManager> demandTracking = new HashMap<>();
+
+   /*
+    * Unique for the lifetime of this policy manager which is either the lifetime of the broker or until the
+    * configuration is reloaded and this bridge instance happens to be updated but not removed in which
+    * case the full bridge instance is shutdown and then removed and re-added as if it was new.
+    */
+   private final String RECEIVER_INFO_ATTACHMENT_KEY = UUID.randomUUID().toString();
+
+   public AMQPBridgeFromQueuePolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metric, AMQPBridgeQueuePolicy policy) {
+      super(bridge, metric, policy.getPolicyName(), AMQPBridgeType.BRIDGE_FROM_QUEUE);
+
+      Objects.requireNonNull(policy, "The Queue match policy cannot be null");
+
+      this.policy = policy;
+   }
+
+   /**
+    * {@return the policy that defines the bridged queue this policy manager monitors}
+    */
+   @Override
+   public AMQPBridgeQueuePolicy getPolicy() {
+      return policy;
+   }
+
+   @Override
+   protected void scanManagedResources() {
+      server.getPostOffice()
+            .getAllBindings()
+            .filter(b -> b instanceof QueueBinding)
+            .map(b -> (QueueBinding) b)
+            .forEach(b -> {
+               if (configuration.isReceiverDemandTrackingDisabled()) {
+                  reactIfQueueMatchesPolicy(b.getQueue());
+               } else {
+                  checkQueueWithConsumerForMatch(b.getQueue());
+               }
+            });
+   }
+
+   @Override
+   protected void safeCleanupManagerResources(boolean force) {
+      try {
+         demandTracking.values().forEach((manager) -> {
+            if (manager != null) {
+               if (isConnected() && !force) {
+                  manager.shutdown();
+               } else {
+                  manager.shutdownNow();
+               }
+            }
+         });
+      } finally {
+         demandTracking.clear();
+      }
+   }
+
+   @Override
+   public synchronized void afterCreateConsumer(ServerConsumer consumer) {
+      if (isActive() && !configuration.isReceiverDemandTrackingDisabled()) {
+         reactIfQueueWithConsumerMatchesPolicy(consumer);
+      }
+   }
+
+   @Override
+   public synchronized void afterCloseConsumer(ServerConsumer consumer, boolean failed) {
+      if (isActive() && !configuration.isReceiverDemandTrackingDisabled()) {
+
+         final AMQPBridgeReceiverInfo receiverInfo = (AMQPBridgeReceiverInfo) consumer.getAttachment(RECEIVER_INFO_ATTACHMENT_KEY);
+
+         if (receiverInfo != null && demandTracking.containsKey(receiverInfo)) {
+            final AMQPBridgeQueueReceiverManager manager = demandTracking.get(receiverInfo);
+            logger.trace("Reducing demand on bridged queue {}", manager.getQueueName());
+            manager.removeDemand(consumer);
+         }
+      }
+   }
+
+   @Override
+   public void afterAddBinding(Binding binding) throws ActiveMQException {
+      if (isActive() && configuration.isReceiverDemandTrackingDisabled() && binding instanceof QueueBinding queueBinding) {
+         reactIfQueueMatchesPolicy(queueBinding.getQueue());
+      }
+   }
+
+   @Override
+   public synchronized void afterRemoveBinding(Binding binding, Transaction tx, boolean deleteData) throws ActiveMQException {
+      if (isActive() && binding instanceof QueueBinding queueBinding) {
+         final String queueName = queueBinding.getQueue().getName().toString();
+
+         demandTracking.values().removeIf((manager) -> {
+            if (manager.getQueueName().equals(queueName)) {
+               logger.trace("Bridged queue {} was removed, closing bridge receiver", queueName);
+
+               // Demand is gone because the Queue binding is gone and any in-flight messages
+               // can be allowed to be released back to the remote as they will not be processed.
+               // We removed the receiver information from demand tracking to prevent build up
+               // of data for entries that may never return and to prevent interference from the
+               // next set of events which will be the close of all local receivers for this now
+               // removed Queue.
+               manager.shutdownNow();
+
+               return true;
+            } else {
+               return false;
+            }
+         });
+      }
+   }
+
+   private void checkQueueWithConsumerForMatch(Queue queue) {
+      queue.getConsumers()
+           .stream()
+           .filter(consumer -> consumer instanceof ServerConsumer)
+           .map(c -> (ServerConsumer) c)
+           .forEach(this::reactIfQueueWithConsumerMatchesPolicy);
+   }
+
+   private void reactIfQueueWithConsumerMatchesPolicy(ServerConsumer consumer) {
+      reactIfDemandMatchesPolicy(consumer.getQueue(), consumer, false);
+   }
+
+   private void reactIfQueueMatchesPolicy(Queue queue) {
+      reactIfDemandMatchesPolicy(queue, null, true);
+   }
+
+   private void reactIfDemandMatchesPolicy(Queue queue, ServerConsumer consumer, boolean forceDemand) {
+      final String queueName = queue.getName().toString();
+      final String addressName = queue.getAddress().toString();
+
+      if (testIfQueueMatchesPolicy(addressName, queueName)) {
+         if (consumer != null) {
+            logger.trace("AMQP Bridge from Queue Policy matched on consumer for Queue: {}", consumer.getQueue());
+         } else {
+            logger.trace("AMQP Bridge Queue Policy matched on Queue: {} when demand tracking disabled", queue.getName());
+         }
+
+         final AMQPBridgeQueueReceiverManager manager;
+         final AMQPBridgeReceiverInfo receiverInfo = createReceiverInfo(consumer, queue);
+
+         // Check for existing receiver and add demand from a additional local consumer to ensure
+         // the remote receiver remains active until all local demand is withdrawn.
+         if (demandTracking.containsKey(receiverInfo)) {
+            logger.trace("AMQP Bridge from Queue Policy manager found existing demand for queue: {}, adding demand", queueName);
+            manager = demandTracking.get(receiverInfo);
+         } else {
+            demandTracking.put(receiverInfo, manager = new AMQPBridgeQueueReceiverManager(this, RECEIVER_INFO_ATTACHMENT_KEY, configuration, receiverInfo, queue));
+         }
+
+         if (forceDemand) {
+            manager.forceDemand();
+         } else {
+            manager.addDemand(consumer);
+         }
+      }
+   }
+
+   private boolean testIfQueueMatchesPolicy(String address, String queueName) {
+      return policy.test(address, queueName);
+   }
+
+   private AMQPBridgeReceiver createBridgeReceiver(AMQPBridgeReceiverInfo receiverInfo) {
+      Objects.requireNonNull(receiverInfo, "AMQP Bridge Queue receiver information object was null");
+
+      if (logger.isTraceEnabled()) {
+         logger.trace("AMQP Bridge {} creating queue receiver: {} for policy: {}", bridge.getName(), receiverInfo, policy.getPolicyName());
+      }
+
+      // Don't initiate anything yet as the caller might need to register error handlers etc
+      // before the attach is sent otherwise they could miss the failure case.
+      return new AMQPBridgeFromQueueReceiver(this, configuration, session, receiverInfo, policy, metrics.newReceiverMetrics());
+   }
+
+   private AMQPBridgeReceiverInfo createReceiverInfo(ServerConsumer consumer, Queue queue) {
+      final StringBuilder remoteAddressBuilder = new StringBuilder();
+
+      if (policy.getRemoteAddressPrefix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressPrefix());
+      }
+
+      if (policy.getRemoteAddress() != null && !policy.getRemoteAddress().isBlank()) {
+         remoteAddressBuilder.append(policy.getRemoteAddress());
+      } else {
+         remoteAddressBuilder.append(queue.getName().toString());
+      }
+
+      if (policy.getRemoteAddressSuffix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressSuffix());
+      }
+
+      final String filterString = selectFilter(
+         policy.getFilter(),
+         configuration.isIgnoreQueueFilters() ? null : queue.getFilter(),
+         configuration.isIgnoreSubscriptionFilters() || consumer == null ? null : consumer.getFilter());
+
+      final Integer priority = selectPriority();
+
+      return new AMQPBridgeReceiverInfo(ReceiverRole.QUEUE_RECEIVER,
+                                        queue.getAddress().toString(),
+                                        queue.getName().toString(),
+                                        queue.getRoutingType(),
+                                        remoteAddressBuilder.toString(),
+                                        filterString,
+                                        priority);
+   }
+
+   private Integer selectPriority() {
+      if (configuration.isReceiverPriorityDisabled()) {
+         return null;
+      } else if (policy.getPriority() != null) {
+         return policy.getPriority();
+      } else {
+         return ActiveMQDefaultConfiguration.getDefaultConsumerPriority() + policy.getPriorityAdjustment();
+      }
+   }
+
+   private static String selectFilter(String policyFilter, Filter queueFilter, Filter consumerFilter) {
+      if (policyFilter != null && !policyFilter.isBlank()) {
+         return policyFilter;
+      } else if (consumerFilter != null) {
+         return consumerFilter.getFilterString().toString();
+      } else {
+         return queueFilter != null ? queueFilter.getFilterString().toString() : null;
+      }
+   }
+
+   private static class AMQPBridgeQueueReceiverManager extends AMQPBridgeReceiverManager<ServerConsumer> {
+
+      private final AMQPBridgeFromQueuePolicyManager manager;
+      private final Queue queue;
+      private final AMQPBridgeReceiverInfo receiverInfo;
+      private final String receiverInfoKey;
+
+      AMQPBridgeQueueReceiverManager(AMQPBridgeFromQueuePolicyManager manager, String receiverInfoKey, AMQPBridgeReceiverConfiguration configuration, AMQPBridgeReceiverInfo receiverInfo, Queue queue) {
+         super(manager, configuration);
+
+         this.manager = manager;
+         this.queue = queue;
+         this.receiverInfo = receiverInfo;
+         this.receiverInfoKey = receiverInfoKey;
+      }
+
+      /**
+       * @return the name of the Queue this bridge receiver manager is attached to.
+       */
+      public String getQueueName() {
+         return queue.getName().toString();
+      }
+
+      @Override
+      protected AMQPBridgeReceiver createBridgeReceiver() {
+         return manager.createBridgeReceiver(receiverInfo);
+      }
+
+      @Override
+      protected void whenDemandTrackingEntryAdded(ServerConsumer consumer) {
+         // Attach the consumer info to the server consumer for later use on receiver close or other
+         // operations that need to retrieve the data used to create the bridge receiver identity.
+         consumer.addAttachment(receiverInfoKey, receiverInfo);
+      }
+
+      @Override
+      protected void whenDemandTrackingEntryRemoved(ServerConsumer consumer) {
+         consumer.removeAttachment(receiverInfoKey);
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueueReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueueReceiver.java
@@ -1,0 +1,417 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.verifyDesiredCapability;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.QueueQueryResult;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.ReceiverMetrics;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPNotFoundException;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpJmsSelectorFilter;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerReceiverContext;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.DeliveryAnnotations;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.EndpointState;
+import org.apache.qpid.proton.engine.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Receiver implementation for Bridged Queues that receives from a remote
+ * AMQP peer and forwards those messages onto the internal broker Queue for
+ * consumption by an attached consumers.
+ */
+public class AMQPBridgeFromQueueReceiver extends AMQPBridgeReceiver {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public static final int DEFAULT_PENDING_MSG_CHECK_BACKOFF_MULTIPLIER = 2;
+   public static final int DEFAULT_PENDING_MSG_CHECK_MAX_DELAY = 30;
+
+   public AMQPBridgeFromQueueReceiver(AMQPBridgeFromPolicyManager policyManager,
+                                      AMQPBridgeReceiverConfiguration configuration,
+                                      AMQPSessionContext session,
+                                      AMQPBridgeReceiverInfo receiverInfo,
+                                      AMQPBridgeQueuePolicy policy,
+                                      ReceiverMetrics metrics) {
+      super(policyManager, configuration, session, receiverInfo, policy, metrics);
+   }
+
+   @Override
+   public int getReceiverIdleTimeout() {
+      return configuration.getQueueReceiverIdleTimeout();
+   }
+
+   @Override
+   protected void doCreateReceiver() {
+      try {
+         final Receiver protonReceiver = session.getSession().receiver(generateLinkName());
+         final Target target = new Target();
+         final Source source = new Source();
+         final String address = receiverInfo.getRemoteAddress();
+         final String filterString = receiverInfo.getFilterString();
+         final Queue localQueue = bridgeManager.getServer().locateQueue(receiverInfo.getLocalQueue());
+
+         source.setOutcomes(Arrays.copyOf(OUTCOMES, OUTCOMES.length));
+         source.setDefaultOutcome(DEFAULT_OUTCOME);
+         source.setDurable(TerminusDurability.NONE);
+         source.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
+         source.setAddress(address);
+         source.setCapabilities(getRemoteTerminusCapabilities());
+
+         if (filterString != null && !filterString.isBlank()) {
+            final AmqpJmsSelectorFilter jmsFilter = new AmqpJmsSelectorFilter(filterString);
+            final Map<Symbol, Object> filtersMap = new HashMap<>();
+            filtersMap.put(AmqpSupport.JMS_SELECTOR_KEY, jmsFilter);
+
+            source.setFilter(filtersMap);
+         }
+
+         target.setAddress(receiverInfo.getLocalFqqn());
+
+         final Map<Symbol, Object> receiverProperties;
+         if (receiverInfo.getPriority() != null) {
+            receiverProperties = new HashMap<>();
+            receiverProperties.put(RECEIVER_PRIORITY, receiverInfo.getPriority());
+         } else {
+            receiverProperties = null;
+         }
+
+         protonReceiver.setSenderSettleMode(configuration.isUsingPresettledSenders() ? SenderSettleMode.SETTLED : SenderSettleMode.UNSETTLED);
+         protonReceiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+         // If enabled offer core tunneling which we prefer to AMQP conversions of core as
+         // the large ones will be converted to standard AMQP messages in memory. When not
+         // offered the remote must not use core tunneling and AMQP conversion will be the
+         // fallback.
+         if (configuration.isCoreMessageTunnelingEnabled()) {
+            protonReceiver.setOfferedCapabilities(new Symbol[] {AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT});
+         }
+         protonReceiver.setProperties(receiverProperties);
+         protonReceiver.setTarget(target);
+         protonReceiver.setSource(source);
+         protonReceiver.open();
+
+         final ScheduledFuture<?> openTimeoutTask;
+         final AtomicBoolean openTimedOut = new AtomicBoolean(false);
+
+         if (configuration.getLinkAttachTimeout() > 0) {
+            openTimeoutTask = bridgeManager.getServer().getScheduledPool().schedule(() -> {
+               openTimedOut.set(true);
+               bridgeManager.signalResourceCreateError(ActiveMQAMQPProtocolMessageBundle.BUNDLE.brokerConnectionTimeout());
+            }, configuration.getLinkAttachTimeout(), TimeUnit.SECONDS);
+         } else {
+            openTimeoutTask = null;
+         }
+
+         this.protonReceiver = protonReceiver;
+
+         protonReceiver.attachments().set(AMQP_LINK_INITIALIZER_KEY, Runnable.class, () -> {
+            try {
+               if (openTimeoutTask != null) {
+                  openTimeoutTask.cancel(false);
+               }
+
+               if (openTimedOut.get()) {
+                  return;
+               }
+
+               final boolean linkOpened = protonReceiver.getRemoteSource() != null;
+
+               // Intercept remote close and check for valid reasons for remote closure such as
+               // the remote peer not having a matching node for this subscription or from an
+               // operator manually closing the link etc.
+               bridgeManager.addLinkClosedInterceptor(receiverInfo.getId(), this::remoteLinkClosedInterceptor);
+
+               receiver = new AMQPBridgeQueueDeliveryReceiver(localQueue, receiverInfo, protonReceiver);
+
+               if (linkOpened) {
+                  logger.debug("AMQP Bridge {} queue receiver {} completed open", bridgeManager.getName(), receiverInfo);
+               } else {
+                  logger.debug("AMQP Bridge {} queue receiver {} rejected by remote", bridgeManager.getName(), receiverInfo);
+               }
+
+               session.addReceiver(protonReceiver, (session, protonRcvr) -> {
+                  return this.receiver;
+               });
+
+               if (linkOpened && remoteOpenHandler != null) {
+                  remoteOpenHandler.accept(this);
+               }
+            } catch (Exception e) {
+               bridgeManager.signalError(e);
+            }
+         });
+      } catch (Exception e) {
+         bridgeManager.signalError(e);
+      }
+
+      connection.flush();
+   }
+
+   private String generateLinkName() {
+      return "amqp-bridge-" + bridgeManager.getName() +
+             "-policy-" + policy.getPolicyName() +
+             "-queue-receiver-" + receiverInfo.getRemoteAddress() +
+             "-" + bridgeManager.getServer().getNodeID() + ":" +
+             LINK_SEQUENCE_ID.getAndIncrement();
+   }
+
+   private static int caclulateNextDelay(int lastDelay, int backoffMultiplier, int maxDelay) {
+      final int nextDelay;
+
+      if (lastDelay == 0) {
+         nextDelay = 1;
+      } else {
+         nextDelay = Math.min(lastDelay * backoffMultiplier, maxDelay);
+      }
+
+      return nextDelay;
+   }
+
+   /**
+    * Wrapper around the standard receiver context that provides bridge specific entry
+    * points and customizes inbound delivery handling for this Queue receiver.
+    */
+   private class AMQPBridgeQueueDeliveryReceiver extends ProtonServerReceiverContext {
+
+      private final SimpleString cachedFqqn;
+      private final Queue localQueue;
+
+      private boolean closed;
+
+      /**
+       * Creates the AMQP bridge receiver instance.
+       *
+       * @param session
+       *    The server session context bound to the receiver instance.
+       * @param receiver
+       *    The proton receiver that will be wrapped in this server context instance.
+       */
+      AMQPBridgeQueueDeliveryReceiver(Queue localQueue, AMQPBridgeReceiverInfo receiverInfo, Receiver receiver) {
+         super(session.getSessionSPI(), session.getAMQPConnectionContext(), session, receiver);
+
+         this.cachedFqqn = SimpleString.of(receiverInfo.getLocalFqqn());
+         this.localQueue = localQueue;
+      }
+
+      @Override
+      public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
+         super.close(remoteLinkClose);
+
+         if (!closed) {
+            closed = true;
+
+            try {
+               AMQPBridgeManagementSupport.unregisterBridgeReceiver(AMQPBridgeFromQueueReceiver.this);
+            } catch (Exception e) {
+               logger.debug("Error caught when trying to remove bridge queue receiver from management", e);
+            }
+
+            if (remoteLinkClose && remoteCloseHandler != null) {
+               try {
+                  remoteCloseHandler.accept(AMQPBridgeFromQueueReceiver.this);
+               } catch (Exception e) {
+                  logger.debug("User remote closed handler threw error: ", e);
+               } finally {
+                  remoteCloseHandler = null;
+               }
+            }
+         }
+      }
+
+      @Override
+      public void initialize() throws Exception {
+         initialized = true;
+
+         final Target target = (Target) receiver.getRemoteTarget();
+
+         // Match the settlement mode of the remote instead of relying on the default of MIXED.
+         receiver.setSenderSettleMode(receiver.getRemoteSenderSettleMode());
+
+         // We don't currently support SECOND so enforce that the answer is always FIRST
+         receiver.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+
+         // the target will have an address and it will naturally have a Target otherwise
+         // the remote is misbehaving and we close it.
+         if (target == null || target.getAddress() == null || target.getAddress().isEmpty()) {
+            throw new ActiveMQAMQPInternalErrorException("Remote should have sent a valid Target but we got: " + target);
+         }
+
+         if (!target.getAddress().equals(receiverInfo.getLocalFqqn())) {
+            throw new ActiveMQAMQPInternalErrorException("Remote should have sent a matching Target FQQN but we got: " + target.getAddress());
+         }
+
+         address = SimpleString.of(receiverInfo.getLocalQueue());
+         defRoutingType = receiverInfo.getRoutingType();
+
+         try {
+            final QueueQueryResult result = sessionSPI.queueQuery(address, defRoutingType, false);
+
+            // We initiated this link so the settings should refer to an queue that definitely exists
+            // however there is a chance the address was removed in the interim.
+            if (!result.isExists()) {
+               throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist(address.toString());
+            }
+         } catch (ActiveMQAMQPNotFoundException e) {
+            throw e;
+         } catch (Exception e) {
+            logger.debug(e.getMessage(), e);
+            throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
+         }
+
+         // If we offered core tunneling then check if the remote indicated support and enabled the readers
+         if (configuration.isCoreMessageTunnelingEnabled() && verifyDesiredCapability(protonReceiver, CORE_MESSAGE_TUNNELING_SUPPORT)) {
+            enableCoreTunneling();
+         }
+
+         try {
+            AMQPBridgeManagementSupport.registerBridgeReceiver(AMQPBridgeFromQueueReceiver.this);
+         } catch (Exception e) {
+            logger.debug("Error caught when trying to add bridge queue receiver to management", e);
+         }
+
+         topUpCreditIfNeeded();
+      }
+
+      @Override
+      protected void actualDelivery(Message message, Delivery delivery, DeliveryAnnotations deliveryAnnotations, Receiver receiver, Transaction tx) {
+         try {
+            if (logger.isTraceEnabled()) {
+               logger.trace("AMQP Bridge {} queue receiver {} dispatching incoming message: {}", bridgeManager.getName(), receiverInfo, message);
+            }
+
+            final Message theMessage = transformer.transform(message);
+
+            if (theMessage != message && logger.isTraceEnabled()) {
+               logger.trace("The transformer {} replaced the original message {} with a new instance {}",
+                            transformer, message, theMessage);
+            }
+
+            sessionSPI.serverSend(this, tx, receiver, delivery, cachedFqqn, routingContext, theMessage);
+         } catch (Exception e) {
+            logger.warn("Inbound delivery for {} encountered an error: {}", receiverInfo, e.getMessage(), e);
+            deliveryFailed(delivery, receiver, e);
+         } finally {
+            recordMessageReceived(message);
+         }
+      }
+
+      @Override
+      protected Runnable createCreditRunnable(AMQPConnectionContext connection) {
+         // We defer to the configuration instance as opposed to the base class version that reads
+         // from the connection this allows us to defer to configured policy properties that specify
+         // credit.
+         if (configuration.getReceiverCredits() > 0) {
+            return createCreditRunnable(configuration.getReceiverCredits(), configuration.getReceiverCreditsLow(), receiver, connection, this);
+         } else {
+            return this::checkIfCreditTopUpNeeded;
+         }
+      }
+
+      @Override
+      protected int getConfiguredMinLargeMessageSize(AMQPConnectionContext connection) {
+         // Looks at policy properties first before looking at bridge configuration and finally
+         // going to the base connection context to read the URI configuration.
+         return configuration.getLargeMessageThreshold();
+      }
+
+      // Credit handling here kicks in when the connection is configured for zero link credit and
+      // we want to then batch credit to the remote only when there is no local pending messages
+      // which implies the local consumers are keeping up and we can pull more across.
+
+      private final AtomicBoolean creditTopUpInProgress = new AtomicBoolean();
+
+      private final Runnable checkForNoBacklogRunnable = this::checkForNoBacklogOnQueue;
+      private final Runnable performCreditTopUpRunnable = this::performCreditTopUp;
+
+      private int lastBacklogCheckDelay;
+
+      private void checkIfCreditTopUpNeeded() {
+         if (!connection.isHandler()) {
+            connection.runLater(creditRunnable);
+            return;
+         }
+
+         if (receiver.getCredit() + AMQPBridgeQueueDeliveryReceiver.this.pendingSettles <= 0 && !creditTopUpInProgress.get()) {
+            // We don't need more scheduled tasks stacking up trying to issue a new
+            // batch of credit so lets gate this now so they give up.
+            creditTopUpInProgress.set(true);
+
+            // Move to the Queue executor to ensure we get a proper read on the state of pending messages.
+            localQueue.getExecutor().execute(checkForNoBacklogRunnable);
+         }
+      }
+
+      private void checkForNoBacklogOnQueue() {
+         // Only when there is no backlog do we grant new credit, otherwise we must wait until
+         // the local backlog is zero. The top up must be run from the connection executor.
+         if (localQueue.getPendingMessageCount() == 0) {
+            lastBacklogCheckDelay = 0;
+            connection.runLater(performCreditTopUpRunnable);
+         } else {
+            lastBacklogCheckDelay = caclulateNextDelay(lastBacklogCheckDelay, DEFAULT_PENDING_MSG_CHECK_BACKOFF_MULTIPLIER, DEFAULT_PENDING_MSG_CHECK_MAX_DELAY);
+
+            bridgeManager.getScheduler().schedule(() -> {
+               localQueue.getExecutor().execute(checkForNoBacklogRunnable);
+            }, lastBacklogCheckDelay, TimeUnit.SECONDS);
+         }
+      }
+
+      private void performCreditTopUp() {
+         connection.requireInHandler();
+
+         try {
+            if (receiver.getLocalState() != EndpointState.ACTIVE) {
+               return; // Closed before this was triggered.
+            }
+
+            receiver.flow(configuration.getPullReceiverBatchSize());
+            connection.instantFlush();
+            lastBacklogCheckDelay = 0;
+         } finally {
+            creditTopUpInProgress.set(false);
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeLinkConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeLinkConfiguration.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+
+/**
+ * Base bridge link configuration that carries configuration common to both sender or receiver
+ * bridge links created by the bridge managers.
+ */
+public abstract class AMQPBridgeLinkConfiguration {
+
+   protected final Map<String, Object> properties;
+   protected final AMQPBridgeConfiguration configuration;
+
+   @SuppressWarnings("unchecked")
+   public AMQPBridgeLinkConfiguration(AMQPBridgeConfiguration configuration, Map<String, ?> properties) {
+      Objects.requireNonNull(configuration, "Bridge configuration cannot be null");
+
+      this.configuration = configuration;
+
+      if (properties == null || properties.isEmpty()) {
+         this.properties = Collections.emptyMap();
+      } else {
+         this.properties = (Map<String, Object>) Collections.unmodifiableMap(new HashMap<>(properties));
+      }
+   }
+
+   /**
+    * {@return the timeout value to use when waiting for a corresponding link attach from the remote}
+    */
+   public final int getLinkAttachTimeout() {
+      final Object property = properties.get(LINK_ATTACH_TIMEOUT);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getLinkAttachTimeout();
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if bridge is configured to create links with the sender settle mode set to settled}
+    */
+   public final boolean isUsingPresettledSenders() {
+      final Object property = properties.get(PRESETTLE_SEND_MODE);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return configuration.isUsingPresettledSenders();
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if link recovery support is enabled, <code>false</code> otherwise}
+    */
+   public final boolean isLinkRecoveryEnabled() {
+      return getMaxLinkRecoveryAttempts() != 0;
+   }
+
+   /**
+    * {@return the maximum number of link recovery attempts, or zero if no attempts allowed}
+    */
+   public final int getMaxLinkRecoveryAttempts() {
+      final Object property = properties.get(MAX_LINK_RECOVERY_ATTEMPTS);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getMaxLinkRecoveryAttempts();
+      }
+   }
+
+   /**
+    * {@return the initial delay before a link recovery attempt is made}
+    */
+   public final long getLinkRecoveryInitialDelay() {
+      final Object property = properties.get(LINK_RECOVERY_INITIAL_DELAY);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getLinkRecoveryInitialDelay();
+      }
+   }
+
+   /**
+    * {@return the delay that will be used between successive link recovery attempts}
+    */
+   public final long getLinkRecoveryDelay() {
+      final Object property = properties.get(LINK_RECOVERY_DELAY);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getLinkRecoveryDelay();
+      }
+   }
+
+   /**
+    * {@return true if the bridge is configured to tunnel core messages as AMQP custom messages}
+    */
+   public boolean isCoreMessageTunnelingEnabled() {
+      final Object property = properties.get(AmqpSupport.TUNNEL_CORE_MESSAGES);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return configuration.isCoreMessageTunnelingEnabled();
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagementSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagementSupport.java
@@ -1,0 +1,371 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import javax.management.ObjectName;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.management.ManagementService;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeReceiverInfo.ReceiverRole;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeToSenderController.SenderRole;
+import org.apache.activemq.artemis.utils.CompositeAddress;
+
+/**
+ * Support methods for working with the AMQP bridge management types
+ */
+public final class AMQPBridgeManagementSupport {
+
+   // Resource names specific to bridge resources that exist on the local end of a broker connection.
+
+   /**
+    * Template used to denote bridge manager instances in the server management registry.
+    */
+   public static final String BRIDGE_MANAGER_RESOURCE_TEMPLATE = "brokerconnection.%s.bridge.%s";
+
+   /**
+    * Template used to denote bridge policy managers created on the source in the server management registry.
+    */
+   public static final String BRIDGE_POLICY_RESOURCE_TEMPLATE = BRIDGE_MANAGER_RESOURCE_TEMPLATE + ".policy.%s";
+
+   /**
+    * Template used to denote bridge receivers on the source in the server management registry. Since policy
+    * names are unique on the local broker AMQP bridge configuration these names should not collide as each
+    * policy will create only one receiver for a given address or queue.
+    */
+   public static final String BRIDGE_RECEIVER_RESOURCE_TEMPLATE = BRIDGE_POLICY_RESOURCE_TEMPLATE + ".receiver.%s";
+
+   /**
+    * Template used to denote bridge senders on the source in the server management registry. Since policy
+    * names are unique on the local broker AMQP bridge configuration these names should not collide as each
+    * policy will create only one sender for a given address or queue.
+    */
+   public static final String BRIDGE_SENDER_RESOURCE_TEMPLATE = BRIDGE_POLICY_RESOURCE_TEMPLATE + ".sender.%s";
+
+   // MBean naming that will be registered under an name that links to the location of the bean
+   // either source or target end of the broker connection.
+
+   /**
+    * The template used to create the object name suffix that is appending to the broker connection
+    * object name when adding and removing AMQP bridge related control elements.
+    */
+   public static final String BRIDGE_NAME_TEMPLATE = "serviceCatagory=bridge,bridgeName=%s";
+
+   /**
+    * The template used to create the object name suffix that is appending to the broker connection
+    * object name when adding and removing AMQP bridge policy control elements.
+    */
+   public static final String BRIDGE_POLICY_NAME_TEMPLATE = BRIDGE_NAME_TEMPLATE + ",policyType=%s,policyName=%s";
+
+   /**
+    * The template used to create the object name suffix that is appending to the broker connection
+    * object name when adding and removing AMQP bridge queue receiver control elements.
+    */
+   public static final String BRIDGE_QUEUE_RECEIVER_NAME_TEMPLATE = BRIDGE_POLICY_NAME_TEMPLATE + ",linkType=receivers,fqqn=%s";
+
+   /**
+    * The template used to create the object name suffix that is appending to the broker connection
+    * object name when adding and removing AMQP bridge address receiver control elements.
+    */
+   public static final String BRIDGE_ADDRESS_RECEIVER_NAME_TEMPLATE = BRIDGE_POLICY_NAME_TEMPLATE + ",linkType=receivers,address=%s";
+
+   /**
+    * The template used to create the object name suffix that is appending to the broker connection
+    * object name when adding and removing AMQP bridge queue sender control elements.
+    */
+   public static final String BRIDGE_QUEUE_SENDER_NAME_TEMPLATE = BRIDGE_POLICY_NAME_TEMPLATE + ",linkType=senders,fqqn=%s";
+
+   /**
+    * The template used to create the object name suffix that is appending to the broker connection
+    * object name when adding and removing AMQP bridge address sender control elements.
+    */
+   public static final String BRIDGE_ADDRESS_SENDER_NAME_TEMPLATE = BRIDGE_POLICY_NAME_TEMPLATE + ",linkType=senders,address=%s";
+
+   /**
+    * Register the given {@link AMQPBridgeManager} instance with the broker management services.
+    *
+    * @param bridge
+    *    The bridge manager instance being registered with management.
+    *
+    * @throws Exception if an error occurs while registering the bridge with the management services.
+    */
+   public static void registerBridgeManager(AMQPBridgeManager bridge) throws Exception {
+      final String bridgeName = bridge.getName();
+      final String brokerConnectionName = bridge.getBrokerConnection().getName();
+      final ActiveMQServer server = bridge.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPBridgeManagerControlType control = new AMQPBridgeManagerControlType(server, bridge);
+
+      management.registerInJMX(getBridgeManagerObjectName(management, brokerConnectionName, bridgeName), control);
+      management.registerInRegistry(getBridgeManagerResourceName(brokerConnectionName, bridgeName), control);
+   }
+
+   /**
+    * Unregister the given {@link AMQPBridgeManager} instance with the broker management services.
+    *
+    * @param bridge
+    *    The bridge manager instance being unregistered from management.
+    *
+    * @throws Exception if an error occurs while unregistering the bridge with the management services.
+    */
+   public static void unregisterBridgeManager(AMQPBridgeManager bridge) throws Exception {
+      final String bridgeName = bridge.getName();
+      final String brokerConnectionName = bridge.getBrokerConnection().getName();
+      final ActiveMQServer server = bridge.getServer();
+      final ManagementService management = server.getManagementService();
+
+      management.unregisterFromJMX(getBridgeManagerObjectName(management, brokerConnectionName, bridgeName));
+      management.unregisterFromRegistry(getBridgeManagerResourceName(brokerConnectionName, bridgeName));
+   }
+
+   public static String getBridgeManagerResourceName(String brokerConnectionName, String bridgeName) {
+      return String.format(BRIDGE_MANAGER_RESOURCE_TEMPLATE, brokerConnectionName, bridgeName);
+   }
+
+   public static ObjectName getBridgeManagerObjectName(ManagementService management, String brokerConnection, String bridgeName) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + BRIDGE_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(bridgeName)));
+   }
+
+   /**
+    * Register an AMQP bridge policy manager with the server management services.
+    *
+    * @param manager
+    *    The AMQP bridge policy manager instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the manager with the management services.
+    */
+   public static void registerBridgePolicyManager(AMQPBridgePolicyManager manager) throws Exception {
+      final AMQPBridgeManager bridgeManager = manager.getBridgeManager();
+      final String brokerConnectionName = bridgeManager.getBrokerConnection().getName();
+      final ActiveMQServer server = bridgeManager.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPBridgePolicyManagerControlType control = new AMQPBridgePolicyManagerControlType(manager);
+      final String bridgeName = bridgeManager.getName();
+      final String policyName = manager.getPolicyName();
+
+      management.registerInJMX(getBridgePolicyManagerObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName), control);
+      management.registerInRegistry(getBridgePolicyManagerResourceName(brokerConnectionName, bridgeName, policyName), control);
+   }
+
+   /**
+    * Unregister an AMQP bridge policy manager with the server management services.
+    *
+    * @param manager
+    *    The AMQP bridge policy manager instance that is being managed.
+    *
+    * @throws Exception if an error occurs while unregistering the manager with the management services.
+    */
+   public static void unregisterBridgePolicyManager(AMQPBridgePolicyManager manager) throws Exception {
+      final AMQPBridgeManager bridgeManager = manager.getBridgeManager();
+      final String brokerConnectionName = bridgeManager.getBrokerConnection().getName();
+      final ActiveMQServer server = bridgeManager.getServer();
+      final ManagementService management = server.getManagementService();
+      final String bridgeName = bridgeManager.getName();
+      final String policyName = manager.getPolicyName();
+
+      management.unregisterFromJMX(getBridgePolicyManagerObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName));
+      management.unregisterFromRegistry(getBridgePolicyManagerResourceName(brokerConnectionName, bridgeName, policyName));
+   }
+
+   public static String getBridgePolicyManagerResourceName(String brokerConnectionName, String bridgeName, String policyName) {
+      return String.format(BRIDGE_POLICY_RESOURCE_TEMPLATE, brokerConnectionName, bridgeName, policyName);
+   }
+
+   public static ObjectName getBridgePolicyManagerObjectName(ManagementService management, String brokerConnection, String bridgeName, String policyType, String policyName) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + BRIDGE_POLICY_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(bridgeName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName)));
+   }
+
+   /**
+    * Registers the bridge receiver with the server management services on the source.
+    *
+    * @param receiver
+    *    The AMQP bridge receiver instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the receiver with the management services.
+    */
+   public static void registerBridgeReceiver(AMQPBridgeReceiver receiver) throws Exception {
+      final AMQPBridgePolicyManager manager = receiver.getPolicyManager();
+      final AMQPBridgeManager bridgeManager = manager.getBridgeManager();
+      final String brokerConnectionName = bridgeManager.getBrokerConnection().getName();
+      final ActiveMQServer server = bridgeManager.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPBridgeReceiverControlType control = new AMQPBridgeReceiverControlType(receiver);
+      final String bridgeName = bridgeManager.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (receiver.getRole() == ReceiverRole.ADDRESS_RECEIVER) {
+         management.registerInJMX(getBridgeAddressReceiverObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, receiver.getReceiverInfo().getLocalAddress()), control);
+         management.registerInRegistry(getBridgeAddressReceiverResourceName(brokerConnectionName, bridgeName, policyName, receiver.getReceiverInfo().getLocalAddress()), control);
+      } else {
+         management.registerInJMX(getBridgeQueueReceiverObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, receiver.getReceiverInfo().getLocalFqqn()), control);
+         management.registerInRegistry(getBridgeQueueReceiverResourceName(brokerConnectionName, bridgeName, policyName, receiver.getReceiverInfo().getLocalFqqn()), control);
+      }
+   }
+
+   /**
+    * Unregisters the bridge receiver with the server management services on the source.
+    *
+    * @param receiver
+    *    The AMQP bridge receiver instance that is being managed.
+    *
+    * @throws Exception if an error occurs while registering the receiver with the management services.
+    */
+   public static void unregisterBridgeReceiver(AMQPBridgeReceiver receiver) throws Exception {
+      final AMQPBridgePolicyManager manager = receiver.getPolicyManager();
+      final AMQPBridgeManager bridgeManager = manager.getBridgeManager();
+      final String brokerConnectionName = bridgeManager.getBrokerConnection().getName();
+      final ActiveMQServer server = bridgeManager.getServer();
+      final ManagementService management = server.getManagementService();
+      final String bridgeName = bridgeManager.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (receiver.getRole() == ReceiverRole.ADDRESS_RECEIVER) {
+         management.unregisterFromJMX(getBridgeAddressReceiverObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, receiver.getReceiverInfo().getLocalAddress()));
+         management.unregisterFromRegistry(getBridgeAddressReceiverResourceName(brokerConnectionName, bridgeName, policyName, receiver.getReceiverInfo().getLocalAddress()));
+      } else {
+         management.unregisterFromJMX(getBridgeQueueReceiverObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, receiver.getReceiverInfo().getLocalFqqn()));
+         management.unregisterFromRegistry(getBridgeQueueReceiverResourceName(brokerConnectionName, bridgeName, policyName, receiver.getReceiverInfo().getLocalFqqn()));
+      }
+   }
+
+   public static String getBridgeAddressReceiverResourceName(String brokerConnectionName, String bridgeName, String policyName, String address) {
+      return String.format(BRIDGE_RECEIVER_RESOURCE_TEMPLATE, brokerConnectionName, bridgeName, policyName, address);
+   }
+
+   public static ObjectName getBridgeAddressReceiverObjectName(ManagementService management, String brokerConnection, String bridgeName, String policyType, String policyName, String address) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + BRIDGE_ADDRESS_RECEIVER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(bridgeName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(address)));
+   }
+
+   public static String getBridgeQueueReceiverResourceName(String brokerConnectionName, String bridgeName, String policyName, String fqqn) {
+      return String.format(BRIDGE_RECEIVER_RESOURCE_TEMPLATE, brokerConnectionName, bridgeName, policyName, fqqn);
+   }
+
+   public static ObjectName getBridgeQueueReceiverObjectName(ManagementService management, String brokerConnection, String bridgeName, String policyType, String policyName, String fqqn) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + BRIDGE_QUEUE_RECEIVER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(bridgeName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(fqqn)));
+   }
+
+   /**
+    * Registers the bridge sender with the server management services on the source.
+    *
+    * @param sender
+    *    The AMQP bridge sender controller that manages the bridgeManager sender.
+    *
+    * @throws Exception if an error occurs while registering the producer with the management services.
+    */
+   public static void registerBridgeSender(AMQPBridgeToSenderController sender) throws Exception {
+      final AMQPBridgePolicyManager manager = sender.getPolicyManager();
+      final AMQPBridgeManager bridgeManager = manager.getBridgeManager();
+      final String brokerConnectionName = bridgeManager.getBrokerConnection().getName();
+      final ActiveMQServer server = bridgeManager.getServer();
+      final ManagementService management = server.getManagementService();
+      final AMQPBridgeSenderControlType control = new AMQPBridgeSenderControlType(sender);
+      final String bridgeName = bridgeManager.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (sender.getRole() == SenderRole.ADDRESS_SENDER) {
+         final String address = control.getAddress();
+
+         management.registerInJMX(getBridgeAddressSenderObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, address), control);
+         management.registerInRegistry(getBridgeAddressSenderResourceName(brokerConnectionName, bridgeName, policyName, address), control);
+      } else {
+         final String fqqn = control.getFqqn();
+
+         management.registerInJMX(getBridgeQueueSenderObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, fqqn), control);
+         management.registerInRegistry(getBridgeQueueSenderResourceName(brokerConnectionName, bridgeName, policyName, fqqn), control);
+      }
+   }
+
+   /**
+    * Unregisters the bridge sender with the server management services on the source.
+    *
+    * @param sender
+    *    The AMQP bridge sender controller that manages the bridge producer.
+    *
+    * @throws Exception if an error occurs while registering the sender with the management services.
+    */
+   public static void unregisterBridgeSender(AMQPBridgeToSenderController sender) throws Exception {
+      final AMQPBridgePolicyManager manager = sender.getPolicyManager();
+      final AMQPBridgeManager bridgeManager = manager.getBridgeManager();
+      final String brokerConnectionName = bridgeManager.getBrokerConnection().getName();
+      final ActiveMQServer server = bridgeManager.getServer();
+      final ManagementService management = server.getManagementService();
+      final String bridgeName = bridgeManager.getName();
+      final String policyName = manager.getPolicyName();
+
+      if (sender.getRole() == SenderRole.ADDRESS_SENDER) {
+         final String address = sender.getServerConsumer().getQueueAddress().toString();
+
+         management.unregisterFromJMX(getBridgeAddressSenderObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, address));
+         management.unregisterFromRegistry(getBridgeAddressSenderResourceName(brokerConnectionName, bridgeName, policyName, address));
+      } else {
+         final String fqqn = CompositeAddress.toFullyQualified(sender.getServerConsumer().getQueueAddress().toString(), sender.getServerConsumer().getQueueName().toString());
+
+         management.unregisterFromJMX(getBridgeQueueSenderObjectName(management, brokerConnectionName, bridgeName, manager.getPolicyType().toString(), policyName, fqqn));
+         management.unregisterFromRegistry(getBridgeQueueSenderResourceName(brokerConnectionName, bridgeName, policyName, fqqn));
+      }
+   }
+
+   public static String getBridgeAddressSenderResourceName(String brokerConnectionName, String bridgeName, String policyName, String address) {
+      return String.format(BRIDGE_SENDER_RESOURCE_TEMPLATE, brokerConnectionName, bridgeName, policyName, address);
+   }
+
+   public static ObjectName getBridgeAddressSenderObjectName(ManagementService management, String brokerConnection, String bridgeName, String policyType, String policyName, String address) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + BRIDGE_ADDRESS_SENDER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(bridgeName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(address)));
+   }
+
+   public static String getBridgeQueueSenderResourceName(String brokerConnectionName, String bridgeName, String policyName, String fqqn) {
+      return String.format(BRIDGE_SENDER_RESOURCE_TEMPLATE, brokerConnectionName, bridgeName, policyName, fqqn);
+   }
+
+   public static ObjectName getBridgeQueueSenderObjectName(ManagementService management, String brokerConnection, String bridgeName, String policyType, String policyName, String fqqn) throws Exception {
+      return ObjectName.getInstance(
+         String.format("%s," + BRIDGE_QUEUE_SENDER_NAME_TEMPLATE,
+            management.getObjectNameBuilder().getBrokerConnectionBaseObjectNameString(brokerConnection),
+            ObjectName.quote(bridgeName),
+            ObjectName.quote(policyType),
+            ObjectName.quote(policyName),
+            ObjectName.quote(fqqn)));
+   }
+   private AMQPBridgeManagementSupport() {
+      // Prevent creation.
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManager.java
@@ -1,0 +1,375 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Predicate;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnection;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.qpid.proton.engine.Connection;
+import org.apache.qpid.proton.engine.Link;
+import org.apache.qpid.proton.engine.Session;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AMQP Bridge manager object that handles starting and stopping bridge
+ * operations as needed for the parent broker connection.
+ */
+public class AMQPBridgeManager {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static final WildcardConfiguration DEFAULT_WILDCARD_CONFIGURATION = new WildcardConfiguration();
+
+   private enum State {
+      UNINITIALIZED,
+      STOPPED,
+      STARTED,
+      SHUTDOWN
+   }
+
+   private final String name;
+   private final ActiveMQServer server;
+   private final AMQPBrokerConnection brokerConnection;
+   private final WildcardConfiguration wildcardConfiguration;
+   private final ScheduledExecutorService scheduler;
+   private final Map<String, Object> properties;
+   private final Map<String, Predicate<Link>> linkClosedinterceptors = new ConcurrentHashMap<>();
+   private final Set<AMQPBridgePolicyManager> policyManagers = new HashSet<>();
+   private final AMQPBridgeMetrics metrics = new AMQPBridgeMetrics();
+
+   private volatile AMQPBridgeConfiguration configuration;
+
+   protected volatile State state = State.UNINITIALIZED;
+   protected volatile boolean connected;
+
+   AMQPBridgeManager(String name, AMQPBrokerConnection brokerConnection,
+                     Set<AMQPBridgeAddressPolicy> fromAddressPolicies,
+                     Set<AMQPBridgeAddressPolicy> toAddressPolicies,
+                     Set<AMQPBridgeQueuePolicy> fromQueuePolicies,
+                     Set<AMQPBridgeQueuePolicy> toQueuePolicies,
+                     Map<String, Object> properties) {
+      Objects.requireNonNull(name, "Bridge name cannot be null");
+
+      this.name = name;
+      this.server = brokerConnection.getServer();
+      this.brokerConnection = brokerConnection;
+      this.brokerConnection.addLinkClosedInterceptor(getName(), this::invokeLinkClosedInterceptors);
+      this.scheduler = server.getScheduledPool();
+
+      if (properties == null || properties.isEmpty()) {
+         this.properties = Collections.emptyMap();
+      } else {
+         this.properties = (Map<String, Object>) Collections.unmodifiableMap(new HashMap<>(properties));
+      }
+
+      fromAddressPolicies.forEach(policy -> this.policyManagers.add(new AMQPBridgeFromAddressPolicyManager(this, metrics.newPolicyMetrics(), policy)));
+      fromQueuePolicies.forEach(policy -> this.policyManagers.add(new AMQPBridgeFromQueuePolicyManager(this, metrics.newPolicyMetrics(), policy)));
+      toAddressPolicies.forEach(policy -> this.policyManagers.add(new AMQPBridgeToAddressPolicyManager(this, metrics.newPolicyMetrics(), policy)));
+      toQueuePolicies.forEach(policy -> this.policyManagers.add(new AMQPBridgeToQueuePolicyManager(this, metrics.newPolicyMetrics(), policy)));
+
+      if (server.getConfiguration().getWildcardConfiguration() != null) {
+         this.wildcardConfiguration = server.getConfiguration().getWildcardConfiguration();
+      } else {
+         this.wildcardConfiguration = DEFAULT_WILDCARD_CONFIGURATION;
+      }
+   }
+
+   /**
+    * Initialize this bridge instance if not already initialized.
+    *
+    * @throws ActiveMQException if an error occurs during the initialization process.
+    */
+   public final synchronized void initialize() throws ActiveMQException {
+      failIfShutdown();
+
+      if (state == State.UNINITIALIZED) {
+         state = State.STOPPED;
+
+         try {
+            AMQPBridgeManagementSupport.registerBridgeManager(this);
+         } catch (Exception e) {
+            logger.warn("Ignoring error while attempting to register bridge with management services");
+         }
+
+         for (AMQPBridgePolicyManager manager : policyManagers) {
+            manager.initialize();
+         }
+      }
+   }
+
+   /**
+    * Starts this bridge instance if not already started.
+    *
+    * @throws ActiveMQException if an error occurs during the start process.
+    */
+   public final synchronized void start() throws ActiveMQException {
+      failIfShutdown();
+
+      if (state.ordinal() < State.STOPPED.ordinal()) {
+         throw new ActiveMQIllegalStateException("The bridge has not been initialized and cannot be started.");
+      }
+
+      if (state == State.STOPPED) {
+         state = State.STARTED;
+
+         for (AMQPBridgePolicyManager manager : policyManagers) {
+            try {
+               manager.start();
+            } catch (Exception e) {
+               logger.debug("Caught error while starting a policy manager: ", e);
+               throw e;
+            }
+         }
+      }
+   }
+
+   /**
+    * Stops this bridge instance and shuts down all remote resources that
+    * the bridge currently has open and active.
+    *
+    * @throws ActiveMQException if an error occurs during the stop process.
+    */
+   public final synchronized void stop() throws ActiveMQException {
+      if (state.ordinal() < State.STOPPED.ordinal()) {
+         throw new ActiveMQIllegalStateException("The bridge has not been initialized and cannot be stopped.");
+      }
+
+      if (state == State.STARTED) {
+         state = State.STOPPED;
+
+         for (AMQPBridgePolicyManager manager : policyManagers) {
+            try {
+               manager.stop();
+            } catch (Exception e) {
+               logger.debug("Caught error while stopping a policy manager: ", e);
+               throw e;
+            }
+         }
+      }
+   }
+
+   /**
+    * Shutdown this bridge instance if not already shutdown (this is a terminal operation).
+    *
+    * @throws ActiveMQException if an error occurs during the shutdown process.
+    */
+   public final synchronized void shutdown() throws ActiveMQException {
+      if (state.ordinal() < State.SHUTDOWN.ordinal()) {
+         state = State.SHUTDOWN;
+
+         try {
+            AMQPBridgeManagementSupport.unregisterBridgeManager(this);
+         } catch (Exception e) {
+            logger.warn("Ignoring error while attempting to unregister bridge with management services");
+         }
+
+         for (AMQPBridgePolicyManager manager : policyManagers) {
+            manager.shutdown();
+         }
+      }
+   }
+
+   /**
+    * {@return the unique name that was assigned to this server bridge connector}
+    */
+   public String getName() {
+      return name;
+   }
+
+   /**
+    * {@return the metrics instance tied to this bridge instance}
+    */
+   public AMQPBridgeMetrics getMetrics() {
+      return metrics;
+   }
+
+   /**
+    * {@return the {@link ActiveMQServer} instance assigned to this bridge}
+    */
+   public ActiveMQServer getServer() {
+      return server;
+   }
+
+   /**
+    * {@return the {@link AMQPBrokerConnection} that this bridge is attached to}
+    */
+   public AMQPBrokerConnection getBrokerConnection() {
+      return brokerConnection;
+   }
+
+   /**
+    * {@return the {@link WildcardConfiguration} that is in use by this bridge instance}
+    */
+   public WildcardConfiguration getWildcardConfiguration() {
+      return wildcardConfiguration;
+   }
+
+   public ScheduledExecutorService getScheduler() {
+      return scheduler;
+   }
+
+   /**
+    * {@return <code>true</code> if the bridge manager has been started}
+    */
+   public boolean isStarted() {
+      return state == State.STARTED;
+   }
+
+   /**
+    * {@return <code>true</code> if the bridge manager has been marked as connected}
+    */
+   public boolean isConnected() {
+      return connected;
+   }
+
+   /**
+    * Called by the parent broker connection when the connection has failed and this AMQP bridge
+    * should tear down any active resources and await a reconnect if one is allowed.
+    *
+    * @throws ActiveMQException if an error occurs processing the connection interrupted event
+    */
+   public synchronized void connectionInterrupted() throws ActiveMQException {
+      final AtomicReference<Exception> errorCaught = new AtomicReference<>();
+
+      policyManagers.forEach(manager -> {
+         try {
+            manager.connectionInterrupted();
+         } catch (Exception ex) {
+            logger.trace("Exception caught on from a policy manager connection state update: ", ex);
+            errorCaught.compareAndExchange(null, ex);
+         }
+      });
+
+      if (errorCaught.get() != null) {
+         final Exception error = errorCaught.get();
+         if (error instanceof ActiveMQException) {
+            throw (ActiveMQException) error;
+         } else {
+            throw (ActiveMQException) new ActiveMQException(error.getMessage()).initCause(error);
+         }
+      }
+   }
+
+   /**
+    * Called by the parent broker connection when the connection has been established and this
+    * AMQP bridge should build up its active state based on the configuration.
+    *
+    * @param connection
+    *    The new {@link Connection} that represents the currently active connection.
+    * @param session
+    *    The new {@link Session} that was created for use by broker connection resources.
+    *
+    * @throws ActiveMQException if an error occurs processing the connection restored event
+    */
+   public synchronized void connectionRestored(AMQPConnectionContext connection, AMQPSessionContext session) throws ActiveMQException {
+      this.configuration = new AMQPBridgeConfiguration(connection, properties);
+
+      for (AMQPBridgePolicyManager manager : policyManagers) {
+         try {
+            manager.connectionRestored(session, configuration);
+         } catch (Exception e) {
+            logger.debug("Caught error while restoring connection state to policy manager: ", e);
+            throw e;
+         }
+      }
+   }
+
+   /**
+    * Error signaling API that can be used to report errors during creation of AMQP links.
+    *
+    * @param cause
+    *    The error that caused the resource creation to fail.
+    */
+   void signalResourceCreateError(Exception cause) {
+      brokerConnection.connectError(cause);
+   }
+
+   /**
+    * Error signaling API that can be used signal errors encountered during normal operations.
+    *
+    * @param cause
+    *    The error that caused the operation to fail.
+    */
+   void signalError(Exception cause) {
+      brokerConnection.runtimeError(cause);
+   }
+
+   /**
+    * Adds a remote linked closed event interceptor that can intercept the closed event and
+    * if it returns true indicate that the close has been handled and that no further action
+    * need to be taken for this event.
+    *
+    * @param id
+    *    A unique Id value that identifies the interceptor for later removal.
+    * @param interceptor
+    *    The predicate that will be called for any link close.
+    *
+    * @return this {@link AMQPBridgeManager} instance.
+    */
+   AMQPBridgeManager addLinkClosedInterceptor(String id, Predicate<Link> interceptor) {
+      linkClosedinterceptors.put(id, interceptor);
+      return this;
+   }
+
+   /**
+    * Remove a previously registered link close interceptor from the list of close interceptor bindings.
+    *
+    * @param id
+    *   The id of the interceptor to remove
+    *
+    * @return this {@link AMQPBridgeManager} instance.
+    */
+   AMQPBridgeManager removeLinkClosedInterceptor(String id) {
+      linkClosedinterceptors.remove(id);
+      return this;
+   }
+
+   protected boolean invokeLinkClosedInterceptors(Link link) {
+      for (Map.Entry<String, Predicate<Link>> interceptor : linkClosedinterceptors.entrySet()) {
+         if (interceptor.getValue().test(link)) {
+            logger.trace("Remote link[{}] close intercepted and handled by interceptor: {}", link.getName(), interceptor.getKey());
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private void failIfShutdown() throws ActiveMQIllegalStateException {
+      if (state == State.SHUTDOWN) {
+         throw new ActiveMQIllegalStateException("The bridge manager instance has been shutdown");
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagerControl.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagerControl.java
@@ -1,0 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import org.apache.activemq.artemis.api.core.management.Attribute;
+
+/**
+ * Management service control interface for an AMQP bridgeManager instance.
+ */
+public interface AMQPBridgeManagerControl {
+
+   /**
+    * {@return the configured name the AMQP bridge being controlled}
+    */
+   @Attribute(desc = "The configured AMQP bridge name that backs this control instance.")
+   String getName();
+
+   /**
+    * {@return the number of messages this bridge has received from the remote}
+    */
+   @Attribute(desc = "returns the number of messages this bridge has received from the remote")
+   long getMessagesReceived();
+
+   /**
+    * {@return the number of messages this bridge has sent to the remote}
+    */
+   @Attribute(desc = "returns the number of messages this bridge has sent to the remote")
+   long getMessagesSent();
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagerControlType.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagerControlType.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.NotCompliantMBeanException;
+
+import org.apache.activemq.artemis.core.management.impl.AbstractControl;
+import org.apache.activemq.artemis.core.management.impl.MBeanInfoHelper;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+/**
+ * Management service control instance for an AMQP bridge manager instance that bridges messages to
+ * or from the remote peer on the opposing side of this broker connection. The bridgeManager manager has
+ * a lifetime that matches that of its parent broker connection.
+ */
+public final class AMQPBridgeManagerControlType extends AbstractControl implements AMQPBridgeManagerControl {
+
+   private final AMQPBridgeManager bridge;
+
+   public AMQPBridgeManagerControlType(ActiveMQServer server, AMQPBridgeManager bridge) throws NotCompliantMBeanException {
+      super(AMQPBridgeManagerControl.class, server.getStorageManager());
+
+      this.bridge = bridge;
+   }
+
+   @Override
+   public String getName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getName(bridge);
+      }
+      clearIO();
+      try {
+         return bridge.getName();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getMessagesReceived() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessagesReceived(bridge);
+      }
+      clearIO();
+      try {
+         return bridge.getMetrics().getMessagesReceived();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getMessagesSent() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessagesSent(bridge);
+      }
+      clearIO();
+      try {
+         return bridge.getMetrics().getMessagesSent();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(AMQPBridgeManagerControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(AMQPBridgeManagerControl.class);
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagers.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeManagers.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Collection;
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnection;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Simple AMQP Bridge aggregation tool used to simplify broker connection management of multiple bridges
+ */
+public class AMQPBridgeManagers {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final Collection<AMQPBridgeManager> bridgeManagers = new ConcurrentHashSet<>();
+   private final AMQPBrokerConnection brokerConnection;
+
+   public AMQPBridgeManagers(AMQPBrokerConnection brokerConnection) {
+      this.brokerConnection = brokerConnection;
+   }
+
+   /**
+    * Shutdown all bridge managers ignoring any thrown exceptions and clears state
+    * from all previously registered manager, new managers can be added after a
+    * reset.
+    */
+   public void shutdown() {
+      bridgeManagers.forEach(bridgeManager -> {
+         try {
+            bridgeManager.shutdown();
+         } catch (Exception e) {
+            logger.trace("Ignoring exception thrown during bridge manager shutdown: ", e);
+         }
+      });
+
+      bridgeManagers.clear();
+   }
+
+   /**
+    * Starts each bridge manager registered in the managers collection.
+    *
+    * @throws Exception if an error occurs while starting any bridge manager.
+    */
+   public void start() throws Exception {
+      for (AMQPBridgeManager manager : bridgeManagers) {
+         try {
+            manager.start();
+         } catch (Exception e) {
+            logger.debug("Exception thrown during bridge manager start: ", e);
+            throw e;
+         }
+      }
+   }
+
+   /**
+    * Stops each bridge manager registered in the managers collection.
+    *
+    * @throws Exception if an error occurs while stopping any bridge manager.
+    */
+   public void stop() throws Exception {
+      Exception firstError = null;
+
+      for (AMQPBridgeManager manager : bridgeManagers) {
+         try {
+            manager.stop();
+         } catch (Exception e) {
+            logger.debug("Exception thrown during bridge manager stop: ", e);
+
+            if (firstError == null) {
+               firstError = e;
+            }
+         }
+      }
+
+      if (firstError != null) {
+         throw firstError;
+      }
+   }
+
+   /**
+    * Adds a new bridge to the collection of managed bridges and starts the new {@link AMQPBridgeManager}
+    *
+    * @param configuration
+    *    The configuration to use when creating a new bridge manager.
+    */
+   public void addBridgeManager(AMQPBridgeBrokerConnectionElement configuration) throws ActiveMQException {
+      final AMQPBridgeManager bridgeManager = AMQPBridgeSupport.createManager(brokerConnection, configuration);
+
+      try {
+         bridgeManager.initialize();
+      } catch (ActiveMQException e) {
+         logger.debug("Error caught and re-thrown while initializing configured bridge connection:", e);
+         throw e;
+      }
+
+      bridgeManagers.add(bridgeManager);
+   }
+
+   /**
+    * Signal all bridge managers that the connection has been restored
+    *
+    * @param session
+    *    The session in which the bridge manager resources will reside.
+    *
+    * @throws ActiveMQException if an error occurs during connection restoration.
+    */
+   public void connectionRestored(AMQPSessionContext session) throws ActiveMQException {
+      for (AMQPBridgeManager bridgeManager : bridgeManagers) {
+         try {
+            bridgeManager.connectionRestored(session.getAMQPConnectionContext(), session);
+         } catch (ActiveMQException e) {
+            logger.trace("AMQP Bridge connection {} threw an error on handling of connection restored: ", bridgeManager.getName(), e);
+            throw e;
+         }
+      }
+   }
+
+   /**
+    * Signals all bridges that the current connection has dropped, exceptions are ignored.
+    */
+   public void connectionInterrupted() {
+      for (AMQPBridgeManager bridgeManager : bridgeManagers) {
+         if (bridgeManager != null) {
+            try {
+               bridgeManager.connectionInterrupted();
+            } catch (ActiveMQException e) {
+               logger.trace("AMQP Bridge connection {} threw an error on handling of connection interrupted", bridgeManager.getName());
+            }
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeMetrics.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeMetrics.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.concurrent.atomic.AtomicLongFieldUpdater;
+
+/**
+ * A Metrics class that supports nesting to provide various elements in the bridge
+ * space a view of its own Metrics for bridging operations.
+ */
+public final class AMQPBridgeMetrics {
+
+   private final AMQPBridgeMetrics parent;
+
+   private static final AtomicLongFieldUpdater<AMQPBridgeMetrics> MESSAGES_SENT_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(AMQPBridgeMetrics.class, "messagesSent");
+   private static final AtomicLongFieldUpdater<AMQPBridgeMetrics> MESSAGES_RECEIVED_UPDATER =
+      AtomicLongFieldUpdater.newUpdater(AMQPBridgeMetrics.class, "messagesReceived");
+
+   private volatile long messagesSent;
+   private volatile long messagesReceived;
+
+   public AMQPBridgeMetrics() {
+      this(null);
+   }
+
+   private AMQPBridgeMetrics(AMQPBridgeMetrics parent) {
+      this.parent = parent;
+   }
+
+   public long getMessagesSent() {
+      return messagesSent;
+   }
+
+   public long getMessagesReceived() {
+      return messagesReceived;
+   }
+
+   AMQPBridgeMetrics newPolicyMetrics() {
+      return new AMQPBridgeMetrics(this);
+   }
+
+   ReceiverMetrics newReceiverMetrics() {
+      return new ReceiverMetrics(this);
+   }
+
+   SenderMetrics newSenderMetrics() {
+      return new SenderMetrics(this);
+   }
+
+   /**
+    * Metrics for a single receiver instance that will also updates to the parents
+    * when the Metrics are updated by the receiver.
+    */
+   public static class ReceiverMetrics {
+
+      private static final AtomicLongFieldUpdater<ReceiverMetrics> MESSAGES_RECEIVED_UPDATER =
+         AtomicLongFieldUpdater.newUpdater(ReceiverMetrics.class, "messagesReceived");
+
+      private final AMQPBridgeMetrics parent;
+
+      private volatile long messagesReceived;
+
+      private ReceiverMetrics(AMQPBridgeMetrics parent) {
+         this.parent = parent;
+      }
+
+      public long getMessagesReceived() {
+         return messagesReceived;
+      }
+
+      public void incrementMessagesReceived() {
+         MESSAGES_RECEIVED_UPDATER.incrementAndGet(this);
+         parent.incrementMessagesReceived();
+      }
+   }
+
+   /**
+    * Metrics for a single sender instance that will also updates to the parents
+    * when the Metrics are updated by the sender.
+    */
+   public static class SenderMetrics {
+
+      private static final AtomicLongFieldUpdater<SenderMetrics> MESSAGES_SENT_UPDATER =
+         AtomicLongFieldUpdater.newUpdater(SenderMetrics.class, "messagesSent");
+
+      private final AMQPBridgeMetrics parent;
+
+      private volatile long messagesSent;
+
+      private SenderMetrics(AMQPBridgeMetrics parent) {
+         this.parent = parent;
+      }
+
+      public long getMessagesSent() {
+         return messagesSent;
+      }
+
+      public void incrementMessagesSent() {
+         MESSAGES_SENT_UPDATER.incrementAndGet(this);
+         parent.incrementMessagesSent();
+      }
+   }
+
+   // Should only have the senders and receivers doing updates of these and then
+   // have those results trickle up to the parent.
+
+   private void incrementMessagesSent() {
+      MESSAGES_SENT_UPDATER.incrementAndGet(this);
+      if (parent != null) {
+         parent.incrementMessagesSent();
+      }
+   }
+
+   private void incrementMessagesReceived() {
+      MESSAGES_RECEIVED_UPDATER.incrementAndGet(this);
+      if (parent != null) {
+         parent.incrementMessagesReceived();
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicy.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.qpid.proton.amqp.Symbol;
+
+/**
+ * Base class for AMQP bridge sender and receiver policies that configure bridging
+ * to or from addresses and queues.
+ */
+public abstract class AMQPBridgePolicy {
+
+   private final Map<String, Object> properties;
+   private final String policyName;
+   private final String remoteAddress;
+   private final String remoteAddressPrefix;
+   private final String remoteAddressSuffix;
+   private final Collection<Symbol> remoteTerminusCapabilities;
+   private final Integer priority;
+   private final String filter;
+   private final TransformerConfiguration transformerConfig;
+
+   public AMQPBridgePolicy(String policyName, Integer priority,
+                           String filter, String remoteAddress,
+                           String remoteAddressPrefix, String remoteAddressSuffix,
+                           Collection<Symbol> remoteTerminusCapabilities,
+                           Map<String, Object> properties,
+                           TransformerConfiguration transformerConfig,
+                           WildcardConfiguration wildcardConfig) {
+      Objects.requireNonNull(policyName, "The provided policy name cannot be null");
+      Objects.requireNonNull(wildcardConfig, "The provided wild card configuration cannot be null");
+
+      this.policyName = policyName;
+      this.remoteAddress = remoteAddress;
+      this.remoteAddressPrefix = remoteAddressPrefix;
+      this.remoteAddressSuffix = remoteAddressSuffix;
+      this.remoteTerminusCapabilities = remoteTerminusCapabilities;
+      this.priority = priority;
+      this.filter = filter;
+      this.transformerConfig = transformerConfig;
+
+      if (properties == null || properties.isEmpty()) {
+         this.properties = Collections.emptyMap();
+      } else {
+         this.properties = Collections.unmodifiableMap(new HashMap<>(properties));
+      }
+   }
+
+   public String getPolicyName() {
+      return policyName;
+   }
+
+   public Map<String, Object> getProperties() {
+      return properties;
+   }
+
+   public Integer getPriority() {
+      return priority;
+   }
+
+   public String getFilter() {
+      return filter;
+   }
+
+   public String getRemoteAddress() {
+      return remoteAddress;
+   }
+
+   public String getRemoteAddressPrefix() {
+      return remoteAddressPrefix;
+   }
+
+   public String getRemoteAddressSuffix() {
+      return remoteAddressSuffix;
+   }
+
+   public Collection<Symbol> getRemoteTerminusCapabilities() {
+      return remoteTerminusCapabilities;
+   }
+
+   public TransformerConfiguration getTransformerConfiguration() {
+      return transformerConfig;
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicyManager.java
@@ -1,0 +1,254 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Objects;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.qpid.proton.engine.Session;
+
+/**
+ * Base API for a bridged resource policy manager.
+ */
+public abstract class AMQPBridgePolicyManager {
+
+   public enum State {
+      UNINITIALIZED,
+      STOPPED,
+      STARTED,
+      SHUTDOWN
+   }
+
+   protected final AMQPBridgeMetrics metrics;
+   protected final ActiveMQServer server;
+   protected final AMQPBridgeManager bridge;
+   protected final String policyName;
+   protected final AMQPBridgeType policyType;
+
+   protected volatile State state = State.UNINITIALIZED;
+   protected boolean connected;
+   protected AMQPSessionContext session;
+
+   public AMQPBridgePolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metrics, String policyName, AMQPBridgeType policyType) {
+      Objects.requireNonNull(bridge, "The bridge manager instance cannot be null");
+
+      this.bridge = bridge;
+      this.server = bridge.getServer();
+      this.policyName = policyName;
+      this.policyType = policyType;
+      this.metrics = metrics;
+   }
+
+   /**
+    * {@return <code>true</code> if the policy is started at the time this method was called}
+    */
+   public final boolean isStarted() {
+      return state == State.STARTED;
+   }
+
+   /**
+    * Returns if the policy manager has been marked as connected to the remote peer. This method
+    * must be called under lock to ensure the returned state is accurate.
+    *
+    * @return the state of the connected flag based on the last update from the connection APIs
+    */
+   protected final boolean isConnected() {
+      return connected;
+   }
+
+   /**
+    * {@return the {@link AMQPBridgeManager} that owns this send to policy manager}
+    */
+   public AMQPBridgeManager getBridgeManager() {
+      return bridge;
+   }
+
+   /**
+    * {@return the metrics instance tied to this bridge policy manager instance}
+    */
+   public AMQPBridgeMetrics getMetrics() {
+      return metrics;
+   }
+
+   /**
+    * {@return the {@link AMQPBridgePolicy} that configured this policy manager}
+    */
+   public abstract AMQPBridgePolicy getPolicy();
+
+   /**
+    * {@return the bridge type this policy manager implements}
+    */
+   public final AMQPBridgeType getPolicyType() {
+      return policyType;
+   }
+
+   /**
+    * {@return the assigned name of the policy that is being managed}
+    */
+   public final String getPolicyName() {
+      return policyName;
+   }
+
+   /**
+    * Initialize the bridge policy manager creating any resource needed and
+    * registering any services offered.
+    */
+   public final synchronized void initialize() {
+      failIfShutdown();
+
+      if (state.ordinal() < State.STOPPED.ordinal()) {
+         state = State.STOPPED;
+         handleManagerInitialized();
+      }
+   }
+
+   /**
+    * Start the bridge policy manager which will initiate a scan of all broker bindings and
+    * create and matching remote senders or receivers. Start on a policy manager should only be
+    * called after its parent {@link AMQPBridgeManager} is started and the bridge connection
+    * has been established.
+    */
+   public final synchronized void start() {
+      if (!bridge.isStarted()) {
+         throw new IllegalStateException("Cannot start a bridge policy manager when the bridge manager is stopped.");
+      }
+
+      if (state == State.UNINITIALIZED) {
+         throw new IllegalStateException("Bridge policy manager has not been initialized");
+      }
+
+      failIfShutdown();
+
+      if (state.ordinal() < State.STARTED.ordinal()) {
+         state = State.STARTED;
+         handleManagerStarted();
+      }
+   }
+
+   /**
+    * Stops the bridge policy manager which will close any open remote senders or receivers that
+    * are active for local queue demand. Stop should generally be called whenever the parent
+    * {@link AMQPBridgeManager} loses its connection to the remote.
+    */
+   public final synchronized void stop() {
+      if (state == State.UNINITIALIZED) {
+         throw new IllegalStateException("Bridge policy manager has not been initialized");
+      }
+
+      if (state == State.STARTED) {
+         state = State.STOPPED;
+         handleManagerStopped();
+      }
+   }
+
+   /**
+    * Shutdown the manager and cleanup any in use resources.
+    */
+   public final synchronized void shutdown() {
+      if (state.ordinal() < State.SHUTDOWN.ordinal()) {
+         state = State.SHUTDOWN;
+         handleManagerShutdown();
+      }
+   }
+
+   /**
+    * Called by the parent AMQP bridge manager when the connection has failed and this AMQP policy
+    * manager should tear down any active resources and await a reconnect if one is allowed.
+    */
+   public final synchronized void connectionInterrupted() {
+      connected = false;
+      handleConnectionInterrupted();
+   }
+
+   /**
+    * Called by the parent AMQP bridge manager when the connection has been established and this
+    * AMQP policy manager should build up its active state based on the configuration. If not
+    * started when a connection is established the policy manager services should remain stopped.
+    *
+    * @param session
+    *    The new {@link Session} that was created for use by broker connection resources.
+    * @param configuration
+    *    The bridge configuration that hold state relative to the new active connection.
+    */
+   public final synchronized void connectionRestored(AMQPSessionContext session, AMQPBridgeConfiguration configuration) {
+      this.connected = true;
+      this.session = session;
+
+      handleConnectionRestored(configuration);
+   }
+
+   /**
+    * Checks if shut down already and throws an {@link IllegalStateException} if so.
+    */
+   protected final void failIfShutdown() throws IllegalStateException {
+      if (state == State.SHUTDOWN) {
+         throw new IllegalStateException("The bridge policy manager has already been shutdown");
+      }
+   }
+
+   /**
+    * Returns <code>true</code> if the policy manager is both started and marked as connected to
+    * the remote peer. This method must always be called under lock to ensure the state returned
+    * is accurate.
+    *
+    * @return <code>true</code> if the manager is both started and the connected state is <code>true</code>
+    */
+   protected final boolean isActive() {
+      return connected && state == State.STARTED;
+   }
+
+   /**
+    * On initialize a bridge policy manager needs to perform any specific initialization actions
+    * it requires to begin tracking broker resources.
+    */
+   protected abstract void handleManagerInitialized();
+
+   /**
+    * On start a bridge policy manager needs to perform any specific startup actions
+    * it requires to begin tracking broker resources.
+    */
+   protected abstract void handleManagerStarted();
+
+   /**
+    * On stop a bridge policy manager needs to perform any specific stopped actions
+    * it requires to cease tracking broker resources and cleanup.
+    */
+   protected abstract void handleManagerStopped();
+
+   /**
+    * On shutdown a bridge policy manager needs to perform any specific shutdown actions
+    * it requires to cease tracking broker resources.
+    */
+   protected abstract void handleManagerShutdown();
+
+   /**
+    * On connection interrupted a bridge policy manager needs to perform any specific
+    * actions to pause of cleanup current resources based on the connection being closed.
+    */
+   protected abstract void handleConnectionInterrupted();
+
+   /**
+    * On connection restoration a bridge policy manager needs to perform any specific
+    * actions to resume service based on a new connection having been established.
+    *
+    * @param configuration
+    *    The bridge configuration relative to the currently established connection.
+    */
+   protected abstract void handleConnectionRestored(AMQPBridgeConfiguration configuration);
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicyManagerControl.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicyManagerControl.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import org.apache.activemq.artemis.api.core.management.Attribute;
+
+/**
+ * Management service control interface for an AMQP bridge policy manager instance.
+ */
+public interface AMQPBridgePolicyManagerControl {
+
+   /**
+    * {@return the type of the AMQP bridge policy manager being controlled}
+    */
+   @Attribute(desc = "AMQP bridge policy manager type that backs this control instance.")
+   String getType();
+
+   /**
+    * {@return the configured name the AMQP bridge policy manager being controlled}
+    */
+   @Attribute(desc = "The configured AMQP bridge policy name that backs this control instance.")
+   String getName();
+
+   /**
+    * {@return the number of messages this bridge policy has received from the remote}
+    */
+   @Attribute(desc = "returns the number of messages this bridge policy has received from the remote")
+   long getMessagesReceived();
+
+   /**
+    * {@return the number of messages this bridge policy has sent to the remote}
+    */
+   @Attribute(desc = "returns the number of messages this bridge policy has sent to the remote")
+   long getMessagesSent();
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicyManagerControlType.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgePolicyManagerControlType.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.NotCompliantMBeanException;
+
+import org.apache.activemq.artemis.core.management.impl.AbstractControl;
+import org.apache.activemq.artemis.core.management.impl.MBeanInfoHelper;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+/**
+ * Management service control for an AMQP bridge policy manager instance.
+ */
+public class AMQPBridgePolicyManagerControlType extends AbstractControl implements AMQPBridgePolicyManagerControl {
+
+   private final AMQPBridgePolicyManager policyManager;
+
+   public AMQPBridgePolicyManagerControlType(AMQPBridgePolicyManager policyManager) throws NotCompliantMBeanException {
+      super(AMQPBridgePolicyManagerControl.class, policyManager.getBridgeManager().getServer().getStorageManager());
+
+      this.policyManager = policyManager;
+   }
+
+   @Override
+   public String getType() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getType(policyManager);
+      }
+      clearIO();
+      try {
+         return policyManager.getPolicyType().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getName(policyManager);
+      }
+      clearIO();
+      try {
+         return policyManager.getPolicyName();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getMessagesReceived() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessagesReceived(policyManager);
+      }
+      clearIO();
+      try {
+         return policyManager.getMetrics().getMessagesReceived();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public long getMessagesSent() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessagesSent(policyManager);
+      }
+      clearIO();
+      try {
+         return policyManager.getMetrics().getMessagesSent();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(AMQPBridgePolicyManagerControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(AMQPBridgePolicyManagerControl.class);
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeQueuePolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeQueuePolicy.java
@@ -1,0 +1,140 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.activemq.artemis.core.settings.impl.Match;
+import org.apache.qpid.proton.amqp.Symbol;
+
+public final class AMQPBridgeQueuePolicy extends AMQPBridgePolicy implements BiPredicate<String, String> {
+
+   private final Set<QueueMatcher> includeMatchers = new LinkedHashSet<>();
+   private final Set<QueueMatcher> excludeMatchers = new LinkedHashSet<>();
+
+   private final Collection<Map.Entry<String, String>> includes;
+   private final Collection<Map.Entry<String, String>> excludes;
+
+   private final int priorityAdjustment;
+
+   public AMQPBridgeQueuePolicy(String policyName, Integer priority, int priorityAdjustment,
+                                String filter, String remoteAddress, String remoteAddressPrefix, String remoteAddressSuffix,
+                                Collection<Symbol> remoteTerminusCapabilities,
+                                Collection<Map.Entry<String, String>> includeQueues,
+                                Collection<Map.Entry<String, String>> excludeQueues,
+                                Map<String, Object> properties,
+                                TransformerConfiguration transformerConfig,
+                                WildcardConfiguration wildcardConfig) {
+      super(policyName, priority, filter, remoteAddress, remoteAddressPrefix, remoteAddressSuffix,
+            remoteTerminusCapabilities, properties, transformerConfig, wildcardConfig);
+
+      this.priorityAdjustment = priorityAdjustment;
+
+      this.includes = Collections.unmodifiableCollection(includeQueues == null ? Collections.emptyList() : includeQueues);
+      this.excludes = Collections.unmodifiableCollection(excludeQueues == null ? Collections.emptyList() : excludeQueues);
+
+      // Create Matchers from configured includes and excludes for use when matching broker resources
+      includes.forEach((entry) -> includeMatchers.add(new QueueMatcher(entry.getKey(), entry.getValue(), wildcardConfig)));
+      excludes.forEach((entry) -> excludeMatchers.add(new QueueMatcher(entry.getKey(), entry.getValue(), wildcardConfig)));
+   }
+
+   public Collection<Map.Entry<String, String>> getIncludes() {
+      return includes;
+   }
+
+   public Collection<Map.Entry<String, String>> getExcludes() {
+      return excludes;
+   }
+
+   public int getPriorityAdjustment() {
+      return priorityAdjustment;
+   }
+
+   public boolean testQueue(String queue) {
+      for (QueueMatcher matcher : excludeMatchers) {
+         if (matcher.testQueue(queue)) {
+            return false;
+         }
+      }
+
+      for (QueueMatcher matcher : includeMatchers) {
+         if (matcher.testQueue(queue)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   @Override
+   public boolean test(String address, String queue) {
+      for (QueueMatcher matcher : excludeMatchers) {
+         if (matcher.test(address, queue)) {
+            return false;
+         }
+      }
+
+      for (QueueMatcher matcher : includeMatchers) {
+         if (matcher.test(address, queue)) {
+            return true;
+         }
+      }
+
+      return false;
+   }
+
+   private class QueueMatcher implements BiPredicate<String, String> {
+
+      private final Predicate<String> addressMatch;
+      private final Predicate<String> queueMatch;
+
+      QueueMatcher(String address, String queue, WildcardConfiguration wildcardConfig) {
+         if (address == null || address.isEmpty()) {
+            addressMatch = (target) -> true;
+         } else {
+            addressMatch = new Match<>(address, null, wildcardConfig).getPattern().asPredicate();
+         }
+
+         if (queue == null || queue.isEmpty()) {
+            queueMatch = (target) -> true;
+         } else {
+            queueMatch = new Match<>(queue, null, wildcardConfig).getPattern().asPredicate();
+         }
+      }
+
+      @Override
+      public boolean test(String address, String queue) {
+         return testAddress(address) && testQueue(queue);
+      }
+
+      public boolean testAddress(String address) {
+         return addressMatch.test(address);
+      }
+
+      public boolean testQueue(String queue) {
+         return queueMatch.test(queue);
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiver.java
@@ -1,0 +1,414 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.DETACH_FORCED;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.NOT_FOUND;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.RESOURCE_DELETED;
+
+import java.io.Closeable;
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+import org.apache.activemq.artemis.core.server.transformer.Transformer;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.ReceiverMetrics;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeReceiverInfo.ReceiverRole;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonAbstractReceiver;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.amqp.messaging.Modified;
+import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
+import org.apache.qpid.proton.amqp.transport.Detach;
+import org.apache.qpid.proton.engine.Link;
+import org.apache.qpid.proton.engine.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base implementation for AMQP Bridge receiver implementations
+ */
+public abstract class AMQPBridgeReceiver implements Closeable {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   protected static final Symbol[] OUTCOMES = new Symbol[]{Accepted.DESCRIPTOR_SYMBOL, Rejected.DESCRIPTOR_SYMBOL,
+                                                           Released.DESCRIPTOR_SYMBOL, Modified.DESCRIPTOR_SYMBOL};
+
+   protected static final Modified DEFAULT_OUTCOME;
+   static {
+      DEFAULT_OUTCOME = new Modified();
+      DEFAULT_OUTCOME.setDeliveryFailed(true);
+   }
+
+   // Sequence ID value used to keep links that would otherwise have the same name from overlapping
+   // this generally occurs when a remote link detach is delayed and new demand is added before it
+   // arrives resulting in an unintended link stealing scenario in the proton engine but can also
+   // occur when consumers on the same queue have differing filters.
+   protected static final AtomicLong LINK_SEQUENCE_ID = new AtomicLong();
+
+   protected final AMQPBridgeManager bridgeManager;
+   protected final AMQPBridgeFromPolicyManager policyManager;
+   protected final AMQPBridgeReceiverConfiguration configuration;
+   protected final AMQPBridgeReceiverInfo receiverInfo;
+   protected final AMQPBridgePolicy policy;
+   protected final AMQPConnectionContext connection;
+   protected final AMQPSessionContext session;
+   protected final Transformer transformer;
+   protected final AtomicBoolean closed = new AtomicBoolean();
+   protected final ReceiverMetrics metrics;
+
+   protected ProtonAbstractReceiver receiver;
+   protected Receiver protonReceiver;
+   protected volatile boolean initialized;
+   protected Consumer<AMQPBridgeReceiver> remoteOpenHandler;
+   protected Consumer<AMQPBridgeReceiver> remoteCloseHandler;
+
+   public AMQPBridgeReceiver(AMQPBridgeFromPolicyManager policyManager,
+                             AMQPBridgeReceiverConfiguration configuration,
+                             AMQPSessionContext session,
+                             AMQPBridgeReceiverInfo receiverInfo,
+                             AMQPBridgePolicy policy,
+                             ReceiverMetrics metrics) {
+      this.policyManager = policyManager;
+      this.bridgeManager = policyManager.getBridgeManager();
+      this.receiverInfo = receiverInfo;
+      this.policy = policy;
+      this.connection = session.getAMQPConnectionContext();
+      this.session = session;
+      this.configuration = configuration;
+      this.metrics = metrics;
+
+      final TransformerConfiguration transformerConfiguration = policy.getTransformerConfiguration();
+      if (transformerConfiguration != null) {
+         this.transformer = bridgeManager.getServer().getServiceRegistry().getBridgeTransformer(policy.getPolicyName(), transformerConfiguration);
+      } else {
+         this.transformer = (m) -> m;
+      }
+   }
+
+   /**
+    * {@return the idle timeout value that is used applied to quiesced receivers}
+    */
+   public abstract int getReceiverIdleTimeout();
+
+   /**
+    * }@return <code>true</code> if the receiver has already been closed}
+    */
+   public boolean isClosed() {
+      return closed.get();
+   }
+
+   /**
+    * {@return the type of bridge receiver being represented}
+    */
+   public final ReceiverRole getRole() {
+      return receiverInfo.getRole();
+   }
+
+   /**
+    * {@return the bridge from policy manager that owns this bridge receiver}
+    */
+   public final AMQPBridgeFromPolicyManager getPolicyManager() {
+      return policyManager;
+   }
+
+   /**
+    * {@return the number of messages this consumer has received from the remote during its lifetime}
+    */
+   public final long getMessagesReceived() {
+      return metrics.getMessagesReceived();
+   }
+
+   /**
+    * {@return <code>true</code> if the receiver has previously been initialized}
+    */
+   public final boolean isInitialized() {
+      return initialized;
+   }
+
+   /**
+    * Called to initialize the AMQP bridge receiver which will trigger an asynchronous
+    * task to attach the link and handle all setup receiver and eventually start the flow
+    * of credit to the remote. This method should be called once after the basic configuration
+    * of the receiver is complete and should not be called again after that.
+    */
+   public void initialize() {
+      if (initialized) {
+         throw new IllegalStateException("A receiver should only be initialized once");
+      }
+
+      initialized = true;
+      connection.runLater(this::doCreateReceiver);
+   }
+
+   /**
+    * Called during the initialization of the receiver to trigger an asynchronous link
+    * attach of the underlying AMQP receiver that backs this bridgeManager receiver. The new
+    * receiver should be initialized in a started state. This method executes on the
+    * connection thread and should not block. This method will be called from the thread
+    * of the connection this receiver operates on.
+    */
+   protected abstract void doCreateReceiver();
+
+   /**
+    * Asynchronously starts a previously stopped bridgeManager receiver which should trigger a grant
+    * of credit to the remote thereby allowing new incoming messages to be bridged. In general
+    * the start should only happen when the receiver is known to be stopped but given the asynchronous
+    * nature of the receiver handling this won't always be the case, below the outcomes of various
+    * cases that could result from calls to this method. The completion methods are always called
+    * from a different thread than this method is called in which means the caller should ensure
+    * that the handling accounts for thread safety of those methods.
+    * <p>
+    * Calling start on an already closed receiver should immediately throw an {@link IllegalStateException}.
+    * Calling start on an non-initialized receiver should immediately throw an {@link IllegalStateException}.
+    * <p>
+    * Calling start on a stopped receiver should start the receiver and signal success to the completion.
+    * Calling start on an already started receiver should simply signal success to the completion.
+    * Calling start on a stopping receiver should fail the completion with an {@link IllegalStateException}.
+    * Calling start on a receiver that closes while the start is in-flight should fail the completion
+    * with an {@link IllegalStateException}
+    *
+    * @param completion
+    *       A {@link AMQPBridgeAsyncCompletion} that will be notified when the stop request succeeds or fails.
+    */
+   public final void startAsync(AMQPBridgeAsyncCompletion<AMQPBridgeReceiver> completion) {
+      Objects.requireNonNull(completion, "The asynchronous completion object cannot be null");
+
+      if (closed.get()) {
+         throw new IllegalStateException("The receiver has already been closed.");
+      }
+
+      if (!initialized) {
+         throw new IllegalStateException("A receiver must be initialized before a start call");
+      }
+
+      connection.runLater(() -> {
+         try {
+            if (receiver == null) {
+               throw new IllegalStateException("The receiver was either not initialized or the receiver create failed");
+            }
+
+            receiver.start();
+            completion.onComplete(this);
+         } catch (Exception error) {
+            completion.onException(this, error);
+         }
+
+         connection.flush();
+      });
+   }
+
+   /**
+    * Stops message consumption on this receiver instance but leaves the receiver in
+    * a state where it could be restarted by a call to {@link #startAsync(AMQPBridgeAsyncCompletion)}
+    * once the receiver enters the stopped state.
+    * <p>
+    * Since the request to stop can take time to complete and this method cannot block
+    * a completion must be provided by the caller that will respond when the receiver
+    * has fully come to rest and all pending work is complete. Before the stopped
+    * completion is signaled the state of the underlying receiver will be stopping and
+    * attempt to restart it should fail until the stopped state has been reached.
+    * <p>
+    * The supplied {@link AMQPBridgeAsyncCompletion} will be completed successfully
+    * once the underling AMQP receiver has drained and pending work is completed. If the
+    * stop does not complete by the supplied timeout the completion will be signaled that
+    * a failure has occurred with a {@link TimeoutException}. The completion methods are
+    * always called from a different thread than this method is called in which means the
+    * caller should ensure that the handling accounts for thread safety of those methods.
+    *
+    * @param completion
+    *       A {@link AMQPBridgeAsyncCompletion} that will be notified when the stop request succeeds or fails.
+    */
+   public final void stopAsync(AMQPBridgeAsyncCompletion<AMQPBridgeReceiver> completion) {
+      Objects.requireNonNull(completion, "The asynchronous completion object cannot be null");
+
+      if (!initialized) {
+         throw new IllegalStateException("A receiver must be initialized before a stop call");
+      }
+
+      connection.runLater(() -> {
+         try {
+            if (receiver == null) {
+               throw new IllegalStateException("The receiver was either not yet initialized or the receiver create failed");
+            }
+
+            receiver.stop(configuration.getReceiverQuiesceTimeout(), (rcvr, stopped) -> {
+               try {
+                  if (stopped) {
+                     completion.onComplete(this);
+                  } else {
+                     completion.onException(this, new TimeoutException("Timed out waiting for the AMQP link to stop"));
+                  }
+               } catch (Exception ex) {
+                  logger.trace("Caught error running provided completion callback: ", ex);
+               }
+            });
+         } catch (Exception error) {
+            completion.onException(this, error);
+         }
+
+         connection.flush();
+      });
+   }
+
+   /**
+    * Close the bridgeManager receiver instance and cleans up its resources. This method
+    * should not block and the actual resource shutdown work should occur asynchronously
+    * however the closed state should be indicated immediately and any further attempts
+    * start the consumer should result in an exception being thrown.
+    */
+   @Override
+   public final void close() {
+      if (closed.compareAndSet(false, true)) {
+         connection.runLater(() -> {
+            bridgeManager.removeLinkClosedInterceptor(receiverInfo.getId());
+
+            if (receiver != null) {
+               try {
+                  receiver.close(false);
+               } catch (ActiveMQAMQPException e) {
+               } finally {
+                  receiver = null;
+               }
+            }
+
+            // Need to track the proton receiver and close it here as the default
+            // context implementation doesn't do that and could result in no detach
+            // being sent in some cases and possible resources leaks.
+            if (protonReceiver != null) {
+               try {
+                  protonReceiver.close();
+               } finally {
+                  protonReceiver = null;
+               }
+            }
+
+            connection.flush();
+         });
+      }
+   }
+
+   /**
+    * (@return the policy that this sender was configured to use)
+    */
+   public final AMQPBridgePolicy getPolicy() {
+      return policy;
+   }
+
+   /**
+    * (@return the {@link AMQPBridgeManager} that this receiver operates under)
+    */
+   public final AMQPBridgeManager getBridgeManager() {
+      return bridgeManager;
+   }
+
+   /**
+    * {@return an information object that defines the characteristics of the {@link AMQPBridgeReceiver}}
+    */
+   public final AMQPBridgeReceiverInfo getReceiverInfo() {
+      return receiverInfo;
+   }
+
+   /**
+    * Provides and event point for notification of the receiver having been opened successfully
+    * by the remote. This handler will not be called if the remote rejects the link attach and
+    * a {@link Detach} is expected to follow.
+    *
+    * @param handler
+    *    The handler that will be invoked when the remote opens this receiver.
+    *
+    * @return this receiver instance.
+    */
+   public final AMQPBridgeReceiver setRemoteOpenHandler(Consumer<AMQPBridgeReceiver> handler) {
+      if (protonReceiver != null) {
+         throw new IllegalStateException("Cannot set a remote open handler after the bridgeManager receiver is started");
+      }
+
+      this.remoteOpenHandler = handler;
+      return this;
+   }
+
+   /**
+    * Provides and event point for notification of the receiver having been closed by
+    * the remote.
+    *
+    * @param handler
+    *    The handler that will be invoked when the remote closes this receiver.
+    *
+    * @return this receiver instance.
+    */
+   public final AMQPBridgeReceiver setRemoteClosedHandler(Consumer<AMQPBridgeReceiver> handler) {
+      if (protonReceiver != null) {
+         throw new IllegalStateException("Cannot set a remote close handler after the bridgeManager receiver is started");
+      }
+
+      this.remoteCloseHandler = handler;
+      return this;
+   }
+
+   /**
+    * Called from a subclass upon handling an incoming message from the remote.
+    *
+    * @param message
+    *    The original message that arrived from the remote.
+    */
+   protected final void recordMessageReceived(Message message) {
+      metrics.incrementMessagesReceived();
+   }
+
+   protected final Symbol[] getRemoteTerminusCapabilities() {
+      if (policy.getRemoteTerminusCapabilities() != null && !policy.getRemoteTerminusCapabilities().isEmpty()) {
+         return policy.getRemoteTerminusCapabilities().toArray(new Symbol[0]);
+      } else {
+         return null;
+      }
+   }
+
+   protected final boolean remoteLinkClosedInterceptor(Link link) {
+      if (link == protonReceiver && link.getRemoteCondition() != null && link.getRemoteCondition().getCondition() != null) {
+         final Symbol errorCondition = link.getRemoteCondition().getCondition();
+
+         // Cases where remote link close is not considered terminal, additional checks
+         // should be added as needed for cases where the remote has closed the link either
+         // during the attach or at some point later.
+
+         if (RESOURCE_DELETED.equals(errorCondition)) {
+            // Remote side manually deleted this queue.
+            return true;
+         } else if (NOT_FOUND.equals(errorCondition)) {
+            // Remote did not have a queue that matched.
+            return true;
+         } else if (DETACH_FORCED.equals(errorCondition)) {
+            // Remote operator forced the link to detach.
+            return true;
+         }
+      }
+
+      return false;
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverConfiguration.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LARGE_MESSAGE_THRESHOLD;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_PRIORITY;
+import java.util.Map;
+
+/**
+ * Configuration options applied to a receiver created from bridge from policies for
+ * address or queue bridging. The options first check the policy properties for
+ * matching configuration settings before looking at the bridgeManager's own configuration
+ * for the options managed here.
+ */
+public final class AMQPBridgeReceiverConfiguration extends AMQPBridgeLinkConfiguration {
+
+   public AMQPBridgeReceiverConfiguration(AMQPBridgeConfiguration configuration, Map<String, ?> properties) {
+      super(configuration, properties);
+   }
+
+   /**
+    * {@return the credit batch size offered to a Receiver link}
+    */
+   public int getReceiverCredits() {
+      final Object property = properties.get(RECEIVER_CREDITS);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getReceiverCredits();
+      }
+   }
+
+   /**
+    * {@return the number of remaining credits on a Receiver before the batch is replenished}
+    */
+   public int getReceiverCreditsLow() {
+      final Object property = properties.get(RECEIVER_CREDITS_LOW);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getReceiverCreditsLow();
+      }
+   }
+
+   /**
+    * {@return the credit batch size offered to a Receiver link that is in pull mode}
+    */
+   public int getPullReceiverBatchSize() {
+      final Object property = properties.get(PULL_RECEIVER_BATCH_SIZE);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getPullReceiverBatchSize();
+      }
+   }
+
+   /**
+    * {@return the configured receiver quiesce timeout before the operation is assumed to have failed}
+    */
+   public int getReceiverQuiesceTimeout() {
+      final Object property = properties.get(RECEIVER_QUIESCE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return configuration.getReceiverQuiesceTimeout();
+      }
+   }
+
+   /**
+    * {@return the idle timeout for a drained bridge address receiver before it is closed}
+    */
+   public int getAddressReceiverIdleTimeout() {
+      final Object property = properties.get(ADDRESS_RECEIVER_IDLE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return configuration.getAddressReceiverIdleTimeout();
+      }
+   }
+
+   /**
+    * {@return the idle timeout for a drained bridge queue receiver before it is closed}
+    */
+   public int getQueueReceiverIdleTimeout() {
+      final Object property = properties.get(QUEUE_RECEIVER_IDLE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return configuration.getQueueReceiverIdleTimeout();
+      }
+   }
+
+   /**
+    * {@return the size in bytes of an incoming message after which the Receiver treats it as large}
+    */
+   public int getLargeMessageThreshold() {
+      final Object property = properties.get(LARGE_MESSAGE_THRESHOLD);
+      if (property instanceof Number) {
+         return ((Number) property).intValue();
+      } else if (property instanceof String) {
+         return Integer.parseInt((String) property);
+      } else {
+         return configuration.getLargeMessageThreshold();
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if the bridgeManager is configured to ignore filters on individual queue consumers}
+    */
+   public boolean isIgnoreSubscriptionFilters() {
+      final Object property = properties.get(IGNORE_QUEUE_CONSUMER_FILTERS);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return configuration.isIgnoreSubscriptionFilters();
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if the bridgeManager is configured to ignore filters on the bridged Queue}
+    */
+   public boolean isIgnoreQueueFilters() {
+      final Object property = properties.get(IGNORE_QUEUE_FILTERS);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return configuration.isIgnoreQueueFilters();
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if bridgeManager is configured to omit any priority properties on receiver links}
+    */
+   public boolean isReceiverPriorityDisabled() {
+      final Object property = properties.get(DISABLE_RECEIVER_PRIORITY);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return configuration.isReceiverPriorityDisabled();
+      }
+   }
+
+   /**
+    * {@return <code>true</code> if bridgeManager is configured to ignore local demand and always create a receiver}
+    */
+   public boolean isReceiverDemandTrackingDisabled() {
+      final Object property = properties.get(DISABLE_RECEIVER_DEMAND_TRACKING);
+      if (property instanceof Boolean) {
+         return (Boolean) property;
+      } else if (property instanceof String) {
+         return Boolean.parseBoolean((String) property);
+      } else {
+         return configuration.isReceiverDemandTrackingDisabled();
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverControl.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverControl.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import org.apache.activemq.artemis.api.core.management.Attribute;
+
+/**
+ * Management interface that is backed by an active bridge receiver
+ * that was created when demand was applied to a matching address or queue.
+ */
+public interface AMQPBridgeReceiverControl {
+
+   /**
+    * {@return the number of messages this bridge receiver has received from the remote}
+    */
+   @Attribute(desc = "returns the number of messages this bridge receiver has received from the remote")
+   long getMessagesReceived();
+
+   /**
+    * {@return the type of bridge receiver being represented}
+    */
+   @Attribute(desc = "AMQP bridge receiver type (address or queue) that backs this instance.")
+   String getRole();
+
+   /**
+    * Gets the queue name that will be used for this bridge receiver instance.
+    *
+    * For Queue bridge this will be the name of the queue whose messages are
+    * being bridged to this server instance. For an Address bridge this will
+    * be an automatically generated name that should be unique to a given bridge
+    * instance
+    *
+    * @return the queue name associated with the bridge receiver
+    */
+   @Attribute(desc = "the queue name associated with the bridge receiver.")
+   String getQueueName();
+
+   /**
+    * Gets the address that will be used for this bridge receiver instance.
+    *
+    * For Queue bridge this is the address under which the matching queue must
+    * reside. For Address bridge this is the actual address whose messages are
+    * being bridged.
+    *
+    * @return the address associated with this bridge receiver.
+    */
+   @Attribute(desc = "the address name associated with the bridge receiver.")
+   String getAddress();
+
+   /**
+    * Gets the FQQN that comprises the address and queue where the remote receiver
+    * will be attached.
+    *
+    * @return provides the FQQN that can be used to address the receiver queue directly.
+    */
+   @Attribute(desc = "the FQQN associated with the bridge receiver.")
+   String getFqqn();
+
+   /**
+    * Gets the routing type that will be requested when creating a receiver on the
+    * remote server.
+    *
+    * @return the routing type of the remote receiver.
+    */
+   @Attribute(desc = "the Routing Type associated with the bridge receiver.")
+   String getRoutingType();
+
+   /**
+    * Gets the filter string that will be used when creating the remote receiver.
+    * <p>
+    * For a queue bridge the filter is selected from configuration if one was set or
+    * if the consumer that generated to demand that creates the bridge carries a filter
+    * that value is chosen, otherwise any filter that is set on the bridged queue is
+    * chosen.
+    * <p>
+    * For an address bridge the filter only exists if one was set in the bridge from address
+    * policy configuration.
+    *
+    * @return the filter string in use for the bridge receiver.
+    */
+   @Attribute(desc = "the filter string associated with the bridge receiver.")
+   String getFilterString();
+
+   /**
+    * Gets the priority value that will be requested for the remote receiver that is
+    * created.
+    *
+    * @return the assigned receiver priority for the bridge receiver.
+    */
+   @Attribute(desc = "the assigned priority of the bridge receiver.")
+   int getPriority();
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverControlType.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverControlType.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.List;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.NotCompliantMBeanException;
+
+import org.apache.activemq.artemis.core.management.impl.AbstractControl;
+import org.apache.activemq.artemis.core.management.impl.MBeanInfoHelper;
+import org.apache.activemq.artemis.logs.AuditLogger;
+
+/**
+ * Management object used for AMQP bridge address and queue receivers to expose receiver state.
+ */
+public class AMQPBridgeReceiverControlType extends AbstractControl implements AMQPBridgeReceiverControl {
+
+   private final AMQPBridgeReceiver receiver;
+   private final AMQPBridgeReceiverInfo receiverInfo;
+
+   public AMQPBridgeReceiverControlType(AMQPBridgeReceiver receiver) throws NotCompliantMBeanException {
+      super(AMQPBridgeReceiverControl.class, receiver.getBridgeManager().getServer().getStorageManager());
+
+      this.receiver = receiver;
+      this.receiverInfo = receiver.getReceiverInfo();
+   }
+
+   @Override
+   public long getMessagesReceived() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessagesReceived(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiver.getMessagesReceived();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getRole() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRole(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiverInfo.getRole().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getQueueName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getQueueName(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiverInfo.getLocalQueue();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getAddress() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAddress(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiverInfo.getLocalAddress();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getFqqn() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFqqn(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiverInfo.getLocalFqqn();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getRoutingType() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRoutingType(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiverInfo.getRoutingType().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getFilterString() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFilterString(receiverInfo);
+      }
+      clearIO();
+      try {
+         return receiverInfo.getFilterString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public int getPriority() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getPriority(receiverInfo);
+      }
+      List.of(new Object[] {"one"});
+      clearIO();
+      try {
+         return receiverInfo.getPriority();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(AMQPBridgeReceiverControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(AMQPBridgeReceiverControl.class);
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverInfo.java
@@ -1,0 +1,170 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+
+/**
+ * Information and identification interface for AMQP bridgeManager receivers that will be
+ * created on the remote peer as demand on the local broker is detected. The behavior
+ * and meaning of some APIs in this interface may vary slightly depending on the role
+ * of the receiver (Address or Queue).
+ */
+public class AMQPBridgeReceiverInfo {
+
+   enum ReceiverRole {
+      /**
+       * Receiver created from a match on a configured bridgeManager from address policy.
+       */
+      ADDRESS_RECEIVER,
+
+      /**
+       * Receiver created from a match on a configured bridgeManager from queue policy.
+       */
+      QUEUE_RECEIVER
+   }
+
+   private final ReceiverRole role;
+   private final String localAddress;
+   private final String localQueue;
+   private final String localFqqn;
+   private final String remoteAddress;
+   private final RoutingType routingType;
+   private final String filterString;
+   private final String id;
+   private final Integer priority;
+
+   public AMQPBridgeReceiverInfo(ReceiverRole role, String localAddress, String localQueue, RoutingType routingType,
+                                 String remoteAddress, String filterString, Integer priority) {
+      this.role = role;
+      this.localAddress = localAddress;
+      this.localQueue = localQueue;
+      this.routingType = routingType;
+      if (role == ReceiverRole.QUEUE_RECEIVER) {
+         localFqqn = localAddress + "::" + localQueue;
+      } else {
+         localFqqn = null;
+      }
+      this.remoteAddress = remoteAddress;
+      this.filterString = filterString;
+      this.priority = priority;
+      this.id = UUID.randomUUID().toString();
+   }
+
+   /**
+    * {@return a unique Id for the receiver being represented}
+    */
+   public String getId() {
+      return id;
+   }
+
+   /**
+    * {@return the role assigned to this receiver instance}
+    */
+   public ReceiverRole getRole() {
+      return role;
+   }
+
+   /**
+    * {@return the remote address used to populate the address in the Source address of the AMQP receiver}
+    */
+   public String getRemoteAddress() {
+      return remoteAddress;
+   }
+
+   /**
+    * {@return local address that the remote receiver was created for}
+    */
+   public String getLocalAddress() {
+      return localAddress;
+   }
+
+   /**
+    * {@return the local queue that the remote receiver was created for (null for address receiver)}
+    */
+   public String getLocalQueue() {
+      return localQueue;
+   }
+
+   /**
+    * {@return the local FQQN if describing a Queue receiver otherwise null for an Address receiver}
+    */
+   public String getLocalFqqn() {
+      return localFqqn;
+   }
+
+   /**
+    * {@return the routing type of the local resource this receiver bridges to}
+    */
+   public RoutingType getRoutingType() {
+      return routingType;
+   }
+
+   /**
+    * {@return the filter string that should be set in the remote receiver configuration}
+    */
+   public String getFilterString() {
+      return filterString;
+   }
+
+   /**
+    * {@return the priority value to assign to the remote receiver configuration (null means no priority)}
+    */
+   public Integer getPriority() {
+      return priority;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(filterString, localAddress, localFqqn, localQueue, remoteAddress, role, routingType);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof AMQPBridgeReceiverInfo)) {
+         return false;
+      }
+
+      final AMQPBridgeReceiverInfo other = (AMQPBridgeReceiverInfo) obj;
+
+      return Objects.equals(filterString, other.filterString) &&
+             Objects.equals(localAddress, other.localAddress) &&
+             Objects.equals(localFqqn, other.localFqqn) &&
+             Objects.equals(localQueue, other.localQueue) &&
+             Objects.equals(remoteAddress, other.remoteAddress) &&
+             Objects.equals(role, other.role) &&
+             Objects.equals(routingType, other.routingType);
+   }
+
+   @Override
+   public String toString() {
+      return "AMQPBridgeReceiverInfo: { " + getLocalAddress() + ", " +
+                                            getLocalQueue() + ", " +
+                                            getLocalFqqn() + ", " +
+                                            getRoutingType() + ", " +
+                                            getRole() + ", " +
+                                            getRemoteAddress() + ", " +
+                                            getPriority() + ", " +
+                                            getFilterString() + " }";
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverManager.java
@@ -1,0 +1,544 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.io.Closeable;
+import java.lang.invoke.MethodHandles;
+import java.util.HashSet;
+import java.util.Objects;
+import java.util.Set;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An abstract base for managing bridge receiver instances that holds the demand
+ * currently present for a bridged resource and the receiver that exists to service
+ * that demand. This object manages the state of the receiver and the various stages
+ * it can pass through during its lifetime.
+ *
+ * All interactions with the receiver tracking entry should occur under the lock of
+ * the parent manager instance and this manager will perform any asynchronous work
+ * with a lock held on the parent manager instance.
+ *
+ * @param <E> Type of object stored in the demand tracking map.
+ */
+public abstract class AMQPBridgeReceiverManager<E> {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private enum State {
+      READY,
+      STARTING,
+      STARTED,
+      STOPPING,
+      STOPPED,
+      CLOSED
+   }
+
+   private final AMQPBridgeManager bridgeManager;
+   private final AMQPBridgeFromPolicyManager policyManager;
+   private final AMQPBridgeReceiverConfiguration configuration;
+   private final Set<E> demandTracking = new HashSet<>();
+
+   private boolean forcedDemand;
+   private State state = State.READY;
+   private AMQPBridgeReceiver receiver;
+   private ScheduledFuture<?> pendingIdleTimeout;
+   private AMQPBridgeReceiverRecoveryHandler recoveryHandler;
+
+   /**
+    * Create a new bridge receiver manager instance.
+    *
+    * @param policyManager
+    *    The policy manager that created this instance.
+    * @param configuration
+    *    The configuration that was in force when the manager was created.
+    */
+   public AMQPBridgeReceiverManager(AMQPBridgeFromPolicyManager policyManager, AMQPBridgeReceiverConfiguration configuration) {
+      this.policyManager = policyManager;
+      this.configuration = configuration;
+      this.bridgeManager = policyManager.getBridgeManager();
+   }
+
+   /**
+    * Creates a new bridge receiver that this manager will monitor and maintain. The returned
+    * receiver should be in an initial state ready for this manager to initialize once it is fully
+    * configured.
+    *
+    * @return a newly create {@link AMQPBridgeReceiver} for use by this manager.
+    */
+   protected abstract AMQPBridgeReceiver createBridgeReceiver();
+
+   /**
+    * An event point that a subclass can use to perform an initialization action whenever an entry is added to
+    * demand tracking.
+    *
+    * @param entry The entry that is being added to demand tracking.
+    */
+   protected abstract void whenDemandTrackingEntryAdded(E entry);
+
+   /**
+    * An event point that a subclass can use to perform a cleanup action whenever an entry is removed from
+    * demand tracking.
+    *
+    * @param entry The entry that is being removed from demand tracking.
+    */
+   protected abstract void whenDemandTrackingEntryRemoved(E entry);
+
+   /**
+    * An orderly shutdown of the bridge receiver which will perform a drain
+    * of link credit before closing the receiver to ensure that all in-flight
+    * messages and dispositions are processed before the link is detached.
+    *
+    * The bridge manager should be calling this method with its lock held.
+    */
+   public void shutdown() {
+      handleShutdown(true);
+   }
+
+   /**
+    * An immediate close of the bridge receiver which does not drain link credit
+    * or wait for any pending operations to complete.
+    *
+    * The bridge manager should be calling this method with its lock held.
+    */
+   public void shutdownNow() {
+      handleShutdown(false);
+   }
+
+   private void handleShutdown(boolean stopFirst) {
+      if (state != State.CLOSED) {
+         state = State.CLOSED;
+
+         try {
+            if (receiver == null) {
+               return;
+            } else if (stopFirst && state != State.STOPPED) {
+               tryStopBridgeReceiver();
+            } else {
+               safeCloseCurrentBridgeReceiver();
+            }
+         } finally {
+            receiver = null;
+
+            demandTracking.forEach(entry -> {
+               try {
+                  whenDemandTrackingEntryRemoved(entry);
+               } catch (Exception ignore) {
+               }
+            });
+            demandTracking.clear();
+
+            // Stop handler in closed state won't schedule idle timeout, ensure
+            // any pending task is canceled just for proper cleanup purposes.
+            if (pendingIdleTimeout != null) {
+               pendingIdleTimeout.cancel(false);
+               pendingIdleTimeout = null;
+            }
+
+            closeRecoveryHandler();
+         }
+      }
+   }
+
+   /**
+    * Forces demand for this manager instance meaning that a consumer will be maintained until
+    * the manager is shutdown.
+    */
+   public void forceDemand() {
+      if (!forcedDemand) {
+         forcedDemand = true;
+
+         // This will create a new receiver only if there isn't one currently assigned to this
+         // entry. An already stopping receiver will check on stop if it should restart.
+         if (state == State.STOPPED) {
+            tryRestartBridgeReceiver();
+         } else if (state == State.READY) {
+            tryCreateBridgeReceiver();
+         }
+      }
+   }
+
+   /**
+    * Add new demand to the receiver manager which creates or sustains the receiver lifetime
+    * that this manager maintains. When the first element of demand is added a new receiver
+    * is attached and when the last unit of demand is removed the receiver will be closed.
+    *
+    * The bridge manager should be calling this method with its lock held.
+    *
+    * @param demand
+    *    A new unit of demand to add to this receiver manager.
+    */
+   public void addDemand(E demand) {
+      checkClosed();
+
+      if (demandTracking.add(demand)) {
+         whenDemandTrackingEntryAdded(demand);
+      }
+
+      // This will create a new receiver only if there isn't one currently assigned to this
+      // entry. An already stopping receiver will check on stop if it should restart.
+      if (state == State.STOPPED) {
+         tryRestartBridgeReceiver();
+      } else if (state == State.READY) {
+         tryCreateBridgeReceiver();
+      }
+   }
+
+   /**
+    * Remove the given element from the tracked receiver demand. If the tracked demand reaches
+    * zero then the managed receiver should be closed and the manager awaits future demand to
+    * be added. The manager can opt to hold a stopped receiver open for some period of time to
+    * avoid spurious open and closes as demand is added and removed.
+    *
+    * The bridge manager should be calling this method with its lock held.
+    *
+    * @param demand
+    *    The element of demand that should be removed from tracking.
+    */
+   public void removeDemand(E demand) {
+      checkClosed();
+
+      if (demandTracking.remove(demand)) {
+         whenDemandTrackingEntryRemoved(demand);
+      }
+
+      if (hasDemand() || state == State.READY) {
+         return;
+      } else if (state != State.STOPPING) {
+         tryStopBridgeReceiver();
+      }
+   }
+
+   /*
+    * Must be called with locks in place from the parent manager to prevent concurrent
+    * access to state changing APIs.
+    */
+   private void tryCreateBridgeReceiver() {
+      state = State.STARTING;
+      receiver = createBridgeReceiver();
+
+      logger.trace("Bridge receiver manager creating remote receiver for: {}", receiver.getReceiverInfo());
+
+      // For a new receiver the broker will start granting credit after it has been opened.
+      receiver.setRemoteOpenHandler((openedReceiver) -> {
+         synchronized (policyManager) {
+            // Stop or close could have followed quick enough that this didn't get completed yet.
+            if (state == State.STARTING) {
+               state = State.STARTED;
+            }
+
+            closeRecoveryHandler();
+         }
+      });
+
+      // Remote close handling involves closing the active receiver and if demand is still
+      // present and configuration allows for a recovery we schedule handling for that case.
+      // If no recovery is initiated a new receiver will be attempted when the next element
+      // of demand is added.
+      receiver.setRemoteClosedHandler((closedReceiver) -> {
+         synchronized (policyManager) {
+            safeCloseCurrentBridgeReceiver();
+
+            if (hasDemand() && configuration.isLinkRecoveryEnabled() && state == State.READY) {
+               // If the close came from a previous attempt that is itself a recovery we use the
+               // existing recovery handler, otherwise we need to create a new handler to deal
+               // with link recovery and track attempt counts.
+               if (recoveryHandler == null) {
+                  recoveryHandler = new AMQPBridgeReceiverRecoveryHandler(this, configuration);
+               }
+
+               final boolean scheduled = recoveryHandler.tryScheduleNextRecovery(bridgeManager.getScheduler());
+
+               if (!scheduled) {
+                  closeRecoveryHandler();
+               }
+            }
+         }
+      });
+
+      receiver.initialize();
+   }
+
+   /*
+    * Must be called with locks in place from the parent manager to prevent concurrent
+    * access to state changing APIs.
+    */
+   private void tryRestartBridgeReceiver() {
+      state = State.STARTING;
+
+      try {
+         if (pendingIdleTimeout != null) {
+            pendingIdleTimeout.cancel(false);
+            pendingIdleTimeout = null;
+         }
+
+         receiver.startAsync(new AMQPBridgeAsyncCompletion<AMQPBridgeReceiver>() {
+
+            @Override
+            public void onComplete(AMQPBridgeReceiver receiver) {
+               logger.trace("Restarted Bridge receiver after new demand added.");
+               synchronized (policyManager) {
+                  // Check in case the receiver was closed or stopped before we got here
+                  if (state == State.STARTING) {
+                     state = State.STARTED;
+                  }
+               }
+            }
+
+            @Override
+            public void onException(AMQPBridgeReceiver receiver, Exception error) {
+               if (error instanceof IllegalStateException) {
+                  // The receiver might be stopping or it could be closed, either of which
+                  // was initiated from this manager so we can ignore and let those complete.
+                  return;
+               } else {
+                  // This is unexpected and our reaction is to close the receiver since we
+                  // have no idea what its state is now. Later new demand or remote events
+                  // will trigger a new receiver to get added.
+                  logger.trace("Start of bridge receiver {} threw unexpected error, closing receiver: ", receiver, error);
+                  synchronized (policyManager) {
+                     safeCloseCurrentBridgeReceiver();
+                  }
+               }
+            }
+         });
+      } catch (Exception ex) {
+         // The receiver might have been remotely closed, we can't be certain but since we
+         // are responding to demand having been added we will close it and clear the entry
+         // so that the follow on code can try and create a new one.
+         logger.trace("Caught error on attempted restart of existing bridge receiver", ex);
+         safeCloseCurrentBridgeReceiver();
+         if (state == State.READY) {
+            tryCreateBridgeReceiver();
+         }
+      }
+   }
+
+   /*
+    * Must be called with locks in place from the parent manager to prevent concurrent
+    * access to state changing APIs.
+    */
+   private void tryStopBridgeReceiver() {
+      if (receiver != null && state != State.STOPPING) {
+         // Retain closed state if close is attempting a safe shutdown.
+         state = state == State.CLOSED ? State.CLOSED : State.STOPPING;
+
+         receiver.stopAsync(new AMQPBridgeAsyncCompletion<AMQPBridgeReceiver>() {
+
+            @Override
+            public void onComplete(AMQPBridgeReceiver receiver) {
+               logger.trace("Stop of bridge receiver {} succeeded, receiver: ", receiver);
+               synchronized (policyManager) {
+                  handleBridgeReceiverStopped(receiver, true);
+               }
+            }
+
+            @Override
+            public void onException(AMQPBridgeReceiver receiver, Exception error) {
+               logger.trace("Stop of bridge receiver {} failed, closing receiver: ", receiver, error);
+               synchronized (policyManager) {
+                  handleBridgeReceiverStopped(receiver, false);
+               }
+            }
+         });
+      }
+   }
+
+   /*
+    * Must be called with locks in place from the parent manager to prevent concurrent
+    * access to state changing APIs.
+    */
+   private void handleBridgeReceiverStopped(AMQPBridgeReceiver stoppedReceiver, boolean didStop) {
+      // Remote close or local resource remove could have beaten us here and already cleaned up the receiver.
+      if (state == State.STOPPING) {
+         // If the receiver stop times out then we assume something has gone wrong and we force close it
+         // now and then decide below if we should recreate it or not.
+         if (!didStop) {
+            safeCloseCurrentBridgeReceiver();
+         } else {
+            state = State.STOPPED;
+         }
+
+         // Demand may have returned while the receiver was stopping in which case
+         // we either restart an existing stopped receiver or recreate if the stop
+         // timed out and we closed it above. Otherwise we check for an idle timeout
+         // configuration and either schedule the close for later or close it now.
+         if (state == State.READY) {
+            if (hasDemand()) {
+               tryCreateBridgeReceiver();
+            }
+         } else if (state == State.STOPPED) {
+            if (hasDemand()) {
+               tryRestartBridgeReceiver();
+            } else if (receiver.getReceiverIdleTimeout() > 0) {
+               pendingIdleTimeout = bridgeManager.getScheduler().schedule(() -> {
+                  synchronized (policyManager) {
+                     logger.debug("Bridge receiver {} idle timeout reached, closing now", receiver.getReceiverInfo());
+
+                     if (state == State.STOPPED) {
+                        safeCloseCurrentBridgeReceiver();
+                        pendingIdleTimeout = null;
+                     }
+                  }
+               }, receiver.getReceiverIdleTimeout(), TimeUnit.MILLISECONDS);
+            } else {
+               safeCloseCurrentBridgeReceiver();
+            }
+         }
+      } else if (state == State.CLOSED) {
+         safeCloseCurrentBridgeReceiver(stoppedReceiver);
+      }
+   }
+
+   /*
+    * Must lock on the policy manager to ensure that state changes occur in safe conditions.
+    */
+   private void tryRecoverReceiver() {
+      synchronized (policyManager) {
+         // Recovery only needs to occur if we are in the READY state, meaning not stopped or closed
+         // and we still have demand, otherwise we can end recovery operations. The recovery handler
+         // is normally closed out on a successful remote attach response.
+         if (state == State.READY && hasDemand()) {
+            tryCreateBridgeReceiver();
+         } else {
+            closeRecoveryHandler();
+         }
+      }
+   }
+
+   private void safeCloseCurrentBridgeReceiver() {
+      try {
+         safeCloseCurrentBridgeReceiver(receiver);
+      } finally {
+         state = state == State.CLOSED ? State.CLOSED : State.READY;
+         receiver = null;
+
+         if (pendingIdleTimeout != null) {
+            pendingIdleTimeout.cancel(false);
+            pendingIdleTimeout = null;
+         }
+      }
+   }
+
+   private void safeCloseCurrentBridgeReceiver(AMQPBridgeReceiver receiver) {
+      if (receiver != null) {
+         try {
+            if (!receiver.isClosed()) {
+               receiver.close();
+            }
+         } catch (Exception e) {
+            logger.trace("Suppressed error on close of bridge receiver. ", e);
+         }
+      }
+   }
+
+   private boolean hasDemand() {
+      return !demandTracking.isEmpty() || forcedDemand;
+   }
+
+   private void checkClosed() {
+      if (state == State.CLOSED) {
+         throw new IllegalStateException("The bridge receiver has been closed already");
+      }
+   }
+
+   private void closeRecoveryHandler() {
+      if (recoveryHandler != null) {
+         try {
+            recoveryHandler.close();
+         } finally {
+            recoveryHandler = null;
+         }
+      }
+   }
+
+   public static class AMQPBridgeReceiverRecoveryHandler implements Closeable {
+
+      private final AMQPBridgeReceiverManager<?> manager;
+      private final AMQPBridgeLinkConfiguration configuration;
+      private final int maxRecoveryAttempts;
+
+      private final AtomicInteger recoveryAttempts = new AtomicInteger();
+      private final AtomicLong nextRecoveryDelay = new AtomicLong();
+      private volatile ScheduledFuture<?> recoveryFuture;
+
+      public AMQPBridgeReceiverRecoveryHandler(AMQPBridgeReceiverManager<?> manager,
+                                               AMQPBridgeLinkConfiguration configuration) {
+         this.manager = manager;
+         this.configuration = configuration;
+         this.nextRecoveryDelay.set(configuration.getLinkRecoveryInitialDelay() > 0 ? configuration.getLinkRecoveryInitialDelay() : 1);
+         this.maxRecoveryAttempts = configuration.getMaxLinkRecoveryAttempts();
+      }
+
+      @Override
+      public void close() {
+         final ScheduledFuture<?> future = this.recoveryFuture;
+
+         if (future != null) {
+            future.cancel(false);
+         }
+
+         recoveryFuture = null;
+      }
+
+      /**
+       * When a link used by the bridge fails, this method is used to try and schedule a new
+       * connection attempt if the configuration rules allow one. If the configuration does not
+       * allow any (more) reconnection attempts this method returns false.
+       *
+       * @param scheduler
+       *    The scheduler to use to schedule the next connection attempt.
+       *
+       * @return true if an attempt was scheduled or false if no attempts are allowed.
+       */
+      public boolean tryScheduleNextRecovery(ScheduledExecutorService scheduler) {
+         Objects.requireNonNull(scheduler, "The scheduler to use cannot be null");
+
+         if (maxRecoveryAttempts < 0 || recoveryAttempts.get() < maxRecoveryAttempts) {
+            recoveryFuture = scheduler.schedule(this::handleReconnectionAttempt, nextRecoveryDelay.get(), TimeUnit.MILLISECONDS);
+            return true;
+         } else {
+            return false;
+         }
+      }
+
+      private void handleReconnectionAttempt() {
+         final ScheduledFuture<?> future = this.recoveryFuture;
+
+         try {
+            if (future != null && !future.isCancelled()) {
+               if (maxRecoveryAttempts > 0) {
+                  recoveryAttempts.incrementAndGet();
+               }
+
+               // If user configures no delay, we impose a small one just to avoid over saturation to some extent.
+               nextRecoveryDelay.set(configuration.getLinkRecoveryDelay() > 0 ? configuration.getLinkRecoveryDelay() : 1);
+
+               manager.tryRecoverReceiver();
+            }
+         } finally {
+            recoveryFuture = null;
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSender.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSender.java
@@ -1,0 +1,239 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.DETACH_FORCED;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.NOT_FOUND;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.RESOURCE_DELETED;
+
+import java.io.Closeable;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.SenderMetrics;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContext;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.transport.Detach;
+import org.apache.qpid.proton.engine.Link;
+import org.apache.qpid.proton.engine.Sender;
+
+/**
+ * Base implementation for AMQP Bridge sender implementations
+ */
+public abstract class AMQPBridgeSender implements Closeable {
+
+   // Sequence ID value used to keep links that would otherwise have the same name from overlapping
+   // this generally occurs when a remote link detach is delayed and new resources are added before it
+   // arrives resulting in an unintended link stealing scenario in the proton engine.
+   protected static final AtomicLong LINK_SEQUENCE_ID = new AtomicLong();
+
+   protected final AMQPBridgeManager bridgeManager;
+   protected final AMQPBridgeToPolicyManager policyManager;
+   protected final AMQPBridgeSenderConfiguration configuration;
+   protected final AMQPBridgeSenderInfo senderInfo;
+   protected final AMQPBridgePolicy policy;
+   protected final AMQPConnectionContext connection;
+   protected final AMQPSessionContext session;
+   protected final SenderMetrics metrics;
+   protected final AtomicBoolean closed = new AtomicBoolean();
+
+   protected ProtonServerSenderContext senderContext;
+   protected Sender protonSender;
+   protected volatile boolean initialized;
+   protected Consumer<AMQPBridgeSender> remoteOpenHandler;
+   protected Consumer<AMQPBridgeSender> remoteCloseHandler;
+
+   public AMQPBridgeSender(AMQPBridgeToPolicyManager policyManager,
+                           AMQPBridgeSenderConfiguration configuration,
+                           AMQPSessionContext session,
+                           AMQPBridgeSenderInfo senderInfo,
+                           SenderMetrics metrics) {
+      this.policyManager = policyManager;
+      this.bridgeManager = policyManager.getBridgeManager();
+      this.senderInfo = senderInfo;
+      this.policy = policyManager.getPolicy();
+      this.connection = session.getAMQPConnectionContext();
+      this.session = session;
+      this.configuration = configuration;
+      this.metrics = metrics;
+   }
+
+   public boolean isClosed() {
+      return closed.get();
+   }
+
+   /**
+    * {@return <code>true</code> if the receiver has previously been initialized}
+    */
+   public final boolean isInitialized() {
+      return initialized;
+   }
+
+   /**
+    * Called to initialize the AMQP bridge sender which will trigger an asynchronous
+    * task to attach the link and handle all setup sender and eventually start the flow
+    * of credit to the remote. This method should be called once after the basic configuration
+    * of the sender is complete and should not be called again after that.
+    */
+   public void initialize() {
+      if (initialized) {
+         throw new IllegalStateException("A sender should only be initialized once");
+      }
+
+      initialized = true;
+      connection.runLater(this::doCreateSender);
+   }
+
+   /**
+    * Close the AMQP bridge sender instance and cleans up its resources. This method
+    * should not block and the actual resource shutdown work should occur asynchronously.
+    */
+   @Override
+   public final synchronized void close() {
+      if (closed.compareAndSet(false, true)) {
+         connection.runNow(() -> {
+            if (senderContext != null) {
+               try {
+                  senderContext.close(null);
+               } catch (ActiveMQAMQPException e) {
+               } finally {
+                  senderContext = null;
+               }
+            }
+
+            // Need to track the proton senderContext and close it here as the default
+            // context implementation doesn't do that and could result in no detach
+            // being sent in some cases and possible resources leaks.
+            if (protonSender != null) {
+               try {
+                  protonSender.close();
+               } finally {
+                  protonSender = null;
+               }
+            }
+
+            connection.flush();
+         });
+      }
+   }
+
+   /**
+    * {@return the policy that this sender was configured to use}
+    */
+   public AMQPBridgePolicy getPolicy() {
+      return policy;
+   }
+
+   /**
+    * {@return the {@link AMQPBridgeManager} that this sender operates under}
+    */
+   public final AMQPBridgeManager getBridgeManager() {
+      return bridgeManager;
+   }
+
+   /**
+    * {@return the {@link AMQPBridgeToPolicyManager} that this sender operates under}
+    */
+   public AMQPBridgeToPolicyManager getPolicyManager() {
+      return policyManager;
+   }
+
+   /**
+    * {@return an information object that defines the characteristics of the {@link AMQPBridgeSender}}
+    */
+   public final AMQPBridgeSenderInfo getSenderInfo() {
+      return senderInfo;
+   }
+
+   /**
+    * Provides and event point for notification of the sender having been opened successfully
+    * by the remote. This handler will not be called if the remote rejects the link attach and
+    * a {@link Detach} is expected to follow.
+    *
+    * @param handler
+    *    The handler that will be invoked when the remote opens this sender.
+    *
+    * @return this sender instance.
+    */
+   public final AMQPBridgeSender setRemoteOpenHandler(Consumer<AMQPBridgeSender> handler) {
+      if (initialized) {
+         throw new IllegalStateException("Cannot set a remote open handler after the senderContext is initialized");
+      }
+
+      this.remoteCloseHandler = handler;
+      return this;
+   }
+
+   /**
+    * Provides and event point for notification of the sender having been closed by
+    * the remote.
+    *
+    * @param handler
+    *    The handler that will be invoked when the remote closes this sender.
+    *
+    * @return this sender instance.
+    */
+   public final AMQPBridgeSender setRemoteClosedHandler(Consumer<AMQPBridgeSender> handler) {
+      if (initialized) {
+         throw new IllegalStateException("Cannot set a remote close handler after the senderContext is initialized");
+      }
+
+      this.remoteCloseHandler = handler;
+      return this;
+   }
+
+   /**
+    * Handles the create of the actual AMQP sender link on the connection thread.
+    */
+   protected abstract void doCreateSender();
+
+   protected final Symbol[] getRemoteTerminusCapabilities() {
+      if (policy.getRemoteTerminusCapabilities() != null && !policy.getRemoteTerminusCapabilities().isEmpty()) {
+         return policy.getRemoteTerminusCapabilities().toArray(new Symbol[0]);
+      } else {
+         return null;
+      }
+   }
+
+   protected final boolean remoteLinkClosedInterceptor(Link link) {
+      if (link == protonSender && link.getRemoteCondition() != null && link.getRemoteCondition().getCondition() != null) {
+         final Symbol errorCondition = link.getRemoteCondition().getCondition();
+
+         // Cases where remote link close is not considered terminal, additional checks
+         // should be added as needed for cases where the remote has closed the link either
+         // during the attach or at some point later.
+
+         if (RESOURCE_DELETED.equals(errorCondition)) {
+            // Remote side manually deleted this queue.
+            return true;
+         } else if (NOT_FOUND.equals(errorCondition)) {
+            // Remote did not have a queue that matched.
+            return true;
+         } else if (DETACH_FORCED.equals(errorCondition)) {
+            // Remote operator forced the link to detach.
+            return true;
+         }
+      }
+
+      return false;
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderConfiguration.java
@@ -1,0 +1,33 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Map;
+
+/**
+ * Configuration options applied to a sender created from bridge from policies for
+ * address or queue bridging. The options first check the policy properties for
+ * matching configuration settings before looking at the bridge's own configuration
+ * for the options managed here.
+ */
+public final class AMQPBridgeSenderConfiguration extends AMQPBridgeLinkConfiguration {
+
+   public AMQPBridgeSenderConfiguration(AMQPBridgeConfiguration configuration, Map<String, ?> properties) {
+      super(configuration, properties);
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderControl.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderControl.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import org.apache.activemq.artemis.api.core.management.Attribute;
+
+/**
+ * Management interface that is backed by an active bridge sender
+ * that was created when demand was applied to a matching address or queue
+ * on the remote broker that is bringing messages to itself via bridge.
+ *
+ * The bridge sender sends messages for the given address or queue to
+ * a remote bridge sender.
+ */
+public interface AMQPBridgeSenderControl {
+
+   /**
+    * {@return the number of messages this bridge sender has sent to the remote}
+    */
+   @Attribute(desc = "returns the number of messages this bridge sender has sent to the remote")
+   long getMessagesSent();
+
+   /**
+    * {@return the type of bridge sender being represented}
+    */
+   @Attribute(desc = "AMQP bridge sender type (address or queue) that backs this instance.")
+   String getRole();
+
+   /**
+    * Gets the queue name that will be used for this bridge sender instance.
+    *
+    * For Queue bridge this will be the name of the queue whose messages are
+    * being bridged from this server instance to the remote. For an Address bridge
+    * this will be an automatically generated name that should be unique to a given
+    * bridge sender instance.
+    *
+    * @return the queue name associated with the bridge sender
+    */
+   @Attribute(desc = "the queue name associated with the bridge sender.")
+   String getQueueName();
+
+   /**
+    * Gets the address that will be used for this bridge sender instance.
+    *
+    * For Queue bridge this is the address under which the matching queue must
+    * reside. For Address bridge this is the actual subscription address whose
+    * messages are being bridged from the local address.
+    *
+    * @return the address associated with this bridge sender.
+    */
+   @Attribute(desc = "the address name associated with the bridge sender.")
+   String getAddress();
+
+   /**
+    * Gets the local FQQN that comprises the address and queue where the remote sender
+    * will be attached.
+    *
+    * @return provides the FQQN that can be used to address the sender queue directly.
+    */
+   @Attribute(desc = "the FQQN associated with the bridge sender.")
+   String getFqqn();
+
+   /**
+    * Gets the routing type that will be requested when creating a sender on the
+    * local server.
+    *
+    * @return the routing type of the bridge sender.
+    */
+   @Attribute(desc = "the Routing Type associated with the bridge sender.")
+   String getRoutingType();
+
+   /**
+    * Gets the filter string that will be used when creating the bridge sender.
+    *
+    * This is the filter string that is applied to the local subscription used to filter
+    * which message are actually sent to the remote broker.
+    *
+    * @return the filter string in use for the bridge sender.
+    */
+   @Attribute(desc = "the filter string associated with the bridge sender.")
+   String getFilterString();
+
+   /**
+    * Gets the priority value that will be requested for the local subscription that feeds
+    * this bridge sender with messages to send to the remote.
+    *
+    * @return the assigned sender priority for the bridge sender.
+    */
+   @Attribute(desc = "the assigned priority of the bridge sender.")
+   int getPriority();
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderControlType.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderControlType.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Objects;
+
+import javax.management.MBeanAttributeInfo;
+import javax.management.MBeanOperationInfo;
+import javax.management.NotCompliantMBeanException;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.management.impl.AbstractControl;
+import org.apache.activemq.artemis.core.management.impl.MBeanInfoHelper;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.logs.AuditLogger;
+import org.apache.activemq.artemis.utils.CompositeAddress;
+
+/**
+ * Management object used for AMQP bridge address and queue senders to expose sender state.
+ */
+public class AMQPBridgeSenderControlType extends AbstractControl implements AMQPBridgeSenderControl {
+
+   private final AMQPBridgeToSenderController senderController;
+
+   private final String address;
+   private final String queue;
+   private final RoutingType routingType;
+   private final String fqqn;
+   private final String filterString;
+   private final int priority;
+
+   public AMQPBridgeSenderControlType(AMQPBridgeToSenderController senderController) throws NotCompliantMBeanException {
+      super(AMQPBridgeSenderControl.class, senderController.getServer().getStorageManager());
+
+      final ServerConsumer consumer = senderController.getServerConsumer();
+
+      Objects.requireNonNull(consumer, "The provided sender controller must have an associated server consumer");
+
+      this.senderController = senderController;
+      this.address = consumer.getQueueAddress().toString();
+      this.queue = consumer.getQueueName().toString();
+      this.routingType = consumer.getQueueType();
+      this.fqqn = CompositeAddress.toFullyQualified(address, queue);
+      this.priority = consumer.getPriority();
+      this.filterString = consumer.getFilterString() == null ? null : consumer.getFilterString().toString();
+   }
+
+   @Override
+   public long getMessagesSent() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getMessagesSent(senderController);
+      }
+      clearIO();
+      try {
+         return senderController.getMessagesSent();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getRole() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRole(senderController);
+      }
+      clearIO();
+      try {
+         return senderController.getRole().toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getQueueName() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getQueueName(senderController);
+      }
+      clearIO();
+      try {
+         return queue;
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getAddress() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getAddress(senderController);
+      }
+      clearIO();
+      try {
+         return address;
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getFqqn() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFqqn(senderController);
+      }
+      clearIO();
+      try {
+         return fqqn;
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getRoutingType() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getRoutingType(senderController);
+      }
+      clearIO();
+      try {
+         return routingType.toString();
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public String getFilterString() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getFilterString(senderController);
+      }
+      clearIO();
+      try {
+         return filterString;
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   public int getPriority() {
+      if (AuditLogger.isBaseLoggingEnabled()) {
+         AuditLogger.getPriority(senderController);
+      }
+      clearIO();
+      try {
+         return priority;
+      } finally {
+         blockOnIO();
+      }
+   }
+
+   @Override
+   protected MBeanOperationInfo[] fillMBeanOperationInfo() {
+      return MBeanInfoHelper.getMBeanOperationsInfo(AMQPBridgeSenderControl.class);
+   }
+
+   @Override
+   protected MBeanAttributeInfo[] fillMBeanAttributeInfo() {
+      return MBeanInfoHelper.getMBeanAttributesInfo(AMQPBridgeSenderControl.class);
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderInfo.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.utils.CompositeAddress;
+
+/**
+ * Information and identification interface for AMQP bridge senders that will be
+ * created on the remote peer as demand on the local broker is detected. The behavior
+ * and meaning of some APIs in this interface may vary slightly depending on the role
+ * of the sender (Address or Queue).
+ */
+public class AMQPBridgeSenderInfo {
+
+   enum Role {
+      /**
+       * Sender created from a match on a configured bridge to address policy.
+       */
+      ADDRESS_SENDER,
+
+      /**
+       * Sender created from a match on a configured bridge to queue policy.
+       */
+      QUEUE_SENDER
+   }
+
+   private final Role role;
+   private final String localAddress;
+   private final String localQueue;
+   private final String localFqqn;
+   private final String remoteAddress;
+   private final RoutingType routingType;
+   private final String id;
+
+   public AMQPBridgeSenderInfo(Role role, String localAddress, String localQueue, RoutingType routingType, String remoteAddress) {
+      this.role = role;
+      this.localAddress = localAddress;
+      this.localQueue = localQueue;
+      if (role == Role.QUEUE_SENDER) {
+         localFqqn = CompositeAddress.toFullyQualified(localAddress, localQueue).toString();
+      } else {
+         localFqqn = null;
+      }
+      this.routingType = routingType;
+      this.remoteAddress = remoteAddress;
+      this.id = UUID.randomUUID().toString();
+   }
+
+   /**
+    * {@return a unique Id for the sender being represented}
+    */
+   public String getId() {
+      return id;
+   }
+
+   /**
+    * {@return the role assigned to this sender instance}
+    */
+   public Role getRole() {
+      return role;
+   }
+
+   /**
+    * {@return the remote address used to populate the address in the Target address of the AMQP sender}
+    */
+   public String getRemoteAddress() {
+      return remoteAddress;
+   }
+
+   /**
+    * {@return local address that the remote sender was created for}
+    */
+   public String getLocalAddress() {
+      return localAddress;
+   }
+
+   /**
+    * {@return local queue that the remote sender was created for or a local queue used to generate demand}
+    */
+   public String getLocalQueue() {
+      return localQueue;
+   }
+
+   /**
+    * {@return the local FQQN if describing a Queue sender or null for an address sender}
+    */
+   public String getLocalFqqn() {
+      return localFqqn;
+   }
+
+   /**
+    * {@return the routing type of the local resource this sender bridges to}
+    */
+   public RoutingType getRoutingType() {
+      return routingType;
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(localAddress, localFqqn, localQueue, remoteAddress, role, routingType);
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof AMQPBridgeSenderInfo)) {
+         return false;
+      }
+
+      final AMQPBridgeSenderInfo other = (AMQPBridgeSenderInfo) obj;
+
+      return Objects.equals(localAddress, other.localAddress) &&
+             Objects.equals(localFqqn, other.localFqqn) &&
+             Objects.equals(localQueue, other.localQueue) &&
+             Objects.equals(remoteAddress, other.remoteAddress) &&
+             role == other.role &&
+             routingType == other.routingType;
+   }
+
+   @Override
+   public String toString() {
+      return "AMQPBridgeSenderInfo: { " + getRole() + ", " + getRemoteAddress() + " }";
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderManager.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.io.Closeable;
+import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An abstract base for managing bridge sender instances that manages the existence
+ * of a bridge sender both while active and while attempting recovery.
+ *
+ * All interactions with the sender manager should occur under the lock of the parent
+ * manager instance and this manager will perform any asynchronous work with a lock
+ * held on the parent manager instance.
+ */
+public abstract class AMQPBridgeSenderManager {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private enum State {
+      READY,
+      STARTING,
+      STARTED,
+      CLOSED
+   }
+
+   private final AMQPBridgeManager bridgeManager;
+   private final AMQPBridgeToPolicyManager policyManager;
+   private final AMQPBridgeSenderConfiguration configuration;
+
+   private State state = State.READY;
+   private AMQPBridgeSender sender;
+   private AMQPBridgeSenderRecoveryHandler recoveryHandler;
+
+   /**
+    * Create a new bridge sender manager instance.
+    *
+    * @param policyManager
+    *    The policy manager that created this instance.
+    * @param configuration
+    *    The configuration that was in force when the manager was created.
+    */
+   public AMQPBridgeSenderManager(AMQPBridgeToPolicyManager policyManager, AMQPBridgeSenderConfiguration configuration) {
+      this.policyManager = policyManager;
+      this.configuration = configuration;
+      this.bridgeManager = policyManager.getBridgeManager();
+   }
+
+   /**
+    * Creates a new bridge sender that this manager will monitor and maintain. The returned
+    * sender should be in an initial state ready for this manager to initialize once it is fully
+    * configured.
+    *
+    * @return a newly create {@link AMQPBridgeSender} for use by this manager.
+    */
+   protected abstract AMQPBridgeSender createBridgeSender();
+
+   /**
+    * An immediate close of the bridge sender and any recovery tasks that might be
+    * pending for a disconnected sender instance.
+    *
+    * The bridge manager should be calling this method with its lock held.
+    */
+   public void shutdownNow() {
+      if (state != State.CLOSED) {
+         state = State.CLOSED;
+
+         try {
+            if (sender != null) {
+               safeCloseCurrentBridgeSender();
+            }
+         } finally {
+            sender = null;
+            closeRecoveryHandler();
+         }
+      }
+   }
+
+   /**
+    * An immediate start of the bridge sender which triggers the first sender attach
+    * request and then allows for ongoing recovery efforts if configuration allows it.
+    *
+    * The bridge manager should be calling this method with its lock held.
+    */
+   public void start() {
+      checkClosed();
+
+      if (state == State.READY) {
+         tryCreateBridgeSender();
+      }
+   }
+
+   /*
+    * Must be called with locks in place from the parent manager to prevent concurrent
+    * access to state changing APIs.
+    */
+   private void tryCreateBridgeSender() {
+      state = State.STARTING;
+      sender = createBridgeSender();
+
+      logger.trace("Bridge sender manager creating remote sender for: {}", sender.getSenderInfo());
+
+      // Handle remote open and cancel any additional link recovery attempts. Ensure that
+      // thread safety is accounted for here as the notification come from the connection
+      // thread.
+      sender.setRemoteOpenHandler(openedSender -> {
+         synchronized (policyManager) {
+            // Stop or close could have followed quick enough that this didn't get completed yet.
+            if (state == State.STARTING) {
+               state = State.STARTED;
+            }
+
+            closeRecoveryHandler();
+         }
+      });
+
+      // Handle remote close with remove of sender which means that future demand will
+      // attempt to create a new sender for that demand. Ensure that thread safety is
+      // accounted for here as the notification can be asynchronous.
+      sender.setRemoteClosedHandler((closedSender) -> {
+         synchronized (this) {
+            synchronized (policyManager) {
+               safeCloseCurrentBridgeSender();
+
+               if (configuration.isLinkRecoveryEnabled() && state == State.READY) {
+                  // If the close came from a previous attempt that is itself a recovery we use the
+                  // existing recovery handler, otherwise we need to create a new handler to deal
+                  // with link recovery and track attempt counts.
+                  if (recoveryHandler == null) {
+                     recoveryHandler = new AMQPBridgeSenderRecoveryHandler(this, configuration);
+                  }
+
+                  final boolean scheduled = recoveryHandler.tryScheduleNextRecovery(bridgeManager.getScheduler());
+
+                  if (!scheduled) {
+                     closeRecoveryHandler();
+                  }
+               }
+            }
+         }
+      });
+
+      sender.initialize();
+   }
+
+   /*
+    * Must lock on the policy manager to ensure that state changes occur in safe conditions.
+    */
+   private void tryRecoverSender() {
+      synchronized (policyManager) {
+         // Recovery only needs to occur if we are in the READY state, meaning not closed,
+         // otherwise we can end recovery operations. The recovery handler is normally closed
+         // out on a successful remote attach response.
+         if (state == State.READY) {
+            tryCreateBridgeSender();
+         } else {
+            closeRecoveryHandler();
+         }
+      }
+   }
+
+   private void safeCloseCurrentBridgeSender() {
+      try {
+         safeCloseCurrentBridgeSender(sender);
+      } finally {
+         state = state == State.CLOSED ? State.CLOSED : State.READY;
+         sender = null;
+      }
+   }
+
+   private void safeCloseCurrentBridgeSender(AMQPBridgeSender sender) {
+      if (sender != null) {
+         try {
+            if (!sender.isClosed()) {
+               sender.close();
+            }
+         } catch (Exception e) {
+            logger.trace("Suppressed error on close of bridge sender. ", e);
+         }
+      }
+   }
+
+   private void checkClosed() {
+      if (state == State.CLOSED) {
+         throw new IllegalStateException("The bridge sender has been closed already");
+      }
+   }
+
+   private void closeRecoveryHandler() {
+      if (recoveryHandler != null) {
+         try {
+            recoveryHandler.close();
+         } finally {
+            recoveryHandler = null;
+         }
+      }
+   }
+
+   public static class AMQPBridgeSenderRecoveryHandler implements Closeable {
+
+      private final AMQPBridgeSenderManager manager;
+      private final AMQPBridgeLinkConfiguration configuration;
+      private final int maxRecoveryAttempts;
+
+      private final AtomicInteger recoveryAttempts = new AtomicInteger();
+      private final AtomicLong nextRecoveryDelay = new AtomicLong();
+      private volatile ScheduledFuture<?> recoveryFuture;
+
+      public AMQPBridgeSenderRecoveryHandler(AMQPBridgeSenderManager manager, AMQPBridgeLinkConfiguration configuration) {
+         this.manager = manager;
+         this.configuration = configuration;
+         this.nextRecoveryDelay.set(configuration.getLinkRecoveryInitialDelay() > 0 ? configuration.getLinkRecoveryInitialDelay() : 1);
+         this.maxRecoveryAttempts = configuration.getMaxLinkRecoveryAttempts();
+      }
+
+      @Override
+      public void close() {
+         final ScheduledFuture<?> future = this.recoveryFuture;
+
+         if (future != null) {
+            future.cancel(false);
+         }
+
+         recoveryFuture = null;
+      }
+
+      /**
+       * When a link used by the bridge fails, this method is used to try and schedule a new
+       * connection attempt if the configuration rules allow one. If the configuration does not
+       * allow any (more) reconnection attempts this method returns false.
+       *
+       * @param scheduler
+       *    The scheduler to use to schedule the next connection attempt.
+       *
+       * @return true if an attempt was scheduled or false if no attempts are allowed.
+       */
+      public boolean tryScheduleNextRecovery(ScheduledExecutorService scheduler) {
+         Objects.requireNonNull(scheduler, "The scheduler to use cannot be null");
+
+         if (maxRecoveryAttempts < 0 || recoveryAttempts.get() < maxRecoveryAttempts) {
+            recoveryFuture = scheduler.schedule(this::handleReconnectionAttempt, nextRecoveryDelay.get(), TimeUnit.MILLISECONDS);
+            return true;
+         } else {
+            return false;
+         }
+      }
+
+      private void handleReconnectionAttempt() {
+         final ScheduledFuture<?> future = this.recoveryFuture;
+
+         try {
+            if (future != null && !future.isCancelled()) {
+               if (maxRecoveryAttempts > 0) {
+                  recoveryAttempts.incrementAndGet();
+               }
+
+               // If user configures no delay, we impose a small one just to avoid over saturation to some extent.
+               nextRecoveryDelay.set(configuration.getLinkRecoveryDelay() > 0 ? configuration.getLinkRecoveryDelay() : 1);
+
+               manager.tryRecoverSender();
+            }
+         } finally {
+            recoveryFuture = null;
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSupport.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_PRIORITY_ADJUSTMENT_VALUE;
+
+import java.lang.invoke.MethodHandles;
+import java.util.AbstractMap;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeAddressPolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeQueuePolicyElement;
+import org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnection;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Support class for operations involving the AMQP Bridge.
+ */
+public class AMQPBridgeSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static final WildcardConfiguration DEFAULT_WILDCARD_CONFIGURATION = new WildcardConfiguration();
+
+   /**
+    * Create a new AMQPBridgeManager from the bridge configuration element.
+    *
+    * @param connection
+    *    The broker connection that will contain the AMQP bridge.
+    * @param bridgeElement
+    *    Configuration of the AMQP bridge.
+    *
+    * @return a configured AMQP bridge manager instance for use by the parent broker connection.
+    */
+   public static AMQPBridgeManager createManager(AMQPBrokerConnection connection, AMQPBridgeBrokerConnectionElement bridgeElement) {
+      final WildcardConfiguration wildcardConfiguration;
+
+      if (connection.getServer().getConfiguration().getWildcardConfiguration() != null) {
+         wildcardConfiguration = connection.getServer().getConfiguration().getWildcardConfiguration();
+      } else {
+         wildcardConfiguration = DEFAULT_WILDCARD_CONFIGURATION;
+      }
+
+      Set<AMQPBridgeAddressPolicy> fromAddressPolicies = Collections.emptySet();
+      Set<AMQPBridgeAddressPolicy> toAddressPolicies = Collections.emptySet();
+      Set<AMQPBridgeQueuePolicy> fromQueuePolicies = Collections.emptySet();
+      Set<AMQPBridgeQueuePolicy> toQueuePolicies = Collections.emptySet();
+
+      final Set<AMQPBridgeAddressPolicyElement> fromAddress = bridgeElement.getBridgeFromAddressPolicies();
+      if (!fromAddress.isEmpty()) {
+         fromAddressPolicies = new HashSet<>();
+
+         for (AMQPBridgeAddressPolicyElement element : fromAddress) {
+            logger.debug("AMQP Bridge {} adding bridge from address policy: {}", bridgeElement.getName(), element.getName());
+            fromAddressPolicies.add(createBridgeAddressPolicy(element, wildcardConfiguration));
+         }
+      }
+      final Set<AMQPBridgeAddressPolicyElement> toAddress = bridgeElement.getBridgeToAddressPolicies();
+      if (!toAddress.isEmpty()) {
+         toAddressPolicies = new HashSet<>();
+
+         for (AMQPBridgeAddressPolicyElement element : toAddress) {
+            logger.debug("AMQP Bridge {} adding bridge to address policy: {}", bridgeElement.getName(), element.getName());
+            toAddressPolicies.add(createBridgeAddressPolicy(element, wildcardConfiguration));
+         }
+      }
+      final Set<AMQPBridgeQueuePolicyElement> fromQueue = bridgeElement.getBridgeFromQueuePolicies();
+      if (!fromQueue.isEmpty()) {
+         fromQueuePolicies = new HashSet<>();
+
+         for (AMQPBridgeQueuePolicyElement element : fromQueue) {
+            logger.debug("AMQP Bridge {} adding bridge from Queue policy: {}", bridgeElement.getName(), element.getName());
+            fromQueuePolicies.add(createBridgeQueuePolicy(element, wildcardConfiguration));
+         }
+      }
+      final Set<AMQPBridgeQueuePolicyElement> toQueue = bridgeElement.getBridgeToQueuePolicies();
+      if (!toQueue.isEmpty()) {
+         toQueuePolicies = new HashSet<>();
+
+         for (AMQPBridgeQueuePolicyElement element : toQueue) {
+            logger.debug("AMQP Bridge {} adding bridge to Queue policy: {}", bridgeElement.getName(), element.getName());
+            toQueuePolicies.add(createBridgeQueuePolicy(element, wildcardConfiguration));
+         }
+      }
+
+      final AMQPBridgeManager bridge = new AMQPBridgeManager(bridgeElement.getName(),
+                                                             connection,
+                                                             fromAddressPolicies,
+                                                             toAddressPolicies,
+                                                             fromQueuePolicies,
+                                                             toQueuePolicies,
+                                                             bridgeElement.getProperties());
+
+      return bridge;
+   }
+
+   /**
+    * From the broker AMQP broker connection configuration element and the configured wild-card
+    * settings create an queue match policy.
+    *
+    * @param element
+    *    The broker connections element configuration that creates this policy.
+    * @param wildcards
+    *    The configured wild-card settings for the broker or defaults.
+    *
+    * @return a new queue match and handling policy for use in the broker connection.
+    */
+   public static AMQPBridgeQueuePolicy createBridgeQueuePolicy(AMQPBridgeQueuePolicyElement element, WildcardConfiguration wildcards) {
+      final Set<Map.Entry<String, String>> includes;
+      final Set<Map.Entry<String, String>> excludes;
+
+      final int priorityAdjustment = element.getPriorityAdjustment() != null ?
+         element.getPriorityAdjustment() : DEFAULT_PRIORITY_ADJUSTMENT_VALUE;
+
+      if (element.getIncludes() != null && !element.getIncludes().isEmpty()) {
+         includes = new HashSet<>(element.getIncludes().size());
+
+         element.getIncludes().forEach(queueMatch ->
+            includes.add(new AbstractMap.SimpleImmutableEntry<String, String>(queueMatch.getAddressMatch(), queueMatch.getQueueMatch())));
+      } else {
+         includes = Collections.emptySet();
+      }
+
+      if (element.getExcludes() != null && !element.getExcludes().isEmpty()) {
+         excludes = new HashSet<>(element.getExcludes().size());
+
+         element.getExcludes().forEach(queueMatch ->
+            excludes.add(new AbstractMap.SimpleImmutableEntry<String, String>(queueMatch.getAddressMatch(), queueMatch.getQueueMatch())));
+      } else {
+         excludes = Collections.emptySet();
+      }
+
+      // We translate from broker configuration to actual implementation to avoid any coupling here
+      // as broker configuration could change and or be updated.
+
+      final AMQPBridgeQueuePolicy policy = new AMQPBridgeQueuePolicy(
+         element.getName(),
+         element.getPriority(),
+         priorityAdjustment,
+         element.getFilter(),
+         element.getRemoteAddress(),
+         element.getRemoteAddressPrefix(),
+         element.getRemoteAddressSuffix(),
+         toSymbolCollection(element.getRemoteTerminusCapabilities()),
+         includes,
+         excludes,
+         element.getProperties(),
+         element.getTransformerConfiguration(),
+         wildcards);
+
+      return policy;
+   }
+
+   /**
+    * From the broker AMQP broker connection configuration element and the configured wild-card
+    * settings create an address match policy.
+    *
+    * @param element
+    *    The broker connections element configuration that creates this policy.
+    * @param wildcards
+    *    The configured wild-card settings for the broker or defaults.
+    *
+    * @return a new address match and handling policy for use in the broker connection.
+    */
+   public static AMQPBridgeAddressPolicy createBridgeAddressPolicy(AMQPBridgeAddressPolicyElement element, WildcardConfiguration wildcards) {
+      final Set<String> includes;
+      final Set<String> excludes;
+
+      if (element.getIncludes() != null && !element.getIncludes().isEmpty()) {
+         includes = new HashSet<>(element.getIncludes().size());
+
+         element.getIncludes().forEach(addressMatch -> includes.add(addressMatch.getAddressMatch()));
+      } else {
+         includes = Collections.emptySet();
+      }
+
+      if (element.getExcludes() != null && !element.getExcludes().isEmpty()) {
+         excludes = new HashSet<>(element.getExcludes().size());
+
+         element.getExcludes().forEach(addressMatch -> excludes.add(addressMatch.getAddressMatch()));
+      } else {
+         excludes = Collections.emptySet();
+      }
+
+      // We translate from broker configuration to actual implementation to avoid any coupling here
+      // as broker configuration could change and or be updated.
+
+      final AMQPBridgeAddressPolicy policy = new AMQPBridgeAddressPolicy(
+         element.getName(),
+         element.isIncludeDivertBindings(),
+         element.getPriority(),
+         element.getFilter(),
+         element.getRemoteAddress(),
+         element.getRemoteAddressPrefix(),
+         element.getRemoteAddressSuffix(),
+         toSymbolCollection(element.getRemoteTerminusCapabilities()),
+         includes,
+         excludes,
+         element.getProperties(),
+         element.getTransformerConfiguration(),
+         wildcards);
+
+      return policy;
+   }
+
+   private static Collection<Symbol> toSymbolCollection(String[] symbols) {
+      if (symbols == null || symbols.length == 0) {
+         return Collections.emptySet();
+      }
+
+      final Set<Symbol> collection = new HashSet<>(symbols.length);
+
+      for (String symbol : symbols) {
+         if (symbol == null || symbol.isBlank()) {
+            continue;
+         }
+
+         collection.add(Symbol.valueOf(symbol));
+      }
+
+      return collection.isEmpty() ? Collections.emptySet() : collection;
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToAddressPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToAddressPolicyManager.java
@@ -1,0 +1,183 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerAddressPlugin;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeSenderInfo.Role;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AMQP Bridge policy manager that tracks local addresses that match the policy configurations
+ * and creates senders to the remote peer for that address until such time as the address is
+ * removed locally.
+ */
+public class AMQPBridgeToAddressPolicyManager extends AMQPBridgeToPolicyManager implements ActiveMQServerAddressPlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final AMQPBridgeAddressPolicy policy;
+   private final Map<String, AMQPBridgeAddressSenderManager> addressTracking = new HashMap<>();
+
+   public AMQPBridgeToAddressPolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metrics, AMQPBridgeAddressPolicy policy) {
+      super(bridge, metrics, policy.getPolicyName(), AMQPBridgeType.BRIDGE_TO_ADDRESS);
+
+      Objects.requireNonNull(policy, "The Address match policy cannot be null");
+
+      this.policy = policy;
+   }
+
+   /**
+    * {@return the policy that defines the bridged address this policy manager monitors}
+    */
+   @Override
+   public AMQPBridgeAddressPolicy getPolicy() {
+      return policy;
+   }
+
+   @Override
+   protected void scanManagedResources() {
+      server.getPostOffice()
+            .getAddresses()
+            .stream()
+            .map(address -> server.getAddressInfo(address))
+            .forEach(addressInfo -> afterAddAddress(addressInfo, false));
+   }
+
+   @Override
+   protected void safeCleanupManagerResources() {
+      try {
+         addressTracking.forEach((k, v) -> {
+            v.shutdownNow();
+         });
+      } finally {
+         addressTracking.clear();
+      }
+   }
+
+   @Override
+   public synchronized void afterAddAddress(AddressInfo addressInfo, boolean reload) {
+      if (isActive() && policy.test(addressInfo)) {
+         try {
+            final AMQPBridgeAddressSenderManager manager = new AMQPBridgeAddressSenderManager(this, configuration, addressInfo);
+            addressTracking.put(manager.getAddress(), manager);
+            manager.start();
+         } catch (Exception e) {
+            ActiveMQServerLogger.LOGGER.bridgeBindingsLookupError(addressInfo.getName(), e);
+         }
+      }
+   }
+
+   @Override
+   public synchronized void afterRemoveAddress(SimpleString address, AddressInfo addressInfo) throws ActiveMQException {
+      if (isActive()) {
+         final AMQPBridgeAddressSenderManager manager = addressTracking.remove(address.toString());
+
+         if (manager != null) {
+            logger.trace("Clearing sender tracking for removed bridged Address {}", addressInfo.getName());
+            manager.shutdownNow();
+         }
+      }
+   }
+
+   private AMQPBridgeSender createBridgeSender(AMQPBridgeSenderInfo senderInfo) {
+      Objects.requireNonNull(senderInfo, "AMQP Bridge Address sender information object was null");
+
+      if (logger.isTraceEnabled()) {
+         logger.trace("AMQP Bridge {} creating address sender: {} for policy: {}", bridge.getName(), senderInfo, policy.getPolicyName());
+      }
+
+      // Don't initiate anything yet as the caller might need to register error handlers etc
+      // before the attach is sent otherwise they could miss the failure case.
+      return new AMQPBridgeToAddressSender(this, configuration, session, senderInfo, metrics.newSenderMetrics());
+   }
+
+   // NOTE: We currently create a temporary queue for bridge to address senders, which means that if the broker
+   // is shutdown and later restarted and there were messages in the queue to be sent because the sender was not
+   // connected we would lose those messages. We may want to consider a configuration for durable sender queues
+   // but that raises question of future clean as in some cases such as the bridge configuration being removed
+   // and the server started back up, there is nothing to enforce cleanup of that durable queue.
+   private String generateTempQueueName(String remoteAddress) {
+      return "amqp-bridge-" + bridge.getName() +
+             "-policy-" + policyName +
+             "-address-sender-to-" + remoteAddress +
+             "-" + UUID.randomUUID().toString();
+   }
+
+   private AMQPBridgeSenderInfo createSenderInfo(AddressInfo address) {
+      final String addressName = address.getName().toString();
+      final StringBuilder remoteAddressBuilder = new StringBuilder();
+
+      if (policy.getRemoteAddressPrefix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressPrefix());
+      }
+
+      if (policy.getRemoteAddress() != null && !policy.getRemoteAddress().isBlank()) {
+         remoteAddressBuilder.append(policy.getRemoteAddress());
+      } else {
+         remoteAddressBuilder.append(addressName);
+      }
+
+      if (policy.getRemoteAddressSuffix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressSuffix());
+      }
+
+      final String remoteAddress = remoteAddressBuilder.toString();
+
+      return new AMQPBridgeSenderInfo(Role.ADDRESS_SENDER,
+                                      addressName,
+                                      generateTempQueueName(remoteAddress),
+                                      address.getRoutingType(),
+                                      remoteAddress);
+   }
+
+   private static class AMQPBridgeAddressSenderManager extends AMQPBridgeSenderManager {
+
+      private final AMQPBridgeToAddressPolicyManager manager;
+      private final AddressInfo addressInfo;
+
+      AMQPBridgeAddressSenderManager(AMQPBridgeToAddressPolicyManager manager, AMQPBridgeSenderConfiguration configuration, AddressInfo addressInfo) {
+         super(manager, configuration);
+
+         this.manager = manager;
+         this.addressInfo = addressInfo;
+      }
+
+      /**
+       * @return the address that this entry is acting to bridge.
+       */
+      public String getAddress() {
+         return addressInfo.getName().toString();
+      }
+
+      @Override
+      protected AMQPBridgeSender createBridgeSender() {
+         return manager.createBridgeSender(manager.createSenderInfo(addressInfo));
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToAddressSender.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToAddressSender.java
@@ -1,0 +1,269 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.AddressQueryResult;
+import org.apache.activemq.artemis.core.server.QueueQueryResult;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.SenderMetrics;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPNotFoundException;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContext;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
+import org.apache.qpid.proton.engine.Sender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sender type that handles sending messages sent to a local address to a remote AMQP peer.
+ */
+public class AMQPBridgeToAddressSender extends AMQPBridgeSender {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public AMQPBridgeToAddressSender(AMQPBridgeToPolicyManager policyManager,
+                                    AMQPBridgeSenderConfiguration configuration,
+                                    AMQPSessionContext session,
+                                    AMQPBridgeSenderInfo senderInfo,
+                                    SenderMetrics metrics) {
+      super(policyManager, configuration, session, senderInfo, metrics);
+   }
+
+   @Override
+   public AMQPBridgeToAddressPolicyManager getPolicyManager() {
+      return (AMQPBridgeToAddressPolicyManager) policyManager;
+   }
+
+   @Override
+   public AMQPBridgeAddressPolicy getPolicy() {
+      return (AMQPBridgeAddressPolicy) policy;
+   }
+
+   @Override
+   protected void doCreateSender() {
+      try {
+         final Sender protonSender = session.getSession().sender(generateLinkName());
+         final Target target = new Target();
+         final Source source = new Source();
+         final String address = senderInfo.getRemoteAddress();
+
+         source.setAddress(senderInfo.getLocalAddress());
+
+         target.setAddress(address);
+         target.setDurable(TerminusDurability.NONE);
+         target.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
+         target.setCapabilities(getRemoteTerminusCapabilities());
+
+         protonSender.setSenderSettleMode(configuration.isUsingPresettledSenders() ? SenderSettleMode.SETTLED : SenderSettleMode.UNSETTLED);
+         protonSender.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+         // If enabled indicate that core tunneling is desired which we prefer to AMQP conversions of core as
+         // the large ones will be converted to standard AMQP messages in memory. If the remote does not offer
+         // the capability in return we cannot use core tunneling which we will check when the remote attach
+         // response arrives and we complete the link attach.
+         if (configuration.isCoreMessageTunnelingEnabled()) {
+            protonSender.setDesiredCapabilities(new Symbol[] {AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT});
+         }
+         protonSender.setTarget(target);
+         protonSender.setSource(source);
+         protonSender.open();
+
+         final ScheduledFuture<?> openTimeoutTask;
+         final AtomicBoolean openTimedOut = new AtomicBoolean(false);
+
+         if (configuration.getLinkAttachTimeout() > 0) {
+            openTimeoutTask = bridgeManager.getServer().getScheduledPool().schedule(() -> {
+               openTimedOut.set(true);
+               bridgeManager.signalResourceCreateError(ActiveMQAMQPProtocolMessageBundle.BUNDLE.brokerConnectionTimeout());
+            }, configuration.getLinkAttachTimeout(), TimeUnit.SECONDS);
+         } else {
+            openTimeoutTask = null;
+         }
+
+         this.protonSender = protonSender;
+
+         protonSender.attachments().set(AMQP_LINK_INITIALIZER_KEY, Runnable.class, () -> {
+            try {
+               if (openTimeoutTask != null) {
+                  openTimeoutTask.cancel(false);
+               }
+
+               if (openTimedOut.get()) {
+                  return;
+               }
+
+               final boolean linkOpened = protonSender.getRemoteTarget() != null;
+
+               if (linkOpened) {
+                  logger.debug("AMQP Bridge {} address senderContext {} completed open", bridgeManager.getName(), senderInfo);
+               } else {
+                  logger.debug("AMQP Bridge {} address senderContext {} rejected by remote", bridgeManager.getName(), senderInfo);
+               }
+
+               // Intercept remote close and check for valid reasons for remote closure such as
+               // the remote peer not having a matching node for this subscription or from an
+               // operator manually closing the link etc.
+               bridgeManager.addLinkClosedInterceptor(senderInfo.getId(), this::remoteLinkClosedInterceptor);
+
+               final AMQPBridgeToAddressSenderController senderController =
+                  new AMQPBridgeToAddressSenderController(senderInfo, getPolicyManager(), session, metrics);
+
+               senderContext = new AMQPBridgeAddressSenderContext(
+                  connection, protonSender, session, session.getSessionSPI(), senderController);
+
+               session.addSender(protonSender, senderContext);
+
+               if (linkOpened && remoteOpenHandler != null) {
+                  remoteOpenHandler.accept(this);
+               }
+            } catch (Exception e) {
+               bridgeManager.signalError(e);
+            }
+         });
+      } catch (Exception e) {
+         bridgeManager.signalError(e);
+      }
+
+      connection.flush();
+   }
+
+   private String generateLinkName() {
+      return "amqp-bridge-" + bridgeManager.getName() +
+             "-policy-" + policy.getPolicyName() +
+             "-address-sender-" + senderInfo.getRemoteAddress() +
+             "-" + bridgeManager.getServer().getNodeID() +
+             "-" + LINK_SEQUENCE_ID.incrementAndGet();
+   }
+
+   private class AMQPBridgeAddressSenderContext extends ProtonServerSenderContext {
+
+      AMQPBridgeAddressSenderContext(AMQPConnectionContext connection, Sender sender,
+                                     AMQPSessionContext protonSession, AMQPSessionCallback server,
+                                     AMQPBridgeToAddressSenderController senderController) {
+         super(connection, sender, protonSession, server, senderController);
+      }
+
+      @Override
+      public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
+         super.close(remoteLinkClose);
+
+         if (remoteLinkClose && remoteCloseHandler != null) {
+            try {
+               remoteCloseHandler.accept(AMQPBridgeToAddressSender.this);
+            } catch (Exception e) {
+               logger.debug("User remote closed handler threw error: ", e);
+            } finally {
+               remoteCloseHandler = null;
+            }
+         }
+      }
+   }
+
+   public static class AMQPBridgeToAddressSenderController extends AMQPBridgeToSenderController {
+
+      private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+      public AMQPBridgeToAddressSenderController(AMQPBridgeSenderInfo senderInfo, AMQPBridgeToPolicyManager policyManager, AMQPSessionContext session, SenderMetrics metrics) throws ActiveMQAMQPException {
+         super(senderInfo, policyManager, session, metrics);
+      }
+
+      @Override
+      public SenderRole getRole() {
+         return SenderRole.ADDRESS_SENDER;
+      }
+
+      public AMQPBridgeAddressPolicy getPolicy() {
+         return (AMQPBridgeAddressPolicy) policy;
+      }
+
+      @Override
+      protected void handleLinkRemotelyClosed() {
+         tryDeleteTemporarySubscriptionQueue();
+      }
+
+      @Override
+      protected void handleLinkLocallyClosed(ErrorCondition error) {
+         tryDeleteTemporarySubscriptionQueue();
+      }
+
+      private void tryDeleteTemporarySubscriptionQueue() {
+         final AMQPSessionCallback sessionSPI = session.getSessionSPI();
+         final SimpleString queueName = SimpleString.of(senderInfo.getLocalQueue());
+
+         try {
+            final QueueQueryResult queueQuery = sessionSPI.queueQuery(queueName, RoutingType.MULTICAST, false);
+
+            if (queueQuery.isExists()) {
+               sessionSPI.deleteQueue(queueName);
+            }
+         } catch (Exception e) {
+            // Ignore as temporary destinations will be cleaned up automatically later.
+         }
+      }
+
+      @Override
+      protected ServerConsumer createServerConsumer(ProtonServerSenderContext senderContext) throws Exception {
+         final AMQPSessionCallback sessionSPI = session.getSessionSPI();
+         final SimpleString address = SimpleString.of(senderInfo.getLocalAddress());
+         final SimpleString queue = SimpleString.of(senderInfo.getLocalQueue());
+         final RoutingType defRoutingType = senderInfo.getRoutingType();
+
+         try {
+            final AddressQueryResult result = sessionSPI.addressQuery(address, defRoutingType, false);
+
+            // We initiated this link so the settings should refer to an address that definitely exists
+            // however there is a chance the address was removed in the interim.
+            if (!result.isExists()) {
+               throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist(address.toString());
+            }
+         } catch (ActiveMQAMQPNotFoundException e) {
+            throw e;
+         } catch (Exception e) {
+            logger.debug(e.getMessage(), e);
+            throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
+         }
+
+         try {
+            sessionSPI.createTemporaryQueue(address, queue, RoutingType.MULTICAST, SimpleString.of(getPolicy().getFilter()), 1, true);
+         } catch (Exception e) {
+            throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.errorCreatingTemporaryQueue(e.getMessage());
+         }
+
+         return sessionSPI.createSender(senderContext, queue, null, false, policy.getPriority());
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToPolicyManager.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBasePlugin;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Base class for AMQP bridge policy managers that bridge to the remote peer from
+ * this peer for some configured resource.
+ */
+public abstract class AMQPBridgeToPolicyManager extends AMQPBridgePolicyManager implements ActiveMQServerBasePlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   protected volatile AMQPBridgeSenderConfiguration configuration;
+
+   public AMQPBridgeToPolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metrics, String policyName, AMQPBridgeType policyType) {
+      super(bridge, metrics, policyName, policyType);
+   }
+
+   @Override
+   protected void handleManagerInitialized() {
+      server.registerBrokerPlugin(this);
+
+      try {
+         AMQPBridgeManagementSupport.registerBridgePolicyManager(this);
+      } catch (Exception e) {
+         logger.trace("Error while attempting to add sender policy control to management", e);
+      }
+   }
+
+   @Override
+   protected void handleManagerStarted() {
+      if (isActive()) {
+         scanManagedResources();
+      }
+   }
+
+   @Override
+   protected void handleManagerStopped() {
+      safeCleanupManagerResources();
+   }
+
+   @Override
+   protected void handleManagerShutdown() {
+      server.unRegisterBrokerPlugin(this);
+
+      try {
+         AMQPBridgeManagementSupport.unregisterBridgePolicyManager(this);
+      } catch (Exception e) {
+         logger.trace("Error while attempting to remove sender policy control from management", e);
+      }
+
+      safeCleanupManagerResources();
+   }
+
+   @Override
+   protected void handleConnectionInterrupted() {
+      safeCleanupManagerResources();
+   }
+
+   @Override
+   protected void handleConnectionRestored(AMQPBridgeConfiguration configuration) {
+      // Capture state for the current connection on each connection as different URIs could have
+      // different options we need to capture in the current configuration state.
+      this.configuration = new AMQPBridgeSenderConfiguration(configuration, getPolicy().getProperties());
+
+      if (isActive()) {
+         scanManagedResources();
+      }
+   }
+
+   /**
+    * Scans all server resources and push them through the normal checks that
+    * would be done on an add. This allows for checks on demand after a start or
+    * after a connection is restored.
+    */
+   protected abstract void scanManagedResources();
+
+   /**
+    * The subclass implements this method and should remove all tracked AMQP bridge
+    * resource data and also close all links immediately.
+    */
+   protected abstract void safeCleanupManagerResources();
+
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToQueuePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToQueuePolicyManager.java
@@ -1,0 +1,177 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import java.lang.invoke.MethodHandles;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.api.core.ActiveMQException;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.QueueBinding;
+import org.apache.activemq.artemis.core.security.SecurityAuth;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerQueuePlugin;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeSenderInfo.Role;
+import org.apache.activemq.artemis.utils.CompositeAddress;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * AMQP Bridge policy manager that tracks local queues that match the policy configurations
+ * and creates senders to the remote peer for that address until such time as the queue is
+ * removed locally.
+ */
+public class AMQPBridgeToQueuePolicyManager extends AMQPBridgeToPolicyManager implements ActiveMQServerQueuePlugin {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final AMQPBridgeQueuePolicy policy;
+   private final Map<String, AMQPBridgeQueueSenderManager> queueSenders = new HashMap<>();
+
+   public AMQPBridgeToQueuePolicyManager(AMQPBridgeManager bridge, AMQPBridgeMetrics metrics, AMQPBridgeQueuePolicy policy) {
+      super(bridge, metrics, policy.getPolicyName(), AMQPBridgeType.BRIDGE_TO_QUEUE);
+
+      Objects.requireNonNull(policy, "The Queue match policy cannot be null");
+
+      this.policy = policy;
+   }
+
+   /**
+    * {@return the policy that defines the bridged queue this policy manager monitors}
+    */
+   @Override
+   public AMQPBridgeQueuePolicy getPolicy() {
+      return policy;
+   }
+
+   @Override
+   protected void scanManagedResources() {
+      server.getPostOffice()
+            .getAllBindings()
+            .filter(binding -> binding instanceof QueueBinding)
+            .forEach(binding -> checkQueueForMatch(((QueueBinding) binding).getQueue()));
+   }
+
+   @Override
+   protected void safeCleanupManagerResources() {
+      try {
+         queueSenders.forEach((k, v) -> {
+            v.shutdownNow();
+         });
+      } finally {
+         queueSenders.clear();
+      }
+   }
+
+   @Override
+   public void afterCreateQueue(Queue queue) throws ActiveMQException {
+      if (isActive()) {
+         checkQueueForMatch(queue);
+      }
+   }
+
+   @Override
+   public void afterDestroyQueue(Queue queue, SimpleString address, final SecurityAuth session, boolean checkConsumerCount,
+                                 boolean removeConsumers, boolean autoDeleteAddress) throws ActiveMQException {
+      if (isActive()) {
+         final String fqqn = CompositeAddress.toFullyQualified(queue.getAddress(), queue.getName()).toString();
+         final AMQPBridgeQueueSenderManager manager = queueSenders.remove(fqqn);
+
+         if (manager != null) {
+            logger.trace("Clearing sender tracking for removed bridged Queues {}", fqqn);
+            manager.shutdownNow();
+         }
+      }
+   }
+
+   private boolean testIfQueueMatchesPolicy(String address, String queueName) {
+      return policy.test(address, queueName);
+   }
+
+   protected final void checkQueueForMatch(Queue queue) {
+      if (testIfQueueMatchesPolicy(queue.getAddress().toString(), queue.getName().toString())) {
+         final AddressInfo addressInfo = server.getPostOffice().getAddressInfo(queue.getAddress());
+         logger.trace("AMQP Bridge To Queue Policy matched on Queue: {}:{}", addressInfo, queue);
+
+         final AMQPBridgeQueueSenderManager manager;
+         final AMQPBridgeSenderInfo info = createSenderInfo(addressInfo, queue);
+
+         manager = new AMQPBridgeQueueSenderManager(this, configuration, info);
+         queueSenders.put(info.getLocalFqqn(), manager);
+         manager.start();
+      }
+   }
+
+   private AMQPBridgeSenderInfo createSenderInfo(AddressInfo addressInfo, Queue queue) {
+      final String queueName = queue.getName().toString();
+      final StringBuilder remoteAddressBuilder = new StringBuilder();
+
+      if (policy.getRemoteAddressPrefix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressPrefix());
+      }
+
+      if (policy.getRemoteAddress() != null && !policy.getRemoteAddress().isBlank()) {
+         remoteAddressBuilder.append(policy.getRemoteAddress());
+      } else {
+         remoteAddressBuilder.append(queueName);
+      }
+
+      if (policy.getRemoteAddressSuffix() != null) {
+         remoteAddressBuilder.append(policy.getRemoteAddressSuffix());
+      }
+
+      return new AMQPBridgeSenderInfo(Role.QUEUE_SENDER,
+                                      addressInfo.getName().toString(),
+                                      queueName,
+                                      addressInfo.getRoutingType(),
+                                      remoteAddressBuilder.toString());
+   }
+
+   private AMQPBridgeSender createBridgeSender(AMQPBridgeSenderInfo senderInfo) {
+      Objects.requireNonNull(senderInfo, "AMQP Bridge Queue sender information object was null");
+
+      if (logger.isTraceEnabled()) {
+         logger.trace("AMQP Bridge {} creating Queue sender: {} for policy: {}", bridge.getName(), senderInfo, policy.getPolicyName());
+      }
+
+      // Don't initiate anything yet as the caller might need to register error handlers etc
+      // before the attach is sent otherwise they could miss the failure case.
+      return new AMQPBridgeToQueueSender(this, configuration, session, senderInfo, metrics.newSenderMetrics());
+   }
+
+   private static class AMQPBridgeQueueSenderManager extends AMQPBridgeSenderManager {
+
+      private final AMQPBridgeToQueuePolicyManager manager;
+      private final AMQPBridgeSenderInfo senderInfo;
+
+      AMQPBridgeQueueSenderManager(AMQPBridgeToQueuePolicyManager manager, AMQPBridgeSenderConfiguration configuration, AMQPBridgeSenderInfo senderInfo) {
+         super(manager, configuration);
+
+         this.manager = manager;
+         this.senderInfo = senderInfo;
+      }
+
+      @Override
+      protected AMQPBridgeSender createBridgeSender() {
+         return manager.createBridgeSender(senderInfo);
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToQueueSender.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToQueueSender.java
@@ -1,0 +1,247 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.AMQP_LINK_INITIALIZER_KEY;
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.AddressQueryResult;
+import org.apache.activemq.artemis.core.server.QueueQueryResult;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.SenderMetrics;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPInternalErrorException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPNotFoundException;
+import org.apache.activemq.artemis.protocol.amqp.logger.ActiveMQAMQPProtocolMessageBundle;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.SenderController;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.messaging.Target;
+import org.apache.qpid.proton.amqp.messaging.TerminusDurability;
+import org.apache.qpid.proton.amqp.messaging.TerminusExpiryPolicy;
+import org.apache.qpid.proton.amqp.transport.ReceiverSettleMode;
+import org.apache.qpid.proton.amqp.transport.SenderSettleMode;
+import org.apache.qpid.proton.engine.Sender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Sender type that handles sending messages sent to a local queue to a remote AMQP peer.
+ */
+public class AMQPBridgeToQueueSender extends AMQPBridgeSender {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public AMQPBridgeToQueueSender(AMQPBridgeToPolicyManager policyManager,
+                                  AMQPBridgeSenderConfiguration configuration,
+                                  AMQPSessionContext session,
+                                  AMQPBridgeSenderInfo senderInfo,
+                                  SenderMetrics metrics) {
+      super(policyManager, configuration, session, senderInfo, metrics);
+   }
+
+   @Override
+   public AMQPBridgeQueuePolicy getPolicy() {
+      return (AMQPBridgeQueuePolicy) policy;
+   }
+
+   @Override
+   protected void doCreateSender() {
+      try {
+         final Sender protonSender = session.getSession().sender(generateLinkName());
+         final Target target = new Target();
+         final Source source = new Source();
+         final String address = senderInfo.getRemoteAddress();
+
+         source.setAddress(senderInfo.getLocalFqqn());
+
+         target.setAddress(address);
+         target.setDurable(TerminusDurability.NONE);
+         target.setExpiryPolicy(TerminusExpiryPolicy.LINK_DETACH);
+         target.setCapabilities(getRemoteTerminusCapabilities());
+
+         protonSender.setSenderSettleMode(configuration.isUsingPresettledSenders() ? SenderSettleMode.SETTLED : SenderSettleMode.UNSETTLED);
+         protonSender.setReceiverSettleMode(ReceiverSettleMode.FIRST);
+         // If enabled indicate that core tunneling is desired which we prefer to AMQP conversions of core as
+         // the large ones will be converted to standard AMQP messages in memory. If the remote does not offer
+         // the capability in return we cannot use core tunneling which we will check when the remote attach
+         // response arrives and we complete the link attach.
+         if (configuration.isCoreMessageTunnelingEnabled()) {
+            protonSender.setDesiredCapabilities(new Symbol[] {AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT});
+         }
+         protonSender.setTarget(target);
+         protonSender.setSource(source);
+         protonSender.open();
+
+         final ScheduledFuture<?> openTimeoutTask;
+         final AtomicBoolean openTimedOut = new AtomicBoolean(false);
+
+         if (configuration.getLinkAttachTimeout() > 0) {
+            openTimeoutTask = bridgeManager.getServer().getScheduledPool().schedule(() -> {
+               openTimedOut.set(true);
+               bridgeManager.signalResourceCreateError(ActiveMQAMQPProtocolMessageBundle.BUNDLE.brokerConnectionTimeout());
+            }, configuration.getLinkAttachTimeout(), TimeUnit.SECONDS);
+         } else {
+            openTimeoutTask = null;
+         }
+
+         this.protonSender = protonSender;
+
+         protonSender.attachments().set(AMQP_LINK_INITIALIZER_KEY, Runnable.class, () -> {
+            try {
+               if (openTimeoutTask != null) {
+                  openTimeoutTask.cancel(false);
+               }
+
+               if (openTimedOut.get()) {
+                  return;
+               }
+
+               final boolean linkOpened = protonSender.getRemoteTarget() != null;
+
+               if (linkOpened) {
+                  logger.debug("AMQP Bridge {} queue senderContext {} completed open", bridgeManager.getName(), senderInfo);
+               } else {
+                  logger.debug("AMQP Bridge {} queue senderContext {} rejected by remote", bridgeManager.getName(), senderInfo);
+               }
+
+               // Intercept remote close and check for valid reasons for remote closure such as
+               // the remote peer not having a matching node for this subscription or from an
+               // operator manually closing the link etc.
+               bridgeManager.addLinkClosedInterceptor(senderInfo.getId(), this::remoteLinkClosedInterceptor);
+
+               final AMQPBridgeToQueueSenderController senderController =
+                  new AMQPBridgeToQueueSenderController(senderInfo, getPolicyManager(), session, metrics);
+
+               senderContext = new AMQPBridgeQueueSenderContext(
+                  connection, protonSender, session, session.getSessionSPI(), senderController);
+
+               session.addSender(protonSender, senderContext);
+
+               if (linkOpened && remoteOpenHandler != null) {
+                  remoteOpenHandler.accept(this);
+               }
+
+            } catch (Exception e) {
+               bridgeManager.signalError(e);
+            }
+         });
+      } catch (Exception e) {
+         bridgeManager.signalError(e);
+      }
+
+      connection.flush();
+   }
+
+   private String generateLinkName() {
+      return "amqp-bridge-" + bridgeManager.getName() +
+             "-policy-" + policy.getPolicyName() +
+             "-queue-sender-" + senderInfo.getRemoteAddress() +
+             "-" + bridgeManager.getServer().getNodeID() +
+             "-" + LINK_SEQUENCE_ID.incrementAndGet();
+   }
+
+   private class AMQPBridgeQueueSenderContext extends ProtonServerSenderContext {
+
+      AMQPBridgeQueueSenderContext(AMQPConnectionContext connection, Sender sender,
+                                   AMQPSessionContext protonSession, AMQPSessionCallback server,
+                                   SenderController senderController) {
+         super(connection, sender, protonSession, server, senderController);
+      }
+
+      @Override
+      public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
+         super.close(remoteLinkClose);
+
+         if (remoteLinkClose && remoteCloseHandler != null) {
+            try {
+               remoteCloseHandler.accept(AMQPBridgeToQueueSender.this);
+            } catch (Exception e) {
+               logger.debug("User remote closed handler threw error: ", e);
+            } finally {
+               remoteCloseHandler = null;
+            }
+         }
+      }
+   }
+
+   public static class AMQPBridgeToQueueSenderController extends AMQPBridgeToSenderController {
+
+      private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+      public AMQPBridgeToQueueSenderController(AMQPBridgeSenderInfo senderInfo, AMQPBridgeToPolicyManager policyManager, AMQPSessionContext session, SenderMetrics metrics) throws ActiveMQAMQPException {
+         super(senderInfo, policyManager, session, metrics);
+      }
+
+      @Override
+      public SenderRole getRole() {
+         return SenderRole.QUEUE_SENDER;
+      }
+
+      public AMQPBridgeQueuePolicy getPolicy() {
+         return (AMQPBridgeQueuePolicy) policy;
+      }
+
+      @Override
+      protected ServerConsumer createServerConsumer(ProtonServerSenderContext senderContext) throws Exception {
+         final AMQPSessionCallback sessionSPI = session.getSessionSPI();
+         final SimpleString address = SimpleString.of(senderInfo.getLocalAddress());
+         final SimpleString queue = SimpleString.of(senderInfo.getLocalQueue());
+         final RoutingType expectedRoutingType = senderInfo.getRoutingType();
+         final AMQPBridgeQueuePolicy policy = getPolicy();
+
+         try {
+            final AddressQueryResult addressResult = sessionSPI.addressQuery(address, expectedRoutingType, false);
+
+            // We initiated this link so the settings should refer to an address that definitely exists
+            // however there is a chance the address was removed in the interim.
+            if (!addressResult.isExists()) {
+               throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist(address.toString());
+            }
+
+            final QueueQueryResult queueResult = sessionSPI.queueQuery(queue, expectedRoutingType, false);
+
+            // We initiated this link so the settings should refer to an queue that definitely exists
+            // however there is a chance the address was removed in the interim.
+            if (!queueResult.isExists()) {
+               throw ActiveMQAMQPProtocolMessageBundle.BUNDLE.addressDoesntExist(queue.toString());
+            }
+         } catch (ActiveMQAMQPNotFoundException e) {
+            throw e;
+         } catch (Exception e) {
+            logger.debug(e.getMessage(), e);
+            throw new ActiveMQAMQPInternalErrorException(e.getMessage(), e);
+         }
+
+         final int priority = policy.getPriority() != null ?
+            policy.getPriority() : ActiveMQDefaultConfiguration.getDefaultConsumerPriority() + policy.getPriorityAdjustment();
+
+         return sessionSPI.createSender(senderContext, queue, policy.getFilter(), false, priority);
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeToSenderController.java
@@ -1,0 +1,327 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.QUEUE_CAPABILITY;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.TOPIC_CAPABILITY;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.verifyCapabilities;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.verifyOfferedCapabilities;
+
+import java.lang.invoke.MethodHandles;
+import java.util.UUID;
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeMetrics.SenderMetrics;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPIllegalStateException;
+import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPNotImplementedException;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPLargeMessageWriter;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPMessageWriter;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledCoreLargeMessageWriter;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledCoreMessageWriter;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.protocol.amqp.proton.MessageWriter;
+import org.apache.activemq.artemis.protocol.amqp.proton.ProtonServerSenderContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.SenderController;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.messaging.Source;
+import org.apache.qpid.proton.amqp.transport.ErrorCondition;
+import org.apache.qpid.proton.engine.Sender;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A base class abstract {@link SenderController} implementation for use by bridge address and
+ * queue senders that provides some common functionality used between both.
+ */
+public abstract class AMQPBridgeToSenderController implements SenderController {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   public enum SenderRole {
+      /**
+       * Producer created from a remote server based on a match for configured address bridge policy.
+       */
+      ADDRESS_SENDER,
+
+      /**
+       * Producer created from a remote server based on a match for configured queue bridge policy.
+       */
+      QUEUE_SENDER
+   }
+
+   protected final AMQPBridgeToPolicyManager policyManager;
+   protected final AMQPBridgePolicy policy;
+   protected final AMQPBridgeSenderInfo senderInfo;
+   protected final AMQPSessionContext session;
+   protected final AMQPSessionCallback sessionSPI;
+   protected final AMQPBridgeManager bridgeManager;
+   protected final SenderMetrics metrics;
+   protected final String controllerId = UUID.randomUUID().toString();
+
+   protected MessageWriter standardMessageWriter;
+   protected MessageWriter largeMessageWriter;
+   protected MessageWriter coreMessageWriter;
+   protected MessageWriter coreLargeMessageWriter;
+   protected ProtonServerSenderContext senderContext;
+   protected ServerConsumer serverConsumer;
+
+   protected boolean tunnelCoreMessages; // only enabled if remote offers support.
+
+   public AMQPBridgeToSenderController(AMQPBridgeSenderInfo senderInfo, AMQPBridgeToPolicyManager policyManager, AMQPSessionContext session, SenderMetrics metrics) throws ActiveMQAMQPException {
+      this.senderInfo = senderInfo;
+      this.policyManager = policyManager;
+      this.policy = policyManager.getPolicy();
+      this.bridgeManager = policyManager.getBridgeManager();
+      this.metrics = metrics;
+      this.session = session;
+      this.sessionSPI = session.getSessionSPI();
+   }
+
+   /**
+    * {@return an enumeration describing the role of the sender controller implementation}
+    */
+   public abstract SenderRole getRole();
+
+   public final long getMessagesSent() {
+      return metrics.getMessagesSent();
+   }
+
+   public final ActiveMQServer getServer() {
+      return session.getServer();
+   }
+
+   public final AMQPBridgeSenderInfo getSenderInfo() {
+      return senderInfo;
+   }
+
+   public final ProtonServerSenderContext getSenderContext() {
+      return senderContext;
+   }
+
+   public final ServerConsumer getServerConsumer() {
+      return serverConsumer;
+   }
+
+   public final AMQPSessionContext getSessionContext() {
+      return session;
+   }
+
+   public final AMQPSessionCallback getSessionCallback() {
+      return sessionSPI;
+   }
+
+   public final AMQPBridgeManager getBridgeManager() {
+      return bridgeManager;
+   }
+
+   public final AMQPBridgeToPolicyManager getPolicyManager() {
+      return policyManager;
+   }
+
+   @Override
+   public final ServerConsumer init(ProtonServerSenderContext senderContext) throws Exception {
+      final Sender sender = senderContext.getSender();
+      final Source source = (Source) sender.getRemoteSource();
+
+      if (bridgeManager == null) {
+         throw new ActiveMQAMQPIllegalStateException("Cannot create a bridge link from non-bridge connection");
+      }
+
+      if (source == null) {
+         throw new ActiveMQAMQPNotImplementedException("Null source lookup not supported on bridge links.");
+      }
+
+      this.senderContext = senderContext;
+
+      // We need to check that the remote offers ability to read tunneled core messages and also
+      // check if we offered it which we might not based on configuration. If neither of those is
+      // true then we cannot send messages as tunneled core messages and instead convert all of
+      // the outbound messages to AMQP versions.
+      tunnelCoreMessages = verifyOfferedCapabilities(sender, AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT) &&
+                           verifyCapabilities(sender.getDesiredCapabilities(), AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT);
+
+      serverConsumer = createServerConsumer(senderContext);
+
+      registerSenderManagement();
+
+      return serverConsumer;
+   }
+
+   /**
+    * The subclass must implement this and create an appropriately configured server consumer
+    * based on the properties of the AMQP link and the role of the implemented sender type.
+    *
+    * @param senderContext
+    *    The server sender context that this controller was created for.
+    *
+    * @return a new {@link ServerConsumer} instance that will send messages to the remote peer.
+    *
+    * @throws Exception if an error occurs while creating the server consumer.
+    */
+   protected abstract ServerConsumer createServerConsumer(ProtonServerSenderContext senderContext) throws Exception;
+
+   @Override
+   public final void close(boolean remoteClose) throws Exception {
+      try {
+         if (bridgeManager != null) {
+            bridgeManager.removeLinkClosedInterceptor(controllerId);
+         }
+      } finally {
+         unregisterSenderManagement();
+         if (remoteClose) {
+            handleLinkRemotelyClosed();
+         } else {
+            handleLinkLocallyClosed(null);
+         }
+      }
+   }
+
+   /**
+    * Subclasses should react to link remote close by cleaning up any resources
+    */
+   protected void handleLinkRemotelyClosed() {
+      // default implementation does nothing
+   }
+
+   @Override
+   public final void close(ErrorCondition error) {
+      try {
+         if (bridgeManager != null) {
+            bridgeManager.removeLinkClosedInterceptor(controllerId);
+         }
+      } finally {
+         unregisterSenderManagement();
+         handleLinkLocallyClosed(error);
+      }
+   }
+
+   /**
+    * Subclasses should react to link local close by cleaning up resources.
+    *
+    * @param error
+    *       The error that triggered the local close or null if no error.
+    */
+   protected void handleLinkLocallyClosed(ErrorCondition error) {
+      // default implementation does nothing
+   }
+
+   private void registerSenderManagement() {
+      try {
+         AMQPBridgeManagementSupport.registerBridgeSender(this);
+      } catch (Exception e) {
+         logger.trace("Ignored exception while adding sender to management: ", e);
+      }
+   }
+
+   private void unregisterSenderManagement() {
+      try {
+         AMQPBridgeManagementSupport.unregisterBridgeSender(this);
+      } catch (Exception e) {
+         logger.trace("Ignored exception while removing sender from management: ", e);
+      }
+   }
+
+   @Override
+   public final MessageWriter selectOutgoingMessageWriter(ProtonServerSenderContext sender, MessageReference reference) {
+      final MessageWriter selected;
+      final Message message = reference.getMessage();
+
+      if (message instanceof AMQPMessage) {
+         if (message.isLargeMessage()) {
+            selected = largeMessageWriter != null ? largeMessageWriter :
+               (largeMessageWriter = new CountedMessageWrites(new AMQPLargeMessageWriter(sender), metrics));
+         } else {
+            selected = standardMessageWriter != null ? standardMessageWriter :
+               (standardMessageWriter = new CountedMessageWrites(new AMQPMessageWriter(sender), metrics));
+         }
+      } else if (tunnelCoreMessages) {
+         if (message.isLargeMessage()) {
+            selected = coreLargeMessageWriter != null ? coreLargeMessageWriter :
+               (coreLargeMessageWriter = new CountedMessageWrites(new AMQPTunneledCoreLargeMessageWriter(sender), metrics));
+         } else {
+            selected = coreMessageWriter != null ? coreMessageWriter :
+               (coreMessageWriter = new CountedMessageWrites(new AMQPTunneledCoreMessageWriter(sender), metrics));
+         }
+      } else {
+         selected = standardMessageWriter != null ? standardMessageWriter :
+            (standardMessageWriter = new CountedMessageWrites(new AMQPMessageWriter(sender), metrics));
+      }
+
+      return selected;
+   }
+
+   protected static RoutingType getRoutingType(Source source) {
+      if (source != null) {
+         if (source.getCapabilities() != null) {
+            for (Symbol capability : source.getCapabilities()) {
+               if (TOPIC_CAPABILITY.equals(capability)) {
+                  return RoutingType.MULTICAST;
+               } else if (QUEUE_CAPABILITY.equals(capability)) {
+                  return RoutingType.ANYCAST;
+               }
+            }
+         }
+      }
+
+      return ActiveMQDefaultConfiguration.getDefaultRoutingType();
+   }
+
+   private static class CountedMessageWrites implements MessageWriter {
+
+      private final MessageWriter wrapped;
+      private final SenderMetrics metrics;
+
+      CountedMessageWrites(MessageWriter wrapped, SenderMetrics metrics) {
+         this.wrapped = wrapped;
+         this.metrics = metrics;
+      }
+
+      @Override
+      public void close() {
+         wrapped.close();
+      }
+
+      @Override
+      public MessageWriter open(MessageReference reference) {
+         wrapped.open(reference);
+         return this;
+      }
+
+      @Override
+      public boolean isWriting() {
+         return wrapped.isWriting();
+      }
+
+      @Override
+      public void writeBytes(MessageReference messageReference) {
+         try {
+            wrapped.writeBytes(messageReference);
+         } finally {
+            metrics.incrementMessagesSent();
+         }
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeType.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeType.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.protocol.amqp.connect.bridge;
+
+/**
+ * Enumeration that defines the type of AMQP bridging a given policy manager implements
+ */
+public enum AMQPBridgeType {
+
+   /**
+    * Indicates a resource that is handling bridging from a remote address
+    */
+   BRIDGE_FROM_ADDRESS("bridge-from-address"),
+
+   /**
+    * Indicates a resource that is handling bridging to a remote address
+    */
+   BRIDGE_TO_ADDRESS("bridge-to-address"),
+
+   /**
+    * Indicates a resource that is handling bridging from a remote queue
+    */
+   BRIDGE_FROM_QUEUE("bridge-from-queue"),
+
+   /**
+    * Indicates a resource that is handling bridging to a remote queue
+    */
+   BRIDGE_TO_QUEUE("bridge-to-queue");
+
+   private final String typeName;
+
+   AMQPBridgeType(String typeName) {
+      this.typeName = typeName;
+   }
+
+   @Override
+   public String toString() {
+      return typeName;
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -451,15 +451,6 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
          return;
       }
 
-      // We need to check if the remote desires to send us tunneled core messages or not, and if
-      // we support that we need to offer that back so it knows it can actually do core tunneling.
-      if (verifyDesiredCapability(receiver, AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT)) {
-         receiver.setOfferedCapabilities(new Symbol[] {AMQPMirrorControllerSource.MIRROR_CAPABILITY,
-                                                       AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT});
-      } else {
-         receiver.setOfferedCapabilities(new Symbol[]{AMQPMirrorControllerSource.MIRROR_CAPABILITY});
-      }
-
       protonSession.addReplicaTarget(receiver);
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -21,7 +21,6 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_NAME;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_POLICY_NAME;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
@@ -41,7 +40,6 @@ import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederati
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationRemoteAddressPolicyManager;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationRemoteQueuePolicyManager;
 import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationTarget;
-import org.apache.activemq.artemis.protocol.amqp.connect.mirror.AMQPMirrorControllerSource;
 import org.apache.activemq.artemis.protocol.amqp.connect.mirror.AMQPMirrorControllerTarget;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPSessionCallback;
 import org.apache.activemq.artemis.protocol.amqp.client.ProtonClientSenderContext;
@@ -391,10 +389,6 @@ public class AMQPSessionContext extends ProtonInitializable {
       addReceiver(receiver, (r, s) -> {
          final AMQPMirrorControllerTarget protonReceiver =
             new AMQPMirrorControllerTarget(sessionSPI, connection, this, receiver, server);
-
-         final HashMap<Symbol, Object> brokerIDProperties = new HashMap<>();
-         brokerIDProperties.put(AMQPMirrorControllerSource.BROKER_ID, server.getNodeID().toString());
-         receiver.setProperties(brokerIDProperties);
 
          return protonReceiver;
       });

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
@@ -108,9 +108,10 @@ public class AmqpSupport {
    public static final Symbol CORE_MESSAGE_TUNNELING_SUPPORT = Symbol.getSymbol("AMQ_CORE_MESSAGE_TUNNELING");
 
    /**
-    * Property value that can be applied to federation configuration that controls if the federation receivers will
-    * request that the sender peer tunnel core messages inside an AMQP message as a binary blob to be unwrapped on the
-    * other side. The sending peer would still need to support this feature for message tunneling to occur.
+    * Property value that can be applied to federation and bridge configurations that controls if the various links
+    * will request that the opposing peers link tunnel core messages inside an AMQP message as a binary blob to be
+    * unwrapped on the other side. The sending peer would still need to support this feature for message tunneling to
+    * occur.
     */
    public static final String TUNNEL_CORE_MESSAGES = "tunnel-core-messages";
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.protocol.amqp.proton;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
@@ -138,11 +139,23 @@ public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
             }
          }
 
-         Symbol[] remoteDesiredCapabilities = receiver.getRemoteDesiredCapabilities();
+         final Symbol[] remoteDesiredCapabilities = receiver.getRemoteDesiredCapabilities();
+
          if (remoteDesiredCapabilities != null) {
-            List<Symbol> list = Arrays.asList(remoteDesiredCapabilities);
-            if (list.contains(AmqpSupport.DELAYED_DELIVERY)) {
-               receiver.setOfferedCapabilities(new Symbol[]{AmqpSupport.DELAYED_DELIVERY});
+            final List<Symbol> offeredCapabilities = new ArrayList<>();
+
+            final Symbol[] desiredCapabilities = remoteDesiredCapabilities;
+            for (Symbol desired : desiredCapabilities) {
+               if (AmqpSupport.DELAYED_DELIVERY.equals(desired)) {
+                  offeredCapabilities.add(AmqpSupport.DELAYED_DELIVERY);
+               } else if (AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT.equals(desired)) {
+                  offeredCapabilities.add(AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT);
+                  enableCoreTunneling();
+               }
+            }
+
+            if (!offeredCapabilities.isEmpty()) {
+               receiver.setOfferedCapabilities(offeredCapabilities.toArray(new Symbol[0]));
             }
          }
       }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerSenderContext.java
@@ -259,7 +259,9 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
             sender.close();
             controller.close(condition);
             try {
-               sessionSPI.closeSender(brokerConsumer);
+               if (brokerConsumer != null) {
+                  sessionSPI.closeSender(brokerConsumer);
+               }
             } catch (Exception e) {
                logger.warn(e.getMessage(), e);
             } finally {
@@ -282,7 +284,9 @@ public class ProtonServerSenderContext extends ProtonInitializable implements Pr
          connection.runLater(() -> {
             try {
                protonSession.removeSender(sender);
-               sessionSPI.closeSender(brokerConsumer);
+               if (brokerConsumer != null) {
+                  sessionSPI.closeSender(brokerConsumer);
+               }
                // if this is a link close rather than a connection close or detach, we need to delete
                // any durable resources for say pub subs
                controller.close(remoteLinkClose);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeAddressPolicyElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeAddressPolicyElement.java
@@ -1,0 +1,280 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.amqpBrokerConnectivity;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+
+public final class AMQPBridgeAddressPolicyElement implements Serializable {
+
+   private static final long serialVersionUID = 6515270736587053708L;
+
+   private final Set<AddressMatch> includes = new HashSet<>();
+   private final Set<AddressMatch> excludes = new HashSet<>();
+   private final Map<String, Object> properties = new HashMap<>();
+
+   private String name;
+   private String remoteAddress;
+   private String remoteAddressPrefix;
+   private String remoteAddressSuffix;
+   private String[] remoteTerminusCapabilities;
+   private boolean includeDivertBindings;
+   private Integer priority;
+   private String filter;
+   private TransformerConfiguration transformerConfig;
+
+   public String getName() {
+      return name;
+   }
+
+   public AMQPBridgeAddressPolicyElement setName(String name) {
+      this.name = name;
+      return this;
+   }
+
+   public Set<AddressMatch> getIncludes() {
+      return includes;
+   }
+
+   public AMQPBridgeAddressPolicyElement addToIncludes(String include) {
+      includes.add(new AddressMatch().setAddressMatch(include));
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement addInclude(AddressMatch include) {
+      includes.add(include);
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement setIncludes(Set<AddressMatch> includes) {
+      this.includes.clear();
+      if (includes != null) {
+         this.includes.addAll(includes);
+      }
+
+      return this;
+   }
+
+   public Set<AddressMatch> getExcludes() {
+      return excludes;
+   }
+
+   public AMQPBridgeAddressPolicyElement addToExcludes(String exclude) {
+      excludes.add(new AddressMatch().setAddressMatch(exclude));
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement addExclude(AddressMatch exclude) {
+      excludes.add(exclude);
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement setExcludes(Set<AddressMatch> excludes) {
+      this.excludes.clear();
+      if (excludes != null) {
+         this.excludes.addAll(excludes);
+      }
+
+      return this;
+   }
+
+   public Map<String, Object> getProperties() {
+      return properties;
+   }
+
+   public AMQPBridgeAddressPolicyElement addProperty(String key, String value) {
+      properties.put(key, value);
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement addProperty(String key, Number value) {
+      properties.put(key, value);
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement setProperties(Map<String, Object> properties) {
+      this.properties.clear();
+      if (properties != null) {
+         this.properties.putAll(properties);
+      }
+
+      return this;
+   }
+
+   public boolean isIncludeDivertBindings() {
+      return includeDivertBindings;
+   }
+
+   public AMQPBridgeAddressPolicyElement setIncludeDivertBindings(boolean includeDivertBindings) {
+      this.includeDivertBindings = includeDivertBindings;
+      return this;
+   }
+
+   public AMQPBridgeAddressPolicyElement setTransformerConfiguration(TransformerConfiguration transformerConfig) {
+      this.transformerConfig = transformerConfig;
+      return this;
+   }
+
+   public TransformerConfiguration getTransformerConfiguration() {
+      return transformerConfig;
+   }
+
+   public String getRemoteAddress() {
+      return remoteAddress;
+   }
+
+   public AMQPBridgeAddressPolicyElement setRemoteAddress(String remoteAddress) {
+      this.remoteAddress = remoteAddress;
+      return this;
+   }
+
+   public String getRemoteAddressPrefix() {
+      return remoteAddressPrefix;
+   }
+
+   public AMQPBridgeAddressPolicyElement setRemoteAddressPrefix(String remoteAddressPrefix) {
+      this.remoteAddressPrefix = remoteAddressPrefix;
+      return this;
+   }
+
+   public String getRemoteAddressSuffix() {
+      return remoteAddressSuffix;
+   }
+
+   public AMQPBridgeAddressPolicyElement setRemoteAddressSuffix(String remoteAddressSuffix) {
+      this.remoteAddressSuffix = remoteAddressSuffix;
+      return this;
+   }
+
+   public String[] getRemoteTerminusCapabilities() {
+      if (remoteTerminusCapabilities != null) {
+         return Arrays.copyOf(remoteTerminusCapabilities, remoteTerminusCapabilities.length);
+      } else {
+         return null;
+      }
+   }
+
+   public AMQPBridgeAddressPolicyElement setRemoteTerminusCapabilities(String[] remoteTerminusCapabilities) {
+      this.remoteTerminusCapabilities = remoteTerminusCapabilities;
+      return this;
+   }
+
+   public Integer getPriority() {
+      return priority;
+   }
+
+   public AMQPBridgeAddressPolicyElement setPriority(Integer priority) {
+      this.priority = priority;
+      return this;
+   }
+
+   public String getFilter() {
+      return filter;
+   }
+
+   public AMQPBridgeAddressPolicyElement setFilter(String filter) {
+      this.filter = filter;
+      return this;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (!(o instanceof AMQPBridgeAddressPolicyElement)) {
+         return false;
+      }
+
+      final AMQPBridgeAddressPolicyElement that = (AMQPBridgeAddressPolicyElement) o;
+
+      return Objects.equals(name, that.name) &&
+             Objects.equals(includes, that.includes) &&
+             Objects.equals(excludes, that.excludes) &&
+             Objects.equals(priority, that.priority) &&
+             Objects.equals(filter, that.filter) &&
+             Objects.equals(remoteAddress, that.remoteAddress) &&
+             Objects.equals(remoteAddressPrefix, that.remoteAddressPrefix) &&
+             Objects.equals(remoteAddressSuffix, that.remoteAddressSuffix) &&
+             Arrays.equals(remoteTerminusCapabilities, that.remoteTerminusCapabilities);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, includes, excludes, filter, priority, remoteAddress, remoteAddressPrefix, remoteAddressSuffix) +
+             Arrays.hashCode(remoteTerminusCapabilities);
+   }
+
+   // We are required to implement a named match type so that we can perform this configuration
+   // from the broker properties mechanism where there is no means of customizing the property
+   // set to parse address and queue names from some string encoded value. This could be simplified
+   // at some point if another configuration mechanism is created. The name value is not used
+   // internally in the AMQP bridge implementation.
+
+   public static class AddressMatch implements Serializable {
+
+      private static final long serialVersionUID = 8517154638045698017L;
+
+      private String name;
+      private String addressMatch;
+
+      public String getName() {
+         return name;
+      }
+
+      public AddressMatch setName(String name) {
+         this.name = name;
+         return this;
+      }
+
+      public String getAddressMatch() {
+         return addressMatch;
+      }
+
+      public AddressMatch setAddressMatch(String addressMatch) {
+         this.addressMatch = addressMatch;
+         return this;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) {
+            return true;
+         }
+
+         if (!(o instanceof AddressMatch)) {
+            return false;
+         }
+
+         final AddressMatch matcher = (AddressMatch) o;
+
+         return Objects.equals(addressMatch, matcher.addressMatch);
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(addressMatch, addressMatch);
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeBrokerConnectionElement.java
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.config.amqpBrokerConnectivity;
+
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+/**
+ * Configuration for broker AMQP message bridge policy managed by a broker connection.
+ */
+public class AMQPBridgeBrokerConnectionElement extends AMQPBrokerConnectionElement {
+
+   private static final long serialVersionUID = 2519807622833191168L;
+
+   private Set<AMQPBridgeAddressPolicyElement> bridgeFromAddressPolicies = new HashSet<>();
+   private Set<AMQPBridgeQueuePolicyElement> bridgeFromQueuePolicies = new HashSet<>();
+
+   private Set<AMQPBridgeAddressPolicyElement> bridgeToAddressPolicies = new HashSet<>();
+   private Set<AMQPBridgeQueuePolicyElement> bridgeToQueuePolicies = new HashSet<>();
+
+   private Map<String, Object> properties = new HashMap<>();
+
+   public AMQPBridgeBrokerConnectionElement() {
+      this.setType(AMQPBrokerConnectionAddressType.BRIDGE);
+   }
+
+   public AMQPBridgeBrokerConnectionElement(String name) {
+      this.setType(AMQPBrokerConnectionAddressType.BRIDGE);
+      this.setName(name);
+   }
+
+   @Override
+   public AMQPBridgeBrokerConnectionElement setType(AMQPBrokerConnectionAddressType type) {
+      if (AMQPBrokerConnectionAddressType.BRIDGE.equals(type)) {
+         return (AMQPBridgeBrokerConnectionElement) super.setType(type);
+      } else {
+         throw new IllegalArgumentException("Cannot change a BRIDGE connection element to type: " + type);
+      }
+   }
+
+   /**
+    * @return the configured bridge from address policy set
+    */
+   public Set<AMQPBridgeAddressPolicyElement> getBridgeFromAddressPolicies() {
+      return bridgeFromAddressPolicies;
+   }
+
+   /**
+    * @param fromAddressPolicy
+    *       the policy to add to the set of bridge from address policies set
+    *
+    * @return this configuration element instance.
+    */
+   public AMQPBridgeBrokerConnectionElement addBridgeFromAddressPolicy(AMQPBridgeAddressPolicyElement fromAddressPolicy) {
+      this.bridgeFromAddressPolicies.add(fromAddressPolicy);
+      return this;
+   }
+
+   /**
+    * @return the configured bridge to address policy set
+    */
+   public Set<AMQPBridgeAddressPolicyElement> getBridgeToAddressPolicies() {
+      return bridgeToAddressPolicies;
+   }
+
+   /**
+    * @param toAddressPolicy
+    *       the policy to add to the set of bridge to address policies set
+    *
+    * @return this configuration element instance.
+    */
+   public AMQPBridgeBrokerConnectionElement addBridgeToAddressPolicy(AMQPBridgeAddressPolicyElement toAddressPolicy) {
+      this.bridgeToAddressPolicies.add(toAddressPolicy);
+      return this;
+   }
+
+   /**
+    * @return the configured bridge from queue policy set
+    */
+   public Set<AMQPBridgeQueuePolicyElement> getBridgeFromQueuePolicies() {
+      return bridgeFromQueuePolicies;
+   }
+
+   /**
+    * @param fromQueuePolicy
+    *       the policy to add to the set of bridge from queue policies set
+    *
+    * @return this configuration element instance.
+    */
+   public AMQPBridgeBrokerConnectionElement addBridgeFromQueuePolicy(AMQPBridgeQueuePolicyElement fromQueuePolicy) {
+      this.bridgeFromQueuePolicies.add(fromQueuePolicy);
+      return this;
+   }
+
+   /**
+    * @return the configured bridge to queue policy set
+    */
+   public Set<AMQPBridgeQueuePolicyElement> getBridgeToQueuePolicies() {
+      return bridgeToQueuePolicies;
+   }
+
+   /**
+    * @param toQueuePolicy
+    *       the policy to add to the set of bridge to queue policies set
+    *
+    * @return this configuration element instance.
+    */
+   public AMQPBridgeBrokerConnectionElement addBridgeToQueuePolicy(AMQPBridgeQueuePolicyElement toQueuePolicy) {
+      this.bridgeToQueuePolicies.add(toQueuePolicy);
+      return this;
+   }
+   /**
+    * Adds the given property key and value to the bridge configuration element.
+    *
+    * @param key
+    *    The key that identifies the property
+    * @param value
+    *    The value associated with the property key.
+    *
+    * @return this configuration element instance.
+    */
+   public AMQPBridgeBrokerConnectionElement addProperty(String key, String value) {
+      properties.put(key, value);
+      return this;
+   }
+
+   /**
+    * Adds the given property key and value to the bridge configuration element.
+    *
+    * @param key
+    *    The key that identifies the property
+    * @param value
+    *    The value associated with the property key.
+    *
+    * @return this configuration element instance.
+    */
+   public AMQPBridgeBrokerConnectionElement addProperty(String key, Number value) {
+      properties.put(key, value);
+      return this;
+   }
+
+   /**
+    * @return the collection of configuration properties associated with this bridge element.
+    */
+   public Map<String, Object> getProperties() {
+      return properties;
+   }
+
+   @Override
+   public int hashCode() {
+      final int prime = 31;
+      int result = super.hashCode();
+      result = prime * result + Objects.hash(bridgeFromAddressPolicies, bridgeFromQueuePolicies, properties, bridgeToAddressPolicies, bridgeToQueuePolicies);
+
+      return result;
+   }
+
+   @Override
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+
+      if (!super.equals(obj)) {
+         return false;
+      }
+
+      if (getClass() != obj.getClass()) {
+         return false;
+      }
+
+      final AMQPBridgeBrokerConnectionElement other = (AMQPBridgeBrokerConnectionElement) obj;
+
+      return Objects.equals(bridgeFromAddressPolicies, other.bridgeFromAddressPolicies) &&
+             Objects.equals(bridgeFromQueuePolicies, other.bridgeFromQueuePolicies) &&
+             Objects.equals(properties, other.properties) &&
+             Objects.equals(bridgeToAddressPolicies, other.bridgeToAddressPolicies) &&
+             Objects.equals(bridgeToQueuePolicies, other.bridgeToQueuePolicies);
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeQueuePolicyElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeQueuePolicyElement.java
@@ -1,0 +1,291 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.config.amqpBrokerConnectivity;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+
+public final class AMQPBridgeQueuePolicyElement implements Serializable {
+
+   private static final long serialVersionUID = 226560733949177716L;
+
+   private final Set<QueueMatch> includes = new HashSet<>();
+   private final Set<QueueMatch> excludes = new HashSet<>();
+   private final Map<String, Object> properties = new HashMap<>();
+
+   private String name;
+   private String remoteAddress;
+   private String remoteAddressPrefix;
+   private String remoteAddressSuffix;
+   private String[] remoteTerminusCapabilities;
+   private Integer priority;
+   private Integer priorityAdjustment;
+   private String filter;
+   private TransformerConfiguration transformerConfig;
+
+   public String getName() {
+      return name;
+   }
+
+   public AMQPBridgeQueuePolicyElement setName(String name) {
+      this.name = name;
+      return this;
+   }
+
+   public Set<QueueMatch> getIncludes() {
+      return includes;
+   }
+
+   public AMQPBridgeQueuePolicyElement addToIncludes(String addressMatch, String queueMatch) {
+      includes.add(new QueueMatch().setAddressMatch(addressMatch).setQueueMatch(queueMatch));
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement addInclude(QueueMatch match) {
+      includes.add(match);
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement setIncludes(Set<QueueMatch> includes) {
+      this.includes.clear();
+      if (includes != null) {
+         this.includes.addAll(includes);
+      }
+
+      return this;
+   }
+
+   public Set<QueueMatch> getExcludes() {
+      return excludes;
+   }
+
+   public AMQPBridgeQueuePolicyElement addExclude(QueueMatch match) {
+      excludes.add(match);
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement addToExcludes(String addressMatch, String queueMatch) {
+      excludes.add(new QueueMatch().setAddressMatch(addressMatch).setQueueMatch(queueMatch));
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement setExcludes(Set<QueueMatch> excludes) {
+      this.excludes.clear();
+      if (excludes != null) {
+         this.excludes.addAll(excludes);
+      }
+
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement addProperty(String key, String value) {
+      properties.put(key, value);
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement addProperty(String key, Number value) {
+      properties.put(key, value);
+      return this;
+   }
+
+   public Map<String, Object> getProperties() {
+      return properties;
+   }
+
+   public AMQPBridgeQueuePolicyElement setProperties(Map<String, Object> properties) {
+      this.properties.clear();
+      if (properties != null) {
+         this.properties.putAll(properties);
+      }
+
+      return this;
+   }
+
+   public AMQPBridgeQueuePolicyElement setTransformerConfiguration(TransformerConfiguration transformerConfig) {
+      this.transformerConfig = transformerConfig;
+      return this;
+   }
+
+   public TransformerConfiguration getTransformerConfiguration() {
+      return transformerConfig;
+   }
+
+   public String getRemoteAddress() {
+      return remoteAddress;
+   }
+
+   public AMQPBridgeQueuePolicyElement setRemoteAddress(String remoteAddress) {
+      this.remoteAddress = remoteAddress;
+      return this;
+   }
+
+   public String getRemoteAddressPrefix() {
+      return remoteAddressPrefix;
+   }
+
+   public AMQPBridgeQueuePolicyElement setRemoteAddressPrefix(String remoteAddressPrefix) {
+      this.remoteAddressPrefix = remoteAddressPrefix;
+      return this;
+   }
+
+   public String getRemoteAddressSuffix() {
+      return remoteAddressSuffix;
+   }
+
+   public AMQPBridgeQueuePolicyElement setRemoteAddressSuffix(String remoteAddressSuffix) {
+      this.remoteAddressSuffix = remoteAddressSuffix;
+      return this;
+   }
+
+   public String[] getRemoteTerminusCapabilities() {
+      if (remoteTerminusCapabilities != null) {
+         return Arrays.copyOf(remoteTerminusCapabilities, remoteTerminusCapabilities.length);
+      } else {
+         return null;
+      }
+   }
+
+   public AMQPBridgeQueuePolicyElement setRemoteTerminusCapabilities(String[] remoteTerminusCapabilities) {
+      this.remoteTerminusCapabilities = remoteTerminusCapabilities;
+      return this;
+   }
+
+   public Integer getPriority() {
+      return priority;
+   }
+
+   public AMQPBridgeQueuePolicyElement setPriority(Integer priority) {
+      this.priority = priority;
+      return this;
+   }
+
+   public Integer getPriorityAdjustment() {
+      return priorityAdjustment;
+   }
+
+   public AMQPBridgeQueuePolicyElement setPriorityAdjustment(Integer priorityAdjustment) {
+      this.priorityAdjustment = priorityAdjustment;
+      return this;
+   }
+
+   public String getFilter() {
+      return filter;
+   }
+
+   public AMQPBridgeQueuePolicyElement setFilter(String filter) {
+      this.filter = filter;
+      return this;
+   }
+
+   @Override
+   public boolean equals(Object o) {
+      if (this == o) {
+         return true;
+      }
+      if (!(o instanceof AMQPBridgeQueuePolicyElement)) {
+         return false;
+      }
+
+      final AMQPBridgeQueuePolicyElement that = (AMQPBridgeQueuePolicyElement) o;
+
+      return Objects.equals(name, that.name) &&
+             Objects.equals(includes, that.includes) &&
+             Objects.equals(excludes, that.excludes) &&
+             Objects.equals(priority, that.priority) &&
+             Objects.equals(priorityAdjustment, that.priorityAdjustment) &&
+             Objects.equals(filter, that.filter) &&
+             Objects.equals(remoteAddress, that.remoteAddress) &&
+             Objects.equals(remoteAddressPrefix, that.remoteAddressPrefix) &&
+             Arrays.equals(remoteTerminusCapabilities, that.remoteTerminusCapabilities);
+   }
+
+   @Override
+   public int hashCode() {
+      return Objects.hash(name, includes, excludes, priority, priorityAdjustment, filter, remoteAddress, remoteAddressPrefix) +
+             Arrays.hashCode(remoteTerminusCapabilities);
+   }
+
+   // We are required to implement a named match type so that we can perform this configuration
+   // from the broker properties mechanism where there is no means of customizing the property
+   // set to parse address and queue names from some string encoded value. This could be simplified
+   // at some point if another configuration mechanism is created. The name value is not used
+   // internally in the AMQP bridge implementation.
+
+   public static class QueueMatch implements Serializable {
+
+      private static final long serialVersionUID = -1641189627591828008L;
+
+      private String name;
+      private String addressMatch;
+      private String queueMatch;
+
+      public String getName() {
+         return name;
+      }
+
+      public QueueMatch setName(String name) {
+         this.name = name;
+         return this;
+      }
+
+      public String getAddressMatch() {
+         return addressMatch;
+      }
+
+      public QueueMatch setAddressMatch(String addressMatch) {
+         this.addressMatch = addressMatch;
+         return this;
+      }
+
+      public String getQueueMatch() {
+         return queueMatch;
+      }
+
+      public QueueMatch setQueueMatch(String queueMatch) {
+         this.queueMatch = queueMatch;
+         return this;
+      }
+
+      @Override
+      public boolean equals(Object o) {
+         if (this == o) {
+            return true;
+         }
+
+         if (!(o instanceof QueueMatch)) {
+            return false;
+         }
+
+         final QueueMatch matcher = (QueueMatch) o;
+
+         return Objects.equals(queueMatch, matcher.queueMatch) &&
+                Objects.equals(addressMatch, matcher.addressMatch);
+      }
+
+      @Override
+      public int hashCode() {
+         return Objects.hash(queueMatch, addressMatch);
+      }
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectConfiguration.java
@@ -75,6 +75,17 @@ public class AMQPBrokerConnectConfiguration extends BrokerConnectConfiguration {
       return connectionElements;
    }
 
+   public AMQPBrokerConnectConfiguration addBridge(AMQPBridgeBrokerConnectionElement amqpBridgeElement) {
+      return addElement(amqpBridgeElement);
+   }
+
+   public List<AMQPBrokerConnectionElement> getBridges() {
+      // This returns all elements not just bridge elements, broker properties relies on being able
+      // to modify the collection from the getter...it does not actually call the add method, it only
+      // uses the method to infer the type.
+      return connectionElements;
+   }
+
    public AMQPBrokerConnectConfiguration addMirror(AMQPMirrorBrokerConnectionElement amqpMirrorBrokerConnectionElement) {
       return addElement(amqpMirrorBrokerConnectionElement);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectionAddressType.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectionAddressType.java
@@ -17,5 +17,5 @@
 package org.apache.activemq.artemis.core.config.amqpBrokerConnectivity;
 
 public enum AMQPBrokerConnectionAddressType {
-   SENDER, RECEIVER, PEER, MIRROR, FEDERATION
+   SENDER, RECEIVER, PEER, MIRROR, FEDERATION, BRIDGE
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1500,4 +1500,8 @@ public interface ActiveMQServerLogger {
    @LogMessage(id = 224144, value = "The topology of the cluster connection {} doesn't include all th expected members. "
        + "Check the discovery group or the static connectors of the cluster connection if the topology is correct: {} / {}", level = LogMessage.Level.WARN)
    void incompleteClusterTopology(String clusterConnection, Topology topology, String topologyMembers);
+
+   @LogMessage(id = 224145, value = "Error looking up bindings for address {}.", level = LogMessage.Level.WARN)
+   void bridgeBindingsLookupError(SimpleString address, Throwable e);
+
 }

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -2189,6 +2189,7 @@
             <xsd:element name="peer" type="amqp-address-match-type"/>
             <xsd:element name="mirror" type="amqp-mirror-type"/>
             <xsd:element name="federation" type="amqp-federation-type"/>
+            <xsd:element name="bridge" type="amqp-bridge-type"/>
          </xsd:choice>
       </xsd:sequence>
       <xsd:attribute name="uri" type="xsd:string" use="required">
@@ -2419,6 +2420,194 @@
       <xsd:attribute name="name" type="xsd:ID" use="required" />
       <xsd:attribute name="enable-divert-bindings" type="xsd:boolean" use="optional" />
       <xsd:attributeGroup ref="xml:specialAttrs"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="amqp-bridge-type">
+      <xsd:annotation>
+         <xsd:documentation>
+            This creates a bridge between this broker and the remote AMQP peer that is being
+            connected to, bridging can occur from a remote resource to an address or queue on
+            the local broker, or to a remote resource from an address or queue on the local
+            broker depending on the policy assigned to the bridge configuration. The remote
+            need not be an Artemis broker simply any peer that support AMQP 1.0 as the wire
+            protocol.
+         </xsd:documentation>
+      </xsd:annotation>
+      <xsd:sequence minOccurs="1" maxOccurs="unbounded">
+         <xsd:choice maxOccurs="unbounded">
+            <xsd:element name="bridge-from-address" type="amqpBridgeAddressType" />
+            <xsd:element name="bridge-to-address" type="amqpBridgeAddressType" />
+            <xsd:element name="bridge-from-queue" type="amqpBridgeQueueType" />
+            <xsd:element name="bridge-to-queue" type="amqpBridgeQueueType" />
+         </xsd:choice>
+          <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded">
+             <xsd:annotation>
+                <xsd:documentation>
+                   Optional properties that can be applied to the bridging configuration
+                </xsd:documentation>
+             </xsd:annotation>
+          </xsd:element>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:ID" use="optional" />
+   </xsd:complexType>
+
+   <xsd:complexType name="amqpBridgedResourceType">
+      <xsd:sequence>
+         <xsd:element ref="property" minOccurs="0" maxOccurs="unbounded">
+            <xsd:annotation>
+               <xsd:documentation>
+                  Optional properties that can be applied to the bridging policy
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+         <xsd:choice maxOccurs="1" minOccurs="0">
+            <xsd:element name="transformer-class-name" type="xsd:string" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     an optional class name of a transformer
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+            <xsd:element name="transformer" type="transformerType" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     optional transformer configuration
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+         </xsd:choice>
+      </xsd:sequence>
+      <xsd:attribute name="name" type="xsd:ID" use="required" />
+      <xsd:attribute name="priority" type="xsd:int" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               A configured priority value which if set is applied either to the receiver or sender side of the
+               bridge policy. When bridging from a remote resource this value is added to the receiver link
+               properties and if supported will influence the priority assigned to the receiver on the remote.
+               When bridging to a remote resource this value is assigned to the local server consumer subscribed
+               to the local resource. This value overrides any automatic adjustment of priority and assigns the
+               value as is.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="filter" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               Optional filter string that is validated as a JMS selector string.
+
+               A JMS selector string applied either to the local or remote side of the bridged resource
+               depending on whether the policy is bridging to or from the remote peer. When bridging to
+               a remote the filter is assigned to the local subscription and when bridging from a remote
+               peer the filter is assigned in the filters portion of the AMQP receiver link that is
+               attached to the remote resource.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="remote-address" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               Optional remote address value applied to the bridge sender or receiver link.
+
+               This value overrides the normal default behaviour of the bridging controller which
+               assigns the name of the resource being bridged to the address field of the remote
+               source or target depending on the bridge action.  When bridging from a remote for an
+               address the default behavior is to assign the receiver source address as that of the
+               bridged address, when bridging to a remote for an address the sender link target address
+               is set to the name of the address being bridged. When bridging from a remote for a queue
+               the default behavior is to assign the receiver source address as that of the bridged
+               queue, when bridging to a remote for a queue the sender link target address is set to
+               the name of the queue being bridged.
+
+               This option allows you to override that and assign a specific source or target address
+               for every bridge link created in response to matches to the configured resource matching
+               settings in this policy.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="remote-address-prefix" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               Optional remote address prefix that can be used when creating bridge sender or receiver links.
+
+               This value overrides the normal default behaviour of the bridging controller which
+               assigns the name of the resource being bridged to the address field of the remote
+               source or target depending on the bridge action.
+
+               This option allows you to prefix the assigned address for every bridge link created in
+               response to matches to the configured resource match settings in this policy.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="remote-address-suffix" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               Optional remote address suffix that can be used when creating bridge sender or receiver links.
+
+               This value overrides the normal default behaviour of the bridging controller which assigns
+               the name of the address being bridged to the address field of the remote source or target
+               depending on the bridge action.
+
+               This option allows you to suffix the assigned address for every bridge link created in response
+               to matches to the configured resource match settings in this policy.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attribute name="remote-terminus-capabilities" type="xsd:string" use="optional">
+         <xsd:annotation>
+            <xsd:documentation>
+               Optional remote terminus capabilities that can be used when creating bridge sender or receiver
+               links (set as a comma delimited string).
+
+               This option sets a collection of source or target capabilities that will be added to the remote
+               source or target depending on the bridging action. When bridging from an resource these capabilities
+               are added to the source capabilities of the receiver link, and when bridging to a resource these
+               capabilities are set on the sender link target capabilities.
+            </xsd:documentation>
+         </xsd:annotation>
+      </xsd:attribute>
+      <xsd:attributeGroup ref="xml:specialAttrs"/>
+   </xsd:complexType>
+
+   <xsd:complexType name="amqpBridgeAddressType">
+      <xsd:complexContent>
+         <xsd:extension base="amqpBridgedResourceType">
+            <xsd:sequence>
+               <xsd:element name="include" type="addressMatchType" minOccurs="0" maxOccurs="unbounded"/>
+               <xsd:element name="exclude" type="addressMatchType" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="enable-divert-bindings" type="xsd:boolean" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     Should the policy include divert bindings in the checks that control if a remote link
+                     is created to bridge from an address. This option is ignored for bridge to configurations.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
+   </xsd:complexType>
+
+   <xsd:complexType name="amqpBridgeQueueType">
+      <xsd:complexContent>
+         <xsd:extension base="amqpBridgedResourceType">
+            <xsd:sequence>
+               <xsd:element name="include" type="queueMatchType" minOccurs="0" maxOccurs="unbounded"/>
+               <xsd:element name="exclude" type="queueMatchType" minOccurs="0" maxOccurs="unbounded"/>
+            </xsd:sequence>
+            <xsd:attribute name="priority-adjustment" type="xsd:int" use="optional">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     A configured priority adjustment value which if set is applied either to the receiver or sender
+                     side of the bridge policy. When bridging from a remote resource this value will be used to compute
+                     a priority value that is added to the receiver link properties and if supported will influence the
+                     priority assigned on the remote. When bridging to a remote resource this value is used to compute
+                     a priority value based on the default server priority which is assigned to the local consumer
+                     subscribed to the local resource.
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:attribute>
+         </xsd:extension>
+      </xsd:complexContent>
    </xsd:complexType>
 
    <xsd:complexType name="cluster-connectionUriType">

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -473,6 +473,11 @@
                   <include address-match="test" queue-match="tracking" />
                </local-queue-policy>
             </federation>
+            <bridge name = "test-bridge">
+               <bridge-from-queue name="bridge-queue-1" priority-adjustment="1">
+                  <include address-match="#" queue-match="tracking" />
+               </bridge-from-queue>
+            </bridge>
          </amqp-connection>
          <amqp-connection uri="tcp://test2:222" name="test2">
             <mirror durable="false"/>
@@ -519,6 +524,34 @@
             <mirror>
               <property key="tunnel-core-messages" value="false"/>
             </mirror>
+         </amqp-connection>
+         <amqp-connection uri="tcp://false" name="test-bridge-configuration" auto-start="false">
+            <bridge>
+               <bridge-from-queue name="bridge-from-queue" priority-adjustment="1">
+                  <property key="amqpCredits" value="2"/>
+                  <property key="amqpLowCredits" value="1"/>
+                  <transformer>
+                     <class-name>something</class-name>
+                     <property key="key1" value="value1"/>
+                     <property key="key2" value="value2"/>
+                  </transformer>
+                  <include address-match="#" queue-match="tracking" />
+               </bridge-from-queue>
+               <bridge-to-queue name="bridge-to-queue" priority-adjustment="2">
+                  <include address-match="test-queue" queue-match="tracking" />
+               </bridge-to-queue>
+               <bridge-from-address name="bridge-from-address">
+                  <transformer-class-name>class-name</transformer-class-name>
+                  <include address-match="test-address" />
+                  <exclude address-match="all.#" />
+               </bridge-from-address>
+               <bridge-to-address name="bridge-to-address">
+                  <include address-match="test-address" />
+                  <exclude address-match="all.#" />
+               </bridge-to-address>
+               <property key="amqpCredits" value="7"/>
+               <property key="amqpLowCredits" value="1"/>
+            </bridge>
          </amqp-connection>
       </broker-connections>
       <grouping-handler name="gh1">

--- a/docs/user-manual/amqp-broker-connections.adoc
+++ b/docs/user-manual/amqp-broker-connections.adoc
@@ -65,10 +65,13 @@ The following types of operations are supported on an AMQP server connection:
 * Federation
 ** Broker federation allows the local broker to create remote receivers for addresses or queues that have local demand.
 Conversely it can also send federation configuration to the remote broker causing it to create receivers on the local broker based on remote demand on an address or queue over this same connection.
+* Bridges
+** The broker uses a set of configured policies to either send messages to or receive messages from a remote AMQP peer for addresses and queues on the local broker.
 * Senders
 ** Messages received on specific queues are transferred to another endpoint.
 * Receivers
 ** The broker pulls messages from another endpoint.
+
 * Peers
 ** The broker creates both senders and receivers on another endpoint that knows how to handle them.
 This is currently implemented by Apache Qpid Dispatch.
@@ -486,14 +489,12 @@ For address federation, a durable queue is created on the broker from which mess
 Set this property to `true` to mark the queue for automatic deletion once the initiating broker disconnects and the delay and message count parameters are met.
 This is a useful option if you want to automate the cleanup of dynamically-created queues.
 The default value is `false`, which means that the queue is not automatically deleted.
-
 auto-delete-delay::
 The amount of time in milliseconds after the initiating broker has disconnected before the created queue can be eligible for `auto-delete`.
 The default value is `0` when option is omitted.
 auto-delete-message-count::
 After the initiating broker has disconnected, the maximum number of messages allowed in the remote queue for the queue to be eligible for automatic deletion.
 The default value is `0`.
-
 enable-divert-bindings::
 Setting to `true` enables divert bindings to be listened-to for demand.
 If a divert binding with an address matches the included addresses for the address policy, any queue bindings that match the forwarding address of the divert creates demand. The default value is `false`.
@@ -535,6 +536,130 @@ When federation consumers are created this value can be used to ensure that thos
 The default is `-1`.
 include-federated::
 Controls if consumers on a queue which come from federation instances should be counted when observing a queue for demand, by default this value is `false` and federation consumers are not counted.
+
+== Bridges
+
+AMQP Bridges allows the local broker to create remote receivers for addresses or queues that have local demand and match configured policy constraints. Conversely the broker can create remote senders for addresses or queues that exist on the local broker and match configured policy constraints.
+
+Add a `<bridge>` element within the `<amqp-connection>` element to configure AMQP bridge to the broker instance.
+The `<amqp-connection>` contains all the configuration for authentication and reconnection handling.
+See above sections to configure those values.
+
+The broker connection bridge configuration consists of one or more policies that define either send-to or receive-from bridge configurations for addresses or queues.
+
+[,xml]
+----
+<broker-connections>
+  <amqp-connection uri="tcp://HOST:PORT" name="bridge-example">
+    <bridge name="example-bridge">
+       <bridge-from-address name="example-bridge-from-address-policy">
+         <include address-match="local-address.#" />
+         <exclude address-match="local-address.excluded" />
+       </bridge-from-address>
+       <bridge-from-queue name="example-bridge-from-queue-policy">
+         <include address-match="address" queue-match="local-queue" />
+       </bridge-from-queue>
+       <bridge-to-address name="example-bridge-to-address-policy">
+         <include address-match="outgoing-address" />
+       </bridge-to-address>
+       <bridge-to-queue name="example-bridge-to-queue-policy">
+         <include address-match="#" queue-match="outbound-queue" />
+         <exclude address-match="#" queue-match="local-queue-excluded" />
+       </bridge-to-queue>
+    </bridge>
+  </amqp-connection>
+</broker-connections>
+----
+
+=== Bridging from remote addresses and queues
+
+Bridging from a remote address or queue involves monitoring a local address or queue for demand and reacting when demand is added or removed. When demand exists the bridge will create a receiver on the matching address or queue on the opposing AMQP peer. Because the receivers are created on addresses and queues on the opposing peer, the authentication credentials supplied to the broker connection must have sufficient access to the bridged address or queue on the remote peer in order to consume messages from them.
+
+An example of AMQP address and queue bridge from configurations are shown below.
+
+[,xml]
+----
+<broker-connections>
+  <amqp-connection uri="tcp://HOST:PORT" name="bridge-example">
+    <bridge name="example-bridge">
+       <bridge-from-address name="example-bridge-from-address-policy">
+         <include address-match="local-address.#" />
+         <exclude address-match="local-address.excluded" />
+       </bridge-from-address>
+       <bridge-from-queue name="example-bridge-from-queue-policy">
+         <include address-match="address" queue-match="local-queue" />
+       </bridge-from-queue>
+    </bridge>
+  </amqp-connection>
+</broker-connections>
+----
+
+name::
+The name of the policy. These names should be unique within a broker connection's bridge policy elements.
+include::
+The address-match or queue-match pattern to use to match included addresses and queues. Multiple of these can be set but if none is set then no matches would be made.
+exclude::
+The address-match or queue-match pattern to use to match excluded addresses and queues. Multiple of these can be set, or it can be omitted if no excludes are needed.
+priority::
+A configured priority value which if set is applied remote receiver created by this bridge policy, this value is added to the receiver link properties and if supported will influence the priority assigned on the remote.
+priority-adjustment::
+When bridge receivers are created this value can be used to ensure that those bridge receivers have a lower priority value than other receivers on the same address or queue. The default is `-1`.
+includeDivertBindings::
+Should the bridge from address policy include divert bindings in the checks that control if a remote receiver is created to bridge from an address.
+filter::
+Optional filter string that is validated as a JMS selector string and is applied to the receiver that is bridging messages from and address or queue on the remote peer.
+remoteAddress::
+An optional override of address that is set as the address in the Source configuration of the AMQP receiver that is bridging messages from the remote peer. The default action is to assign either the address or queue name depending on whether the policy is bridging an address or queue.
+remoteAddressPrefix::
+An optional address prefix that is set on the address in the Source configuration of the AMQP receiver that is bridging messages from the remote peer. The default value is `null` and no prefix is applied to the source address.
+remoteAddressSuffix::
+An optional address suffix that is set on the address in the Source configuration of the AMQP receiver that is bridging messages from the remote peer. The default value is `null` and no suffix is applied to the source address.
+remoteTerminusCapabilities::
+Optional set of remote source capabilities that are set on the receiver when bridging an address or queue from the remote peer. The capabilities are configured as a comma delimited list whose default value is `null`.
+
+=== Bridging to remote addresses and queues
+
+Bridging to a remote address or queue involves monitoring for the existence of a local address or queue amd reacting when one is added or removed. When the target address or queue exists the bridge will create a sender on the matching address or queue on the opposing AMQP peer. Because the senders are created on addresses and queues on the opposing peer, the authentication credentials supplied to the broker connection must have sufficient access to the bridged address or queue on the remote peer in order to produce messages to them.
+
+An example of AMQP address and queue bridge to configurations are shown below.
+
+[,xml]
+----
+<broker-connections>
+  <amqp-connection uri="tcp://HOST:PORT" name="bridge-example">
+    <bridge name="example-bridge">
+       <bridge-to-address name="example-bridge-to-address-policy">
+         <include address-match="outgoing-address" />
+       </bridge-to-address>
+       <bridge-to-queue name="example-bridge-to-queue-policy">
+         <include address-match="#" queue-match="outbound-queue" />
+         <exclude address-match="#" queue-match="local-queue-excluded" />
+       </bridge-to-queue>
+    </bridge>
+  </amqp-connection>
+</broker-connections>
+----
+
+name::
+The name of the policy. These names should be unique within a broker connection's bridge policy elements.
+include::
+The address-match or queue-match pattern to use to match included addresses and queues. Multiple of these can be set but if none is set then no matches would be made.
+exclude::
+The address-match or queue-match pattern to use to match excluded addresses and queues. Multiple of these can be set, or it can be omitted if no excludes are needed.
+priority::
+A configured priority value which if set is applied local receiver created by this bridge policy, this value is added to the receiver link properties and if supported will influence the priority assigned on the local server.
+priority-adjustment::
+When bridge senders are created this value can be used to ensure that those bridge senders have a lower priority value than other senders on the same address or queue. The default is `-1`.
+filter::
+Optional filter string that is validated as a JMS selector string and is applied to the sender that is bridging messages to an address or queue on the remote peer.
+remoteAddress::
+An optional override of address that is set as the address in the Target configuration of the AMQP sender that is bridging messages to the remote peer. The default action is to assign either the address or queue name depending on whether the policy is bridging an address or queue.
+remoteAddressPrefix::
+An optional address prefix that is set on the address in the Target configuration of the AMQP sender that is bridging messages to the remote peer. The default value is `null` and no prefix is applied to the target address.
+remoteAddressSuffix::
+An optional address suffix that is set on the address in the Target configuration of the AMQP sender that is bridging messages to the remote peer. The default value is `null` and no suffix is applied to the target address.
+remoteTerminusCapabilities::
+Optional set of remote target capabilities that are set on the sender when bridging an address or queue to the remote peer. The capabilities are configured as a comma delimited list whose default value is `null`.
 
 === Examples
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpCoreTunnelingSupportTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpCoreTunnelingSupportTest.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import static org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledMessageConstants.AMQP_TUNNELED_CORE_MESSAGE_FORMAT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.qpid.protonj2.test.driver.ProtonTestClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class AmqpCoreTunnelingSupportTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   // Captured CORE wrapped AMQP transfer payload. (TextMessage whose body = "Hello")
+   private static byte[] CORE_MESSAGE_PAYLOAD =
+      {0, 83, 117, -80, 0, 0, 1, 68, 0, 0, 1, 64, 0, 0, 0, 28, 1, 0, 0, 0, 10, 72, 0, 101, 0, 108, 0, 108, 0, 111, 0, 0, 0, 0,
+       0, 0, 0, 0, 80, 1, 0, 0, 0, 108, 116, 0, 101, 0, 115, 0, 116, 0, 82, 0, 101, 0, 99, 0, 101, 0, 105, 0, 118, 0, 101, 0,
+       114, 0, 84, 0, 104, 0, 97, 0, 116, 0, 79, 0, 102, 0, 102, 0, 101, 0, 114, 0, 115, 0, 67, 0, 111, 0, 114, 0, 101, 0, 84,
+       0, 117, 0, 110, 0, 110, 0, 101, 0, 108, 0, 105, 0, 110, 0, 103, 0, 71, 0, 101, 0, 116, 0, 115, 0, 68, 0, 101, 0, 115, 0,
+       105, 0, 114, 0, 101, 0, 100, 0, 82, 0, 101, 0, 115, 0, 112, 0, 111, 0, 110, 0, 115, 0, 101, 0, 1, -51, 105, -29, -51, -3,
+       -19, 17, -17, -72, -69, -88, -95, 89, -21, -74, -92, 3, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, -107, -127, -69, -39, -72, 4,
+       1, 0, 0, 0, 2, 0, 0, 0, 18, 95, 0, 95, 0, 65, 0, 77, 0, 81, 0, 95, 0, 67, 0, 73, 0, 68, 0, 10, 0, 0, 0, 72, 99, 0, 100, 0,
+       54, 0, 53, 0, 57, 0, 101, 0, 48, 0, 57, 0, 45, 0, 102, 0, 100, 0, 101, 0, 100, 0, 45, 0, 49, 0, 49, 0, 101, 0, 102, 0, 45,
+       0, 98, 0, 56, 0, 98, 0, 98, 0, 45, 0, 97, 0, 56, 0, 97, 0, 49, 0, 53, 0, 57, 0, 101, 0, 98, 0, 98, 0, 54, 0, 97, 0, 52, 0,
+       0, 0, 0, 34, 95, 0, 65, 0, 77, 0, 81, 0, 95, 0, 82, 0, 79, 0, 85, 0, 84, 0, 73, 0, 78, 0, 71, 0, 95, 0, 84, 0, 89, 0, 80, 0,
+       69, 0, 3, 1};
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testReceiverThatOffersCoreTunnelingGetsDesiredResponse() throws Exception {
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofSender().withDesiredCapability(CORE_MESSAGE_TUNNELING_SUPPORT.toString());
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofReceiver()
+                            .withOfferedCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("queue").also()
+                            .withTarget().also()
+                            .now();
+         peer.remoteFlow().withLinkCredit(10).now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectTransfer().withMessageFormat(AMQP_TUNNELED_CORE_MESSAGE_FORMAT).accept();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("CORE", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createQueue(getTestName()));
+
+            producer.send(session.createTextMessage("Hello"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testReceiverThatDoesNotOffersCoreTunnelingGetsNoDesiredResponse() throws Exception {
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofSender().withDesiredCapabilities(nullValue());
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofReceiver()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withSource().withAddress(getTestName()).also()
+                            .withTarget().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testSenderthatDesiresCoreTunnelingGetsOfferedResponse() throws Exception {
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver().withOfferedCapability(CORE_MESSAGE_TUNNELING_SUPPORT.toString());
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withDesiredCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Send core tunneled message which should then get to the core receiver as the original Text Message
+         peer.remoteTransfer().withMessageFormat(AMQP_TUNNELED_CORE_MESSAGE_FORMAT)
+                              .withDeliveryId(0)
+                              .withPayload(CORE_MESSAGE_PAYLOAD)
+                              .withSettled(true)
+                              .withState().accepted()
+                              .now();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("CORE", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            final Message received = consumer.receive(5_000);
+
+            assertNotNull(received);
+            assertTrue(received instanceof TextMessage);
+
+            final TextMessage textMessage = (TextMessage) received;
+
+            assertEquals("Hello", textMessage.getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testSenderthatDoesNotDesireCoreTunnelingDoesNotGetOfferedResponse() throws Exception {
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         logger.info("Test started, client connected on: {}", AMQP_PORT);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver().withOfferedCapabilities(nullValue());
+         peer.expectFlow();
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.close();
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeConfigurationReloadTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeConfigurationReloadTest.java
@@ -1,0 +1,416 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.Collections;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageConsumer;
+import javax.jms.Session;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeAddressPolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeQueuePolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.protocol.amqp.broker.ProtonProtocolManagerFactory;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test for reload handling in the broker connection bridge implementation
+ */
+class AMQPBridgeConfigurationReloadTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConfigurationWithoutChangesIsIgnoredOnUpdate() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addToExcludes("test.ignore.#");
+         receiveFromAddress.setPriority(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            final ProtonProtocolManagerFactory protocolFactory = (ProtonProtocolManagerFactory)
+               server.getRemotingService().getProtocolFactoryMap().get("AMQP");
+            assertNotNull(protocolFactory);
+
+            final AMQPBridgeAddressPolicyElement updatedReceiveFromAddress = new AMQPBridgeAddressPolicyElement();
+            updatedReceiveFromAddress.setName("address-policy");
+            updatedReceiveFromAddress.addToIncludes(getTestName());
+            updatedReceiveFromAddress.addToExcludes("test.ignore.#");
+            updatedReceiveFromAddress.setPriority(1);
+
+            final AMQPBridgeBrokerConnectionElement updatedElement = new AMQPBridgeBrokerConnectionElement();
+            updatedElement.setName(getTestName());
+            updatedElement.addBridgeFromAddressPolicy(updatedReceiveFromAddress);
+
+            amqpConnection.getConnectionElements().clear();
+            amqpConnection.addElement(updatedElement); // This should be equivalent to replacing the previous instance.
+
+            server.getConfiguration().getAMQPConnection().clear();
+            server.getConfiguration().addAMQPConnection(amqpConnection);
+
+            protocolFactory.updateProtocolServices(server, Collections.emptyList());
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConnectsToSecondPeerWhenConfigurationUpdatedWithNewConnection() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addToExcludes("test.ignore.#");
+         receiveFromAddress.setPriority(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName() + ":1");
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName() + ":1", "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withName(allOf(containsString(getTestName() + ":1"),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            try (ProtonTestServer peer2 = new ProtonTestServer()) {
+               peer2.expectSASLAnonymousConnect();
+               peer2.expectOpen().respond();
+               peer2.expectBegin().respond();
+               peer2.expectAttach().ofReceiver()
+                                   .withName(allOf(containsString(getTestName() + ":2"),
+                                                   containsString("address-receiver"),
+                                                   containsString("amqp-bridge"),
+                                                   containsString(server.getNodeID().toString())))
+                                   .respond();
+               peer2.expectFlow().withLinkCredit(1000);
+               peer2.start();
+
+               final URI remoteURI2 = peer2.getServerURI();
+               logger.info("Test peer 2 started, peer listening on: {}", remoteURI2);
+
+               final ProtonProtocolManagerFactory protocolFactory = (ProtonProtocolManagerFactory)
+                  server.getRemotingService().getProtocolFactoryMap().get("AMQP");
+               assertNotNull(protocolFactory);
+
+               final AMQPBridgeAddressPolicyElement updatedReceiveFromAddress = new AMQPBridgeAddressPolicyElement();
+               updatedReceiveFromAddress.setName("address-policy");
+               updatedReceiveFromAddress.addToIncludes(getTestName());
+               updatedReceiveFromAddress.addToExcludes("test.ignore.#");
+               updatedReceiveFromAddress.setPriority(1);
+
+               final AMQPBridgeBrokerConnectionElement updatedElement = new AMQPBridgeBrokerConnectionElement();
+               updatedElement.setName(getTestName() + ":2");
+               updatedElement.addBridgeFromAddressPolicy(updatedReceiveFromAddress);
+
+               final AMQPBrokerConnectConfiguration updatedAmqpConnection =
+                  new AMQPBrokerConnectConfiguration(getTestName() + ":2", "tcp://" + remoteURI2.getHost() + ":" + remoteURI2.getPort());
+               updatedAmqpConnection.setReconnectAttempts(0);// No reconnects
+               updatedAmqpConnection.addElement(updatedElement);
+
+               server.getConfiguration().addAMQPConnection(updatedAmqpConnection);
+
+               protocolFactory.updateProtocolServices(server, Collections.emptyList());
+
+               peer2.waitForScriptToComplete(5, TimeUnit.SECONDS);
+               peer2.close();
+            }
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeDisconnectsFromExistingPeerIfConfigurationRemoved() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addToExcludes("test.ignore.#");
+         receiveFromAddress.setPriority(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach().optional();
+            peer.expectClose().optional();
+            peer.expectConnectionToDrop();
+
+            final ProtonProtocolManagerFactory protocolFactory = (ProtonProtocolManagerFactory)
+               server.getRemotingService().getProtocolFactoryMap().get("AMQP");
+            assertNotNull(protocolFactory);
+
+            server.getConfiguration().clearAMQPConnectionConfigurations();
+
+            protocolFactory.updateProtocolServices(server, Collections.emptyList());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Create more demand, no federation should be initiated
+            session.createConsumer(session.createTopic(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBidgeUpdatesPolicyAndBridgesQueueInsteadOfAddress() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setPriority(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+            session.createConsumer(session.createQueue("queue"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach().optional();
+            peer.expectClose().optional();
+            peer.expectConnectionToDrop();
+            peer.expectSASLAnonymousConnect();
+            peer.expectOpen().respond();
+            peer.expectBegin().respond();
+            peer.expectAttach().ofReceiver()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            final ProtonProtocolManagerFactory protocolFactory = (ProtonProtocolManagerFactory)
+               server.getRemotingService().getProtocolFactoryMap().get("AMQP");
+            assertNotNull(protocolFactory);
+
+            final AMQPBridgeQueuePolicyElement updatedReceiveFromQueue = new AMQPBridgeQueuePolicyElement();
+            updatedReceiveFromQueue.setName("queue-policy");
+            updatedReceiveFromQueue.addToIncludes("*", "queue");
+
+            final AMQPBridgeBrokerConnectionElement updatedElement = new AMQPBridgeBrokerConnectionElement();
+            updatedElement.setName(getTestName());
+            updatedElement.addBridgeFromQueuePolicy(updatedReceiveFromQueue);
+
+            final AMQPBrokerConnectConfiguration updatedAmqpConnection =
+               new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+            updatedAmqpConnection.setReconnectAttempts(0);// No reconnects
+            updatedAmqpConnection.addElement(updatedElement);
+
+            server.getConfiguration().getAMQPConnection().clear();
+            server.getConfiguration().addAMQPConnection(updatedAmqpConnection);
+
+            protocolFactory.updateProtocolServices(server, Collections.emptyList());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromAddressTest.java
@@ -1,0 +1,3554 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledMessageConstants.AMQP_TUNNELED_CORE_MESSAGE_FORMAT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.TUNNEL_CORE_MESSAGES;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.BRIDGE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeAddressPolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ComponentConfigurationRoutingType;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.transformer.Transformer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.LinkError;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.apache.qpid.protonj2.test.driver.codec.messaging.Modified;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests the AMQP bridge from address behavior.
+ */
+class AMQPBridgeFromAddressTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testLinkAttachTimeoutAppliedAndConnectionClosed() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(LINK_ATTACH_TIMEOUT, 1); // Seconds
+         element.addProperty(LINK_RECOVERY_INITIAL_DELAY, 20); // Milliseconds
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Modified deliveryFailed = new Modified();
+         deliveryFailed.setDeliveryFailed(true);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withDefaultOutcome(deliveryFailed).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())));
+         peer.expectDetach();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesAddressReceiverWhenLocalQueueIsStaticlyDefined() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Modified deliveryFailed = new Modified();
+         deliveryFailed.setDeliveryFailed(true);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withDefaultOutcome(deliveryFailed).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Should be no frames generated as we already bridged the address and the statically added
+         // queue should retain demand when this consumer leaves.
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+
+            session.createConsumer(session.createTopic(getTestName()));
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged consumer to be shutdown as the statically defined queue
+         // should be the only remaining demand on the address.
+         logger.info("Removing Queues from bridged address to eliminate demand");
+         server.destroyQueue(SimpleString.of(getTestName()));
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesAddressReceiverLinkForConsumerDemandCreatedQueue() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesAddressReceiverLinkForAddressMatchUsingPolicyCredit() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(RECEIVER_CREDITS, "25");
+         receiveFromAddress.addProperty(RECEIVER_CREDITS_LOW, "5");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(25);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeClosesAddressReceiverLinkWhenDemandRemovedNoIdleTimeout() throws Exception {
+      doTestBridgeClosesAddressReceiverLinkWhenDemandRemoved(0);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeClosesAddressReceiverLinkWhenDemandRemovedWithIdleTimeout() throws Exception {
+      doTestBridgeClosesAddressReceiverLinkWhenDemandRemoved(5);
+   }
+
+   private void doTestBridgeClosesAddressReceiverLinkWhenDemandRemoved(int idleTimeout) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, idleTimeout);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            // Demand is removed so receiver should be detached.
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetainsAddressReceiverLinkWhenDurableSubscriberIsOffline() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 100); // Should be overridden
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            connection.setClientID("test-clientId");
+
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Topic topic = session.createTopic(getTestName());
+            final MessageConsumer consumer = session.createSharedDurableConsumer(topic, "shared-subscription");
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Consumer goes offline but demand is retained for address
+            consumer.close();
+
+            // Should provoke no action on the bridge
+            session.createSharedDurableConsumer(topic, "shared-subscription").close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            session.unsubscribe("shared-subscription");
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeClosesAddressReceiverLinkWaitsForAllDemandToRemoved() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer1 = session.createConsumer(session.createTopic(getTestName()));
+            final MessageConsumer consumer2 = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+            consumer1.close(); // One is gone but another remains
+
+            // Will fail if any frames arrive
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer2.close(); // Now demand is gone
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeHandlesAddressDeletedAndConsumerRecreates() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true).optional();
+            peer.expectDetach().respond();
+
+            server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         // Consumer recreates Address and adds demand back and bridge should restart
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConsumerCreatedWhenDemandAddedToDivertAddress() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward")
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the forwarding address should create a remote consumer for the forwarded address.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic("forward"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConsumerCreatedWhenDemandAddedToCompositeDivertAddress() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward1,forward2")
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the forwarding address should create a remote consumer for the forwarded address.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+
+            // Creating a consumer on each should result in only one attach for the source address
+            final MessageConsumer consumer1 = session.createConsumer(session.createTopic("forward1"));
+            final MessageConsumer consumer2 = session.createConsumer(session.createTopic("forward2"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Closing one should not remove all demand on the source address
+            consumer1.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer2.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConsumerRemovesDemandFromDivertConsumersOnlyWhenAllDemandIsRemoved() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward")
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the forwarding address should create a remote consumer for the forwarded address.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer1 = session.createConsumer(session.createTopic("forward"));
+            final MessageConsumer consumer2 = session.createConsumer(session.createTopic("forward"));
+
+            connection.start();
+            consumer1.close(); // One is gone but another remains
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer2.close(); // Now demand is gone
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConsumerRetainsDemandForDivertBindingWithoutActiveAnycastSubscriptions() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName()); // Divert matching works on the source address of the divert
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         // Any demand on the forwarding address even if the forward is a Queue (ANYCAST) should create
+         // demand on the remote for the source address (If the source is MULTICAST)
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward")
+                                                                           .setRoutingType(ComponentConfigurationRoutingType.ANYCAST)
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         // Current implementation requires the source address exist on the local broker before it
+         // will attempt to federate it from the remote.
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the forwarding address should create a remote consumer for the forwarded address.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue = session.createQueue("forward");
+            final MessageConsumer consumer1 = session.createConsumer(queue);
+            final MessageConsumer consumer2 = session.createConsumer(queue);
+
+            connection.start();
+            consumer1.close(); // One is gone but another remains
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            consumer2.close(); // Demand remains as the Queue continues to exist
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeConsumerRemovesDemandForDivertBindingWithoutActiveMulticastSubscriptions() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName()); // Divert matching works on the source address of the divert
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         // Any demand on the forwarding address even if the forward is a Queue (ANYCAST) should create
+         // demand on the remote for the source address (If the source is MULTICAST)
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward")
+                                                                           .setRoutingType(ComponentConfigurationRoutingType.MULTICAST)
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         // Current implementation requires the source address exist on the local broker before it
+         // will attempt to federate it from the remote.
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the forwarding address should create a remote consumer for the forwarded address.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Topic topic = session.createTopic("forward");
+            final MessageConsumer consumer1 = session.createConsumer(topic);
+            final MessageConsumer consumer2 = session.createConsumer(topic);
+
+            connection.start();
+            consumer1.close(); // One is gone but another remains
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer2.close(); // Now demand is gone from the divert
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesRemoteDemandIfDivertIsRemoved() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName()); // Divert matching works on the source address of the divert
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward")
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the forwarding address should create a remote consumer for the forwarding address.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic("forward"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            server.destroyDivert(SimpleString.of("test-divert"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testDivertBindingsDoNotCreateAdditionalDemandIfDemandOnForwardingAddressAlreadyExists() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divertConfig = new DivertConfiguration().setAddress(getTestName())
+                                                                           .setForwardingAddress("forward")
+                                                                           .setName("test-divert");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.deployDivert(divertConfig);
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Demand on the main address creates demand on the same address remotely and then the diverts
+         // should just be tracked under that original demand.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final MessageConsumer consumer1 = session.createConsumer(session.createTopic("forward"));
+            final MessageConsumer consumer2 = session.createConsumer(session.createTopic("forward"));
+
+            consumer1.close();
+            consumer2.close();
+
+            server.destroyDivert(SimpleString.of("test-divert"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testInboundMessageRoutedToReceiverOnLocalAddress() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertTrue(message instanceof TextMessage);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testTransformInboundBridgedMessageBeforeDispatch() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final Map<String, String> newApplicationProperties = new HashMap<>();
+         newApplicationProperties.put("appProperty1", "one");
+         newApplicationProperties.put("appProperty2", "two");
+
+         final TransformerConfiguration transformerConfiguration = new TransformerConfiguration();
+         transformerConfiguration.setClassName(ApplicationPropertiesTransformer.class.getName());
+         transformerConfiguration.setProperties(newApplicationProperties);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setTransformerConfiguration(transformerConfiguration);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertTrue(message instanceof TextMessage);
+            assertEquals("test-message", ((TextMessage) message).getText());
+            assertEquals("one", message.getStringProperty("appProperty1"));
+            assertEquals("two", message.getStringProperty("appProperty2"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeDoesNotCreateAddressReceiverLinkForAddressMatchWhenLinkCreditIsSetToZero() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            assertNull(consumer.receiveNoWait());
+            consumer.close();
+
+            // Should be no interactions with the peer as credit is zero and address policy
+            // will not apply to any match when credit cannot be offered to avoid stranding
+            // a receiver on a remote address with no credit.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeStartedTriggersRemoteDemandWithExistingAddressBindings() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.setAutostart(false);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                          .setAddress(getTestName())
+                                                          .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Create demand on the addresses so that on start bridge should happen
+         final Connection connection = factory.createConnection();
+         final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         session.createConsumer(session.createTopic(getTestName()));
+         session.createConsumer(session.createTopic(getTestName()));
+
+         // Add other non-bridged address bindings for the policy to check on start.
+         session.createConsumer(session.createTopic("a1"));
+         session.createConsumer(session.createTopic("a2"));
+
+         connection.start();
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // Starting the broker connection should trigger bridge of address with demand.
+         server.getBrokerConnections().forEach(c -> {
+            try {
+               c.start();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         });
+
+         // Add more demand while bridge is starting
+         session.createConsumer(session.createTopic(getTestName()));
+         session.createConsumer(session.createTopic(getTestName()));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // This removes the connection demand, but leaves behind the static queue
+         connection.close();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridge consumer to be shutdown as the statically defined queue
+         // should be the only remaining demand on the address.
+         logger.info("Removing Queues from bridged address to eliminate demand");
+         server.destroyQueue(SimpleString.of(getTestName()));
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeStartedTriggersRemoteDemandWithExistingAddressAndDivertBindings() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.setAutostart(false);
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divert = new DivertConfiguration();
+         divert.setName("test-divert");
+         divert.setAddress(getTestName());
+         divert.setExclusive(false);
+         divert.setForwardingAddress("target");
+         divert.setRoutingType(ComponentConfigurationRoutingType.MULTICAST);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         // Configure addresses and divert for the test
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("target"), RoutingType.MULTICAST));
+         server.deployDivert(divert);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+         final Connection connection = factory.createConnection();
+         final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Topic test = session.createTopic(getTestName());
+         final Topic target = session.createTopic("target");
+
+         session.createConsumer(test);
+         session.createConsumer(test);
+
+         session.createConsumer(target);
+         session.createConsumer(target);
+
+         // Add other non-bridge address bindings for the policy to check on start.
+         session.createConsumer(session.createTopic("a1"));
+         session.createConsumer(session.createTopic("a2"));
+
+         connection.start();
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // Starting the broker connection should trigger bridging of address with demand.
+         server.getBrokerConnections().forEach(c -> {
+            try {
+               c.start();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         });
+
+         // Add more demand while bridge is starting
+         session.createConsumer(test);
+         session.createConsumer(target);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // This removes the connection demand, but leaves behind the static queue
+         connection.close();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeStartTriggersBridgingWithMultipleDivertsAndRemainsActiveAfterOneRemoved() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setIncludeDivertBindings(true);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.setAutostart(false);
+         amqpConnection.addElement(element);
+
+         final DivertConfiguration divert1 = new DivertConfiguration();
+         divert1.setName("test-divert-1");
+         divert1.setAddress(getTestName());
+         divert1.setExclusive(false);
+         divert1.setForwardingAddress("target1,target2");
+         divert1.setRoutingType(ComponentConfigurationRoutingType.MULTICAST);
+
+         final DivertConfiguration divert2 = new DivertConfiguration();
+         divert2.setName("test-divert-2");
+         divert2.setAddress(getTestName());
+         divert2.setExclusive(false);
+         divert2.setForwardingAddress("target1,target3");
+         divert2.setRoutingType(ComponentConfigurationRoutingType.MULTICAST);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         // Configure addresses and divert for the test
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("target1"), RoutingType.MULTICAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("target2"), RoutingType.MULTICAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("target3"), RoutingType.MULTICAST));
+         server.deployDivert(divert1);
+         server.deployDivert(divert2);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+         final Connection connection = factory.createConnection();
+         final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Topic target1 = session.createTopic("target1");
+         final Topic target2 = session.createTopic("target2");
+         final Topic target3 = session.createTopic("target2");
+
+         session.createConsumer(target1);
+         session.createConsumer(target2);
+         session.createConsumer(target3);
+
+         connection.start();
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // Starting the broker connection should trigger bridging of address with demand.
+         server.getBrokerConnections().forEach(c -> {
+            try {
+               c.start();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         });
+
+         // Add more demand while bridging is starting
+         session.createConsumer(target1);
+         session.createConsumer(target2);
+         session.createConsumer(target3);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.destroyDivert(SimpleString.of(divert1.getName()));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         server.destroyDivert(SimpleString.of(divert2.getName()));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         connection.close();
+
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressDemandTrackedWhenRemoteRejectsInitialAttempts() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Topic topic = session.createTopic(getTestName());
+
+            connection.start();
+
+            // First consumer we reject the bridge attempt
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respondInKind()
+                               .withNullSource();
+            peer.expectFlow().withLinkCredit(1000);
+            peer.remoteDetach().withErrorCondition("amqp:not-found", "the requested address was not found").queue().afterDelay(10);
+            peer.expectDetach();
+
+            final MessageConsumer consumer1 = session.createConsumer(topic);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Second consumer we reject the bridge attempt
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respondInKind()
+                               .withNullSource();
+            peer.expectFlow().withLinkCredit(1000);
+            peer.remoteDetach().withErrorCondition("amqp:not-found", "the requested address was not found").queue().afterDelay(10);
+            peer.expectDetach();
+
+            final MessageConsumer consumer2 = session.createConsumer(topic);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Third consumer we accept the bridging attempt
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respondInKind();
+            peer.expectFlow().withLinkCredit(1000);
+
+            final MessageConsumer consumer3 = session.createConsumer(topic);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Demand should remain
+            consumer3.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Demand should remain
+            consumer2.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            // Demand should be gone now
+            consumer1.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testAddressPolicyCanOverridesZeroCreditsInBridgeConfigurationAndFederateAddress() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(RECEIVER_CREDITS, 10);
+         receiveFromAddress.addProperty(RECEIVER_CREDITS_LOW, 3);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(RECEIVER_CREDITS, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .respondInKind();
+         peer.expectFlow().withLinkCredit(10);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverCarriesConfiguredPolicyFilter() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setFilter("color='red'");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withJMSSelector("color='red'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverCarriesConfiguredPrioirty() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setPriority(10);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withProperty(BRIDGE_RECEIVER_PRIORITY.toString(), 10)
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverOmitsConfiguredPrioirtyIfPriorityDisabled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setPriority(10); // Should be ignored regardless
+         receiveFromAddress.addProperty(DISABLE_RECEIVER_PRIORITY, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withProperties(not(Matchers.hasEntry(BRIDGE_RECEIVER_PRIORITY.toString(), 10)))
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverAppliesConfiguredRemoteAddressPrefix() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations("queue://", null, null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverAppliesConfiguredRemoteAddressSuffix() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations(null, null, "?consumer-priority=1");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverAppliesConfiguredRemoteAddress() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations(null, "alternate", null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverAppliesConfiguredRemoteAddressCustomizations() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations("queue://", "alternate", "?consumer-priority=1");
+   }
+
+   private void doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations(String prefix, String address, String suffix) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setRemoteAddress(address);
+         receiveFromAddress.setRemoteAddressPrefix(prefix);
+         receiveFromAddress.setRemoteAddressSuffix(suffix);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         final String expectedSourceAddress = (prefix != null ? prefix : "") +
+                                              (address != null ? address : getTestName()) +
+                                              (suffix != null ? suffix : "");
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(expectedSourceAddress).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverAddsRemoteTerminusCapabilitiesConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.setRemoteTerminusCapabilities(new String[] {"queue", "another"});
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("queue", "another")
+                                         .also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverSetsSenderPresettledWhenConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(PRESETTLE_SEND_MODE, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withSenderSettleModeSettled()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeStartedTriggersRemoteDemandWithExistingAddressesWithoutBindingsWhenTrackingDisabled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.setAutostart(false);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+         // Other non-matching addresses that also get scanned on start
+         server.addAddressInfo(new AddressInfo(SimpleString.of("other"), RoutingType.MULTICAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("another"), RoutingType.MULTICAST));
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // Starting the broker connection should trigger bridge of address with demand.
+         server.getBrokerConnections().forEach(c -> {
+            try {
+               c.start();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         });
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridge consumer to be shutdown as the statically defined queue
+         // should be the only remaining demand on the address.
+         logger.info("Removing Queues from bridged address to eliminate demand");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeTriggersRemoteDemandAfterAddressCreatedWhenTrackingDisabled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         // Other non-matching addresses that also get scanned on start
+         server.addAddressInfo(new AddressInfo(SimpleString.of("other"), RoutingType.MULTICAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("another"), RoutingType.MULTICAST));
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridge consumer to be shutdown as the statically defined queue
+         // should be the only remaining demand on the address.
+         logger.info("Removing Queues from bridged address to eliminate demand");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverForceDetached() throws Exception {
+      doTestBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverDetached(LinkError.DETACH_FORCED);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverResourceDeleted() throws Exception {
+      doTestBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverDetached(AmqpError.RESOURCE_DELETED);
+   }
+
+   private void doTestBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverDetached(Symbol condition) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach();
+            peer.remoteDetach().withErrorCondition(condition.toString(), "Forced Detach").now();
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after another consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString(getTestName()),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createTopic(getTestName())); // New demand.
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after another consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString(getTestName()),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createTopic(getTestName())); // New demand.
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRecoversLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 10 millisecond initial recovery delay
+         receiveFromAddress.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after delay.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString(getTestName()),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAttemptsLimitedRecoveryLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addToIncludes("another");
+         receiveFromAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 1); // 1 millisecond initial recovery delay
+         receiveFromAddress.addProperty(LINK_RECOVERY_DELAY, 10);        // 10 millisecond continued recovery delay
+         receiveFromAddress.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 2);  // 3 attempts then stop trying
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Attempt #1
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond()
+                               .withNullSource();
+            peer.remoteDetach().withClosed(true)
+                               .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+            peer.expectFlow().optional();
+            peer.expectDetach();
+
+            // Attempt #2
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond()
+                               .withNullSource();
+            peer.remoteDetach().withClosed(true)
+                               .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+            peer.expectFlow().optional();
+            peer.expectDetach();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after new consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("another").also()
+                               .withSource().withAddress("another").also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("another"),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Now add demand on the alternate which should trigger an attach
+            session.createConsumer(session.createTopic("another"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after new consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString(getTestName()),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Now add new demand and trigger another attempt to create the bridge receiver
+            session.createConsumer(session.createTopic(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeDoesNotAttemptRecoveryOfLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addToIncludes("another");
+         receiveFromAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 1);  // 1 millisecond initial recovery delay
+         receiveFromAddress.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+         receiveFromAddress.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 0);   // No attempts
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("another").also()
+                               .withSource().withAddress("another").also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("another"),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Now add demand to the alternate and it should trigger new receiver attach
+            session.createConsumer(session.createTopic("another"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Now add demand to previous and it should retry the receiver attach
+            session.createConsumer(session.createTopic(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testMultipleBridgeConfigurationElementsHandledAndCreatesReceiversForDemand() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         // Bridge element one
+         final AMQPBridgeAddressPolicyElement receiveFromAddress1 = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress1.setName("address-policy-1");
+         receiveFromAddress1.addToIncludes("testA");
+         final AMQPBridgeBrokerConnectionElement element1 = new AMQPBridgeBrokerConnectionElement();
+         element1.setName(getTestName());
+         element1.addBridgeFromAddressPolicy(receiveFromAddress1);
+         element1.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         // Bridge element two
+         final AMQPBridgeAddressPolicyElement receiveFromAddress2 = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress2.setName("address-policy-2");
+         receiveFromAddress2.addToIncludes("testB");
+         final AMQPBridgeBrokerConnectionElement element2 = new AMQPBridgeBrokerConnectionElement();
+         element2.setName(getTestName());
+         element2.addBridgeFromAddressPolicy(receiveFromAddress2);
+         element2.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element1);
+         amqpConnection.addElement(element2);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Modified deliveryFailed = new Modified();
+         deliveryFailed.setDeliveryFailed(true);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress("testA").also()
+                            .withSource().withAddress("testA")
+                                         .withDefaultOutcome(deliveryFailed).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("testA"),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of("testA").setRoutingType(RoutingType.MULTICAST)
+                                                          .setAddress("testA")
+                                                          .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("testA")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress("testB").also()
+                            .withSource().withAddress("testB")
+                                         .withDefaultOutcome(deliveryFailed).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("testB"),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of("testB").setRoutingType(RoutingType.MULTICAST)
+                                                          .setAddress("testB")
+                                                          .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("testB")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged consumer to be shutdown as the statically defined queue
+         // should be the only demand on the address.
+         logger.info("Removing Queues from bridged address 'testA' to eliminate demand");
+         server.destroyQueue(SimpleString.of("testA"));
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of("testA")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged consumer to be shutdown as the statically defined queue
+         // should be the only demand on the address.
+         logger.info("Removing Queues from bridged address 'testB' to eliminate demand");
+         server.destroyQueue(SimpleString.of("testB"));
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of("testB")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testNewBridgeConsumerCreatedWhenDemandRemovedAndAddedWithDelayedPreviousDetach() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress1 = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress1.setName("address-policy-1");
+         receiveFromAddress1.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress1);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Create demand on the address which creates a bridge consumer then let it close which
+         // should shut down that bridge consumer.
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond().afterDelay(40); // Defer the detach response for a bit
+
+            consumer.receiveNoWait();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // Create demand on the address which creates a bridge consumer again quickly which
+         // can trigger a new consumer before the previous one was fully closed with a Detach
+         // response and get stuck because it will steal the link in proton and not be treated
+         // as a new attach for this consumer.
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            consumer.receiveNoWait();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksDetachesAfterLinkQuiesceTimeoutNoIldeTimeout() throws Exception {
+      doTestBridgeLinksDetachesAfterLinkQuiesceTimeout(0);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksDetachesAfterLinkQuiesceTimeoutAndIdleTimeout() throws Exception {
+      doTestBridgeLinksDetachesAfterLinkQuiesceTimeout(10);
+   }
+
+   public void doTestBridgeLinksDetachesAfterLinkQuiesceTimeout(int idleTimeout) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(RECEIVER_QUIESCE_TIMEOUT, 20);
+         receiveFromAddress.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, idleTimeout);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true);  // Don't answer drained then wait for the
+            peer.expectDetach().respond();                           // timeout to see the link is detached.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // New demand should create a new consumer after the last drain timed out and closed the link
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(2000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.expectFlow().withLinkCredit(1000);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksRecoveredAfterLinkQuiesceTimeoutWithRenewedDemand() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(RECEIVER_QUIESCE_TIMEOUT, 300);
+         receiveFromAddress.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 10);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Demand is removed so expect a drain, don't respond then add new consumer to add
+            // demand that must wait on drain to timeout and recover.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true);
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("address-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                              .respond();
+            peer.expectDetach().respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createTopic(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Demand goes away and the bridge link is closed.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(2000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksRecoveredAfterLinkQuiescedButNotIdledOut() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(RECEIVER_QUIESCE_TIMEOUT, 10_000);
+         receiveFromAddress.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 10_000);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Demand is removed so expect a drain, respond to drain to quiesce the link
+            // which should leave it idling and ready for recovery by next consumer.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Link should be restarted by receiving a new batch of credit
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createTopic(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinkIdleTimeoutAtPolicyLevelOverridesTopLevelConfiguration() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(RECEIVER_QUIESCE_TIMEOUT, 10_000);
+         receiveFromAddress.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 250);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 90_000);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Demand is removed so expect a drain, respond to drain to quiesce the link
+            // which should leave it idling and ready for recovery by next consumer.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach().respond();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeResourceDeletedBeforeLinkQuiesceCompletes() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                           .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true); // No answer to allow for race of answer plus delete
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // Now answer the drain request and then immediately remove the resource.
+         peer.remoteFlow().withLinkCredit(0).withDeliveryCount(1000).withDrain(true).now();
+
+         server.removeAddressInfo(SimpleString.of(getTestName()), null);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testTunnledCoreMessageOnSenderThatDidNotDesireThatClosesConnection() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withOfferedCapability(AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .respondInKind(); // Offered capabilities are not reflected as desired here.
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withMessageFormat(AMQP_TUNNELED_CORE_MESSAGE_FORMAT)
+                              .withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectClose().withError(AmqpError.INTERNAL_ERROR.toString()).respond();
+         peer.expectConnectionToDrop();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testDisableOfCoreTunnelingRemovesOfferedCapability() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+         receiveFromAddress.addProperty(TUNNEL_CORE_MESSAGES, Boolean.FALSE.toString());
+         receiveFromAddress.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, Boolean.TRUE.toString());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(TUNNEL_CORE_MESSAGES, Boolean.TRUE.toString());
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.expectAttach().ofReceiver()
+                            .withOfferedCapabilities(nullValue())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .respondInKind(); // Offered capabilities are not reflected as desired here.
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   public static class ApplicationPropertiesTransformer implements Transformer {
+
+      private final Map<String, String> properties = new HashMap<>();
+
+      @Override
+      public void init(Map<String, String> externalProperties) {
+         properties.putAll(externalProperties);
+      }
+
+      @Override
+      public org.apache.activemq.artemis.api.core.Message transform(org.apache.activemq.artemis.api.core.Message message) {
+         if (!(message instanceof AMQPMessage)) {
+            return message;
+         }
+
+         properties.forEach((k, v) -> {
+            message.putStringProperty(k, v);
+         });
+
+         // An AMQP message must be encoded again to carry along the modifications.
+         message.reencode();
+
+         return message;
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromQueueTest.java
@@ -1,0 +1,3791 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledMessageConstants.AMQP_TUNNELED_CORE_MESSAGE_FORMAT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.TUNNEL_CORE_MESSAGES;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.BRIDGE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_PULL_CREDIT_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_PRIORITY;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.TransformerConfiguration;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeQueuePolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.transformer.Transformer;
+import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.proton.amqp.Symbol;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.proton.amqp.transport.LinkError;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.apache.qpid.protonj2.test.driver.codec.messaging.Modified;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests the AMQP bridge from queue behavior.
+ */
+public class AMQPBridgeFromQueueTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testLinkAttachTimeoutAppliedAndConnectionClosed() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+         receiveFromQueue.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(LINK_ATTACH_TIMEOUT, 1); // Seconds
+         element.addProperty(LINK_RECOVERY_INITIAL_DELAY, 20); // Milliseconds
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Modified deliveryFailed = new Modified();
+         deliveryFailed.setDeliveryFailed(true);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withDefaultOutcome(deliveryFailed).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())));
+         peer.expectDetach();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueReceiverLinkForQueueMatchAnycast() throws Exception {
+      doTestBridgeCreatesQueueReceiverLinkForQueueMatch(RoutingType.ANYCAST);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueReceiverLinkForQueueMatchMulticast() throws Exception {
+      doTestBridgeCreatesQueueReceiverLinkForQueueMatch(RoutingType.MULTICAST);
+   }
+
+   private void doTestBridgeCreatesQueueReceiverLinkForQueueMatch(RoutingType routingType) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(routingType)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final Modified deliveryFailed = new Modified();
+         deliveryFailed.setDeliveryFailed(true);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withDefaultOutcome(deliveryFailed).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            if (RoutingType.MULTICAST.equals(routingType)) {
+               // Requires FQQN to meet the test expectations
+               session.createConsumer(session.createTopic(getTestName() + "::" + getTestName()));
+            } else {
+               session.createConsumer(session.createQueue(getTestName()));
+            }
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCarriesConfiguredPolicyFilter() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.setFilter("color='red'");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withJMSSelector("color='red'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCarriesConfiguredPolicyFilterOverQueueFilter() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.setFilter("color='red'");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setFilterString("color='green'")
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withJMSSelector("color='red'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCarriesConfiguredQueueFilter() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setFilterString("color='red'")
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withJMSSelector("color='red'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCarriesConsumerQueueFilter() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setFilterString("color='red' OR color = 'blue'")
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withJMSSelector("color='red'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue  = session.createQueue(getTestName());
+
+            session.createConsumer(queue, "color='red'"); // new receiver for this selector
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName())
+                                            .withJMSSelector("color='blue'").also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(queue, "color='blue'"); // new receiver for this selector
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName())
+                                            .withJMSSelector("color='red' OR color = 'blue'").also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(queue); // No selector so the queue filter should be used
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Should not see more attaches as these match previous variations
+            session.createConsumer(queue, "color='blue'");
+            session.createConsumer(queue, "color='red'");
+            session.createConsumer(queue);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCanIgnoreConsumerQueueFilter() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(IGNORE_QUEUE_CONSUMER_FILTERS, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setFilterString("color='red' OR color = 'blue'")
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withJMSSelector("color='red' OR color = 'blue'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue  = session.createQueue(getTestName());
+
+            session.createConsumer(queue, "color='red'"); // Consumer filter should be ignored
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            session.createConsumer(queue, "color='blue'"); // Consumer filter should be ignored
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCanIgnoreAllFilters() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(IGNORE_QUEUE_CONSUMER_FILTERS, "true");
+         receiveFromQueue.addProperty(IGNORE_QUEUE_FILTERS, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setFilterString("color='red' OR color = 'blue'")
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue  = session.createQueue(getTestName());
+
+            session.createConsumer(queue, "color='red'"); // Consumer filter should be ignored
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            session.createConsumer(queue, "color='blue'"); // Consumer filter should be ignored
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueReceiverLinkForQueueMatchUsingPolicyCredit() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(RECEIVER_CREDITS, "30");
+         receiveFromQueue.addProperty(RECEIVER_CREDITS_LOW, "3");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(30);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeClosesQueueReceiverWhenDemandIsRemovedFromQueue() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeHandlesQueueDeletedAndConsumerRecreates() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach().respond();
+
+            server.destroyQueue(SimpleString.of(getTestName()), null, false, true);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         // Consumer recreates Queue and adds demand back and bridge should restart
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testSecondQueueConsumerDoesNotGenerateAdditionalBridgeReceiver() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testLinkCreatedForEachDistinctQueueMatchInSameConfiguredPolicy() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("addr1", "test.1");
+         receiveFromQueue.addToIncludes("addr2", "test.2");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.1").setRoutingType(RoutingType.ANYCAST)
+                                                           .setAddress("addr1")
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("test.2").setRoutingType(RoutingType.ANYCAST)
+                                                           .setAddress("addr2")
+                                                           .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress("addr1::test.1").also()
+                            .withSource().withAddress("test.1")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.1"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.1"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("addr2::test.2").also()
+                               .withSource().withAddress("test.2")
+                                            .withFilter(nullValue()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("test.2"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000).optional();
+
+            session.createConsumer(session.createQueue("test.2"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true).afterDelay(10);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true).afterDelay(10);
+            peer.expectDetach().respond();
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeReceiverCreatedWhenWildcardPolicyMatchesConsumerQueue() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("", "test.#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.queue").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress(getTestName())
+                                                               .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::test.queue").also()
+                            .withSource().withAddress("test.queue")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.queue"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.queue"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testRemoteCloseOfQueueReceiverRespondsToDetach() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("", "test.#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.queue").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress(getTestName())
+                                                               .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::test.queue").also()
+                            .withSource().withAddress("test.queue")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.queue"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.queue"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach();
+            peer.remoteDetach().withErrorCondition("amqp:resource-deleted", "the resource was deleted").afterDelay(10).now();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testRejectedQueueReceiverAttachWhenLocalMatchingQueueNotFoundIsHandled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("", "test.#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.queue").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress(getTestName())
+                                                               .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() +  "::test.queue").also()
+                            .withSource().withAddress("test.queue")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.queue"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteDetach().withErrorCondition("amqp:not-found", "the requested queue was not found").queue().afterDelay(10);
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.queue"));
+
+            connection.start();
+
+            // Broker normally treats any remote link closure on the broker connection as terminal
+            // but shouldn't in this case as it indicates the requested bridged queue wasn't present
+            // on the remote. New queue interest should result in a new attempt to bridge the queue
+            // and this time we will let it succeed.
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::test.queue").also()
+                               .withSource().withAddress("test.queue")
+                                            .withFilter(nullValue()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("test.queue"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createQueue("test.queue"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testRemoteCloseQueueReceiverWhenRemoteResourceIsDeletedIsHandled() throws Exception {
+      doTestRemoteCloseQueueReceiverForExpectedConditionsIsHandled("amqp:resource-deleted");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testRemoteCloseQueueReceiverWhenRemoteReceiverIsForcedToDetachIsHandled() throws Exception {
+      doTestRemoteCloseQueueReceiverForExpectedConditionsIsHandled("amqp:link:detach-forced");
+   }
+
+   private void doTestRemoteCloseQueueReceiverForExpectedConditionsIsHandled(String condition) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("", "test.#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.queue").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress(getTestName())
+                                                               .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::test.queue").also()
+                            .withSource().withAddress("test.queue")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.queue"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteDetach().withErrorCondition(condition, "error message from remote....").queue().afterDelay(20);
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.queue"));
+
+            connection.start();
+
+            // Broker normally treats any remote link closure on the broker connection as terminal
+            // but shouldn't in this case as it indicates the requested bridge queue receiver was
+            // forced closed. New queue interest should result in a new attempt to bridge the queue
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::test.queue").also()
+                               .withSource().withAddress("test.queue")
+                                            .withFilter(nullValue()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("test.queue"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createQueue("test.queue"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testUnhandledRemoteReceiverCloseConditionCausesConnectionRebuild() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("", "test.#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(1); // One reconnect to meet test expectations and use a
+         amqpConnection.setRetryInterval(100);   // Short reconnect interval.
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.queue").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress(getTestName())
+                                                               .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::test.queue").also()
+                            .withSource().withAddress("test.queue")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.queue"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.queue"));
+
+            connection.start();
+
+            // Broker treats some remote link closures on the broker connection as terminal
+            // in this case we signal some internal error which should cause rebuild of the
+            // broker connection.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            peer.expectDetach().optional(); // Broker is not consistent on sending the detach
+            peer.expectClose().optional();
+            peer.expectConnectionToDrop();
+            peer.expectSASLAnonymousConnect();
+            peer.expectOpen().respond();
+            peer.expectBegin().respond();
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::test.queue").also()
+                               .withSource().withAddress("test.queue")
+                                            .withFilter(nullValue()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("test.queue"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Trigger the error that should cause the broker to drop and reconnect
+            peer.remoteDetach().withErrorCondition("amqp:internal-error", "the resource suffered an internal error").afterDelay(15).now();
+
+            peer.waitForScriptToComplete(50, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testInboundMessageRoutedToReceiverOnLocalQueue() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("", "test.#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.queue").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress(getTestName())
+                                                               .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::test.queue").also()
+                            .withSource().withAddress("test.queue")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.queue"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue("test.queue"));
+
+            connection.start();
+
+            final Message message = consumer.receive(20_0000);
+            assertNotNull(message);
+            assertTrue(message instanceof TextMessage);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testLinkCreatedForEachDistinctQueueMatchInSameConfiguredPolicyWithSameAddressMatch() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("addr", "test.1");
+         receiveFromQueue.addToIncludes("addr", "test.2");
+         receiveFromQueue.addToIncludes("addr", "test.3");
+         receiveFromQueue.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("test.1").setRoutingType(RoutingType.ANYCAST)
+                                                           .setAddress("addr")
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("test.2").setRoutingType(RoutingType.ANYCAST)
+                                                           .setAddress("addr")
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("test.3").setRoutingType(RoutingType.ANYCAST)
+                                                           .setAddress("addr")
+                                                           .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress("addr::test.1").also()
+                            .withSource().withAddress("test.1")
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("test.1"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000).optional();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("test.1"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("addr::test.2").also()
+                               .withSource().withAddress("test.2")
+                                            .withFilter(nullValue()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("test.2"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000).optional();
+
+            session.createConsumer(session.createQueue("test.2"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("addr::test.3").also()
+                               .withSource().withAddress("test.3")
+                                            .withFilter(nullValue()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("test.3"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000).optional();
+
+            session.createConsumer(session.createQueue("test.3"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true).afterDelay(10);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true).afterDelay(10);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true).afterDelay(10);
+            peer.expectDetach().respond();
+            peer.expectDetach().respond();
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testTransformInboundBridgeMessageBeforeDispatch() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final Map<String, String> newApplicationProperties = new HashMap<>();
+         newApplicationProperties.put("appProperty1", "one");
+         newApplicationProperties.put("appProperty2", "two");
+
+         final TransformerConfiguration transformerConfiguration = new TransformerConfiguration();
+         transformerConfiguration.setClassName(ApplicationPropertiesTransformer.class.getName());
+         transformerConfiguration.setProperties(newApplicationProperties);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.setTransformerConfiguration(transformerConfiguration);
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertTrue(message instanceof TextMessage);
+            assertEquals("test-message", ((TextMessage) message).getText());
+            assertEquals("one", message.getStringProperty("appProperty1"));
+            assertEquals("two", message.getStringProperty("appProperty2"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testPullQueueConsumerGrantsDefaultCreditOnEmptyQueue() throws Exception {
+      doTestPullConsumerGrantsConfiguredCreditOnEmptyQueue(0, false, 0, false, DEFAULT_PULL_CREDIT_BATCH_SIZE);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testPullQueueConsumerGrantsReceiverConfiguredCreditOnEmptyQueue() throws Exception {
+      doTestPullConsumerGrantsConfiguredCreditOnEmptyQueue(0, false, 10, true, 10);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testPullQueueConsumerGrantsConfiguredCreditOnEmptyQueue() throws Exception {
+      doTestPullConsumerGrantsConfiguredCreditOnEmptyQueue(20, true, 0, false, 20);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testPullQueueConsumerGrantsReceiverConfiguredCreditOverBridgeConfiguredOnEmptyQueue() throws Exception {
+      doTestPullConsumerGrantsConfiguredCreditOnEmptyQueue(20, true, 10, true, 10);
+   }
+
+   private void doTestPullConsumerGrantsConfiguredCreditOnEmptyQueue(int globalBatch, boolean setGlobal,
+                                                                     int receiverBatch, boolean setReceiver,
+                                                                     int expected) throws Exception {
+
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(RECEIVER_CREDITS, 0);
+         if (setReceiver) {
+            receiveFromQueue.addProperty(PULL_RECEIVER_BATCH_SIZE, receiverBatch);
+         }
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         if (setGlobal) {
+            element.addProperty(PULL_RECEIVER_BATCH_SIZE, globalBatch);
+         }
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(expected);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(30)
+   public void testPullQueueConsumerGrantsCreditOnlyWhenPendingMessageIsConsumed() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // Must be pull consumer to ensure we can check that demand on remote doesn't
+         // offer credit until the pending message count on the Queue is zeroed
+         final ConnectionFactory factory = CFUtil.createConnectionFactory(
+            "AMQP", "tcp://localhost:" + AMQP_PORT + "?jms.prefetchPolicy.all=0");
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue = session.createQueue(getTestName());
+            final MessageProducer producer = session.createProducer(queue);
+
+            // Add to backlog
+            producer.send(session.createMessage());
+
+            // Now create demand on the queue
+            final MessageConsumer consumer = session.createConsumer(queue);
+
+            connection.start();
+            producer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(DEFAULT_PULL_CREDIT_BATCH_SIZE);
+
+            // Remove the backlog and credit should be offered to the remote
+            assertNotNull(consumer.receiveNoWait());
+
+            peer.waitForScriptToComplete(20, TimeUnit.SECONDS);
+
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(30)
+   public void testPullQueueConsumerBatchCreditTopUpAfterEachBacklogDrain() throws Exception {
+      doTestPullConsumerCreditTopUpAfterEachBacklogDrain(0, false, 0, false, DEFAULT_PULL_CREDIT_BATCH_SIZE);
+   }
+
+   @Test
+   @Timeout(30)
+   public void testPullQueueConsumerBatchCreditTopUpAfterEachBacklogDrainBridgeConfigured() throws Exception {
+      doTestPullConsumerCreditTopUpAfterEachBacklogDrain(10, true, 0, false, 10);
+   }
+
+   @Test
+   @Timeout(30)
+   public void testPullQueueConsumerBatchCreditTopUpAfterEachBacklogDrainPolicyConfigured() throws Exception {
+      doTestPullConsumerCreditTopUpAfterEachBacklogDrain(0, false, 20, true, 20);
+   }
+
+   @Test
+   @Timeout(30)
+   public void testPullQueueConsumerBatchCreditTopUpAfterEachBacklogDrainBothConfigured() throws Exception {
+      doTestPullConsumerCreditTopUpAfterEachBacklogDrain(100, true, 20, true, 20);
+   }
+
+   private void doTestPullConsumerCreditTopUpAfterEachBacklogDrain(int globalBatch, boolean setGlobal,
+                                                                   int receiverBatch, boolean setReceiver,
+                                                                   int expected) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final SimpleString queueName = SimpleString.of(getTestName());
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         if (setReceiver) {
+            receiveFromQueue.addProperty(PULL_RECEIVER_BATCH_SIZE, receiverBatch);
+         }
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+         if (setGlobal) {
+            element.addProperty(PULL_RECEIVER_BATCH_SIZE, globalBatch);
+         }
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(
+               getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort() + "?amqpCredits=0");
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // Must be pull consumer to ensure we can check that demand on remote doesn't
+         // offer credit until the pending message count on the Queue is zeroed
+         final ConnectionFactory factory = CFUtil.createConnectionFactory(
+            "AMQP", "tcp://localhost:" + AMQP_PORT + "?jms.prefetchPolicy.all=0");
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue = session.createQueue(getTestName());
+            final MessageProducer producer = session.createProducer(queue);
+
+            // Add to backlog
+            producer.send(session.createMessage());
+
+            // Now create demand on the queue
+            final MessageConsumer consumer = session.createConsumer(queue);
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(expected);
+
+            // Remove the backlog and credit should be offered to the remote
+            assertNotNull(consumer.receiveNoWait());
+
+            peer.waitForScriptToComplete(20, TimeUnit.SECONDS);
+
+            // Consume all the credit that was presented in the batch
+            for (int i = 0; i < expected; ++i) {
+               peer.expectDisposition().withState().accepted();
+               peer.remoteTransfer().withBody().withString("test-message")
+                                    .also()
+                                    .withDeliveryId(i)
+                                    .now();
+            }
+
+            Wait.assertTrue(() -> server.queueQuery(queueName).getMessageCount() == expected, 10_000);
+
+            // Consume all the newly received message from the remote except one
+            // which should leave the queue with a pending message so no credit
+            // should be offered.
+            for (int i = 0; i < expected - 1; ++i) {
+               assertNotNull(consumer.receiveNoWait());
+            }
+
+            // We should not get a new batch yet as there is still one pending
+            // message on the local queue we have not consumed.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(expected);
+
+            // Remove the backlog and credit should be offered to the remote again
+            assertNotNull(consumer.receiveNoWait());
+
+            peer.waitForScriptToComplete(20, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(expected).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(expected + expected).withDrain(true);
+            peer.expectDetach().respond();
+
+            consumer.close(); // Remove local demand and bridge consumer is torn down.
+
+            peer.waitForScriptToComplete(20, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueReceiverLinkForQueueAfterBrokerConnectionStarted() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.setAutostart(false);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         final Connection connection = factory.createConnection();
+         final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Queue queue = session.createQueue(getTestName());
+
+         session.createConsumer(queue);
+         session.createConsumer(queue);
+         session.createConsumer(queue);
+
+         connection.start();
+
+         // Should be no interactions yet, check to be sure
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.getBrokerConnections().forEach(c -> {
+            try {
+               c.start();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         });
+
+         // Add another demand consumer immediately after start to add more events
+         // on the bridge plugin for broker events.
+         session.createConsumer(queue);
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withFilter(nullValue()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                          .respond()
+                          .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+         peer.expectDetach().respond();
+
+         // Add more demand after the broker connection starts
+         session.createConsumer(queue);
+         session.createConsumer(queue);
+
+         // This should remove all demand on the queue and bridge should stop
+         connection.close();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueDemandTrackedWhenRemoteRejectsInitialAttempts() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final Queue queue = session.createQueue(getTestName());
+
+            connection.start();
+
+            // First consumer we reject the bridge attempt
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond()
+                               .withNullSource();
+            peer.expectFlow().withLinkCredit(1000);
+            peer.remoteDetach().withErrorCondition("amqp:not-found", "the requested queue was not found").queue().afterDelay(10);
+            peer.expectDetach();
+
+            final MessageConsumer consumer1 = session.createConsumer(queue);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Second consumer we reject the bridge attempt
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond()
+                               .withNullSource();
+            peer.expectFlow().withLinkCredit(1000);
+            peer.remoteDetach().withErrorCondition("amqp:not-found", "the requested queue was not found").queue().afterDelay(10);
+            peer.expectDetach();
+
+            final MessageConsumer consumer2 = session.createConsumer(queue);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Third consumer we accept the bridge attempt
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            final MessageConsumer consumer3 = session.createConsumer(queue);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Demand should remain
+            consumer3.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Demand should remain
+            consumer2.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+
+            // Demand should be gone now
+            consumer1.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCarriesConfiguredPrioirty() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.setPriority(10);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withProperty(BRIDGE_RECEIVER_PRIORITY.toString(), 10)
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverCarriesConfiguredPrioirtyAdjustment() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.setPriorityAdjustment(-10); // Default minus this value
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withProperty(BRIDGE_RECEIVER_PRIORITY.toString(), ActiveMQDefaultConfiguration.getDefaultConsumerPriority() - 10)
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverOmitsConfiguredPrioirtyWhenPrioritiesDisabled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.setPriority(10); // Should be ignored regardless of being manually set.
+         receiveFromQueue.addProperty(DISABLE_RECEIVER_PRIORITY, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withProperties(not(Matchers.hasEntry(BRIDGE_RECEIVER_PRIORITY.toString(), 10)))
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverAppliesConfiguredRemoteAddressPrefix() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations("topic://", null, null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverAppliesConfiguredRemoteAddressSuffix() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations(null, null, "?consumer-priority=1");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverAppliesConfiguredRemoteAddress() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations(null, "alternate", null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverAppliesConfiguredRemoteAddressCustomizations() throws Exception {
+      doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations("topic://", "alternate", "?consumer-priority=1");
+   }
+
+   private void doTestBridgeReceiverAppliesConfiguredRemoteAddressCustomizations(String prefix, String address, String suffix) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("address-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.setRemoteAddress(address);
+         receiveFromQueue.setRemoteAddressPrefix(prefix);
+         receiveFromQueue.setRemoteAddressSuffix(suffix);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         final String expectedSourceAddress = (prefix != null ? prefix : "") +
+                                              (address != null ? address : getTestName()) +
+                                              (suffix != null ? suffix : "");
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(expectedSourceAddress).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueReceiverAddsRemoteTerminusCapabilitiesConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.setRemoteTerminusCapabilities(new String[] {"topic", "another"});
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("topic", "another")
+                                         .also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressReceiverSetsSenderPresettledWhenConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(PRESETTLE_SEND_MODE, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withSenderSettleModeSettled()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeStartedTriggersRemoteDemandWithExistingQueuesWithoutConsumersWhenTrackingDisabled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.setAutostart(false);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                         .setAddress(getTestName())
+                                                         .setAutoCreated(false));
+
+         // Other non-matching queues that also get scanned on start
+         server.createQueue(QueueConfiguration.of("other").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress("other")
+                                                          .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("another").setRoutingType(RoutingType.ANYCAST)
+                                                            .setAddress("another")
+                                                            .setAutoCreated(false));
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // Starting the broker connection should trigger bridge of address with demand.
+         server.getBrokerConnections().forEach(c -> {
+            try {
+               c.start();
+            } catch (Exception e) {
+               throw new RuntimeException(e);
+            }
+         });
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridge consumer to be shutdown as the target Queue is now gone.
+         logger.info("Removing Queues to eliminate demand");
+         server.destroyQueue(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeTriggersRemoteDemandAfterQueueCreatedWhenTrackingDisabled() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         // Other non-matching queues that also get scanned on start
+         server.createQueue(QueueConfiguration.of("other").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress("other")
+                                                          .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("another").setRoutingType(RoutingType.ANYCAST)
+                                                            .setAddress("another")
+                                                            .setAutoCreated(false));
+
+         // Should be no interactions at this point, check to make sure.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridge consumer to be shutdown as the target Queue is now gone.
+         logger.info("Removing Queues to eliminate demand");
+         server.destroyQueue(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverForceDetached() throws Exception {
+      doTestBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverDetached(LinkError.DETACH_FORCED);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverResourceDeleted() throws Exception {
+      doTestBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverDetached(AmqpError.RESOURCE_DELETED);
+   }
+
+   private void doTestBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverDetached(Symbol condition) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach();
+            peer.remoteDetach().withErrorCondition(condition.toString(), "Forced Detach").now();
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after another consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createQueue(getTestName())); // New demand.
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRetriesReceiverAttachOnNewDemandAfterFirstReceiverResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after another consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createQueue(getTestName())); // New demand.
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRecoversLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 10 millisecond initial recovery delay
+         receiveFromQueue.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after delay.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAttemptsLimitedRecoveryLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addToIncludes("another", "another");
+         receiveFromQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 10 millisecond initial recovery delay
+         receiveFromQueue.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+         receiveFromQueue.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 2);   // 2 attempts then stop trying
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("another"), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Attempt #1
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond()
+                               .withNullSource();
+            peer.remoteDetach().withClosed(true)
+                               .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+            peer.expectFlow().optional();
+            peer.expectDetach();
+
+            // Attempt #2
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .respond()
+                               .withNullSource();
+            peer.remoteDetach().withClosed(true)
+                               .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+            peer.expectFlow().optional();
+            peer.expectDetach();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after new consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("another::another").also()
+                               .withSource().withAddress("another").also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("another"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Trigger demand on the alternate to which will start an attach on that
+            session.createConsumer(session.createQueue("another"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after new consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Now add new demand and trigger another attempt to create the bridge receiver
+            session.createConsumer(session.createQueue(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeDoesNotAttemptLimitedRecoveryAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addToIncludes("another", "another");
+         receiveFromQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 1);  // 1 millisecond initial recovery delay
+         receiveFromQueue.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+         receiveFromQueue.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 0);   // No attempts
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
+         server.addAddressInfo(new AddressInfo(SimpleString.of("another"), RoutingType.ANYCAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullSource();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectFlow().optional();
+         peer.expectDetach();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Try after new consumer added to alternate queue.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress("another::another").also()
+                               .withSource().withAddress("another").also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("another"),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Add demand on alternate Queue which triggers a receiver attach.
+            session.createConsumer(session.createQueue("another"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Retry after new consumer added.
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            // Now add new demand on Queue and it should trigger another attach attempt
+            session.createConsumer(session.createQueue(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeFromQueueHandledMultipleBridgeConfigurationsAndCreatesReceiver() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue1 = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue1.setName("queue-policy-1");
+         receiveFromQueue1.setFilter("color='red'");
+         receiveFromQueue1.addToIncludes(getTestName(), "testA");
+         final AMQPBridgeBrokerConnectionElement element1 = new AMQPBridgeBrokerConnectionElement();
+         element1.setName(getTestName());
+         element1.addBridgeFromQueuePolicy(receiveFromQueue1);
+         element1.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue2 = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue2.setName("queue-policy-2");
+         receiveFromQueue2.setFilter("color='blue'");
+         receiveFromQueue2.addToIncludes("#", "testB");
+         final AMQPBridgeBrokerConnectionElement element2 = new AMQPBridgeBrokerConnectionElement();
+         element2.setName(getTestName());
+         element2.addBridgeFromQueuePolicy(receiveFromQueue2);
+         element2.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element1);
+         amqpConnection.addElement(element2);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of("testA").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress(getTestName())
+                                                          .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("testB").setRoutingType(RoutingType.ANYCAST)
+                                                          .setAddress("address")
+                                                          .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::testA").also()
+                            .withSource().withAddress("testA")
+                                         .withJMSSelector("color='red'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("testA"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("testA"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress("address::testB").also()
+                            .withSource().withAddress("testB")
+                                         .withJMSSelector("color='blue'").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("testB"),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue("testB"));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksDetachesAfterLinkQuiesceTimeoutWithIdleTimeout() throws Exception {
+      doTestBridgeLinksDetachesAfterLinkQuiesceTimeout(2);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksDetachesAfterLinkQuiesceTimeoutNoIdleTimeout() throws Exception {
+      doTestBridgeLinksDetachesAfterLinkQuiesceTimeout(0);
+   }
+
+   private void doTestBridgeLinksDetachesAfterLinkQuiesceTimeout(int idleTimeout) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(RECEIVER_QUIESCE_TIMEOUT, 20);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, idleTimeout);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true);  // Don't answer drained then wait for the
+            peer.expectDetach().respond();                           // timeout to see the link is detached.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         // New demand should create a new bridge consumer after the last drain timed out and closed the link
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(2000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksRecoveredAfterLinkQuiesceTimeoutWithRenewedDemandNoIdleTimeout() throws Exception {
+      doTestBridgeLinksRecoveredAfterLinkQuiesceTimeoutWithRenewedDemand(0);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksRecoveredAfterLinkQuiesceTimeoutWithRenewedDemandWithIdleTimeout() throws Exception {
+      doTestBridgeLinksRecoveredAfterLinkQuiesceTimeoutWithRenewedDemand(2);
+   }
+
+   private void doTestBridgeLinksRecoveredAfterLinkQuiesceTimeoutWithRenewedDemand(int idleTimeout) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(RECEIVER_QUIESCE_TIMEOUT, 300);
+         receiveFromQueue.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, idleTimeout);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Demand is removed so expect a drain, don't respond then add new consumer to add
+            // demand that must wait on drain to timeout and recover.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true);
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectAttach().ofReceiver()
+                               .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-receiver"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+            peer.expectDetach().respond();
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createQueue(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Demand goes away and the bridge link is closed.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(2000).withDrain(true);
+            peer.expectDetach().respond();
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeResourceDeletedBeforeLinkQuiesceCompletesNoIdleTimeout() throws Exception {
+      doTestBridgeResourceDeletedBeforeLinkQuiesceCompletes(0);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeResourceDeletedBeforeLinkQuiesceCompletesWithIdleTimeout() throws Exception {
+      doTestBridgeResourceDeletedBeforeLinkQuiesceCompletes(2);
+   }
+
+   private void doTestBridgeResourceDeletedBeforeLinkQuiesceCompletes(int idleTimeout) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, idleTimeout);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectFlow().withLinkCredit(1000).withDrain(true); // No answer to allow for race of answer plus delete
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // Now answer the drain request and then immediately remove the resource.
+         peer.remoteFlow().withLinkCredit(0).withDeliveryCount(1000).withDrain(true).now();
+
+         server.destroyQueue(SimpleString.of(getTestName()));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinksRecoveredAfterLinkQuiescedButNotIdledOut() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(RECEIVER_QUIESCE_TIMEOUT, 10_000);
+         receiveFromQueue.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 10_000);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Demand is removed so expect a drain, respond to drain to quiesce the link
+            // which should leave it idling and ready for recovery by next consumer.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Link should be restarted by receiving a new batch of credit
+            peer.expectFlow().withLinkCredit(1000);
+
+            session.createConsumer(session.createQueue(getTestName()));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeLinkIdleTimeoutAtPolicyLevelOverridesTopLevelConfiguration() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes(getTestName(), getTestName());
+         receiveFromQueue.addProperty(RECEIVER_QUIESCE_TIMEOUT, 10_000);
+         receiveFromQueue.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 250);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 90_000);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            // Demand is removed so expect a drain, respond to drain to quiesce the link
+            // which should leave it idling and ready for recovery by next consumer.
+            peer.expectFlow().withLinkCredit(1000).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+
+            consumer.close();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectDetach().respond();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testTunnledCoreMessageOnSenderThatDidNotDesireThatClosesConnection() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withOfferedCapability(AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .respondInKind(); // Offered capabilities are not reflected as desired here.
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withMessageFormat(AMQP_TUNNELED_CORE_MESSAGE_FORMAT)
+                              .withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectClose().withError(AmqpError.INTERNAL_ERROR.toString()).respond();
+         peer.expectConnectionToDrop();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testDisableOfCoreTunnelingRemovesOfferedCapability() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+         receiveFromQueue.addProperty(TUNNEL_CORE_MESSAGES, Boolean.FALSE.toString());
+         receiveFromQueue.addProperty(DISABLE_RECEIVER_DEMAND_TRACKING, Boolean.TRUE.toString());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(TUNNEL_CORE_MESSAGES, Boolean.TRUE.toString());
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.expectAttach().ofReceiver()
+                            .withOfferedCapabilities(nullValue())
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString(server.getNodeID().toString())))
+                            .respondInKind(); // Offered capabilities are not reflected as desired here.
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   public static class ApplicationPropertiesTransformer implements Transformer {
+
+      private final Map<String, String> properties = new HashMap<>();
+
+      @Override
+      public void init(Map<String, String> externalProperties) {
+         properties.putAll(externalProperties);
+      }
+
+      @Override
+      public org.apache.activemq.artemis.api.core.Message transform(org.apache.activemq.artemis.api.core.Message message) {
+         if (!(message instanceof AMQPMessage)) {
+            return message;
+         }
+
+         properties.forEach((k, v) -> {
+            message.putStringProperty(k, v);
+         });
+
+         // An AMQP message must be encoded again to carry along the modifications.
+         message.reencode();
+
+         return message;
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeManagementTest.java
@@ -1,0 +1,1500 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.BrokerConnectionControl;
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeAddressPolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeQueuePolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeManagementSupport;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeManagerControl;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgePolicyManagerControl;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeReceiverControl;
+import org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeSenderControl;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests that the broker create management objects for AMQP bridge configurations.
+ */
+public class AMQPBridgeManagementTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesManagementResourcesForAddressPolicyConfigurations() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+
+         assertNotNull(brokerConnection);
+         assertTrue(brokerConnection.isConnected());
+
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "address-policy");
+         final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeAddressReceiverResourceName(getTestName(), getTestName(), "address-policy", getTestName());
+
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+         final AMQPBridgePolicyManagerControl addressPolicyControl =
+            (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+
+         assertNotNull(bridgeControl);
+         assertEquals(getTestName(), bridgeControl.getName());
+         assertEquals(0, bridgeControl.getMessagesReceived());
+         assertEquals(0, bridgeControl.getMessagesSent());
+
+         assertNotNull(addressPolicyControl);
+         assertEquals("address-policy", addressPolicyControl.getName());
+         assertEquals(0, addressPolicyControl.getMessagesReceived());
+
+         final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+            server.getManagementService().getResource(consumerResourceName);
+
+         assertNotNull(consumerControl);
+         assertEquals(getTestName(), consumerControl.getAddress());
+         assertEquals(0, consumerControl.getMessagesReceived());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         brokerConnection.stop();
+
+         // Stopping the connection should remove the bridge consumer management objects.
+         Wait.assertTrue(() -> server.getManagementService().getResource(consumerResourceName) == null, 5_000, 100);
+
+         assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+         server.getBrokerConnections().forEach((connection) -> {
+            try {
+               connection.shutdown();
+            } catch (Exception e) {
+               fail("Broker connection shutdown should not have thrown an exception");
+            }
+         });
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(bridgeResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(brokerConnectionName) == null, 5_000, 100);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesAddressConsumerManagementWhenConnectionDrops() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(ResourceNames.BROKER_CONNECTION + getTestName());
+
+         assertNotNull(brokerConnection);
+         assertTrue(brokerConnection.isConnected());
+
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "address-policy");
+         final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeAddressReceiverResourceName(getTestName(), getTestName(), "address-policy", getTestName());
+
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+         final AMQPBridgePolicyManagerControl addressPolicyControl =
+            (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+         final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+            server.getManagementService().getResource(consumerResourceName);
+
+         assertNotNull(bridgeControl);
+         assertNotNull(addressPolicyControl);
+         assertNotNull(consumerControl);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+
+         // Closing the connection without a detach or close frame should still cleanup the management
+         // resources for the consumer but the policy views should still be in place
+         Wait.assertTrue(() -> server.getManagementService().getResource(consumerResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesAddressConsumerManagementWhenBrokerConnectionStopped() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.MULTICAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(ResourceNames.BROKER_CONNECTION + getTestName());
+
+         assertNotNull(brokerConnection);
+         assertTrue(brokerConnection.isConnected());
+
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "address-policy");
+         final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeAddressReceiverResourceName(getTestName(), getTestName(), "address-policy", getTestName());
+
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+         final AMQPBridgePolicyManagerControl addressPolicyControl =
+            (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+         final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+            server.getManagementService().getResource(consumerResourceName);
+
+         assertNotNull(bridgeControl);
+         assertNotNull(addressPolicyControl);
+         assertNotNull(consumerControl);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectConnectionToDrop();
+
+         brokerConnection.stop();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Closing the connection without a detach or close frame should still cleanup the management
+         // resources for the consumer but the policy views should still be in place
+         Wait.assertTrue(() -> server.getManagementService().getResource(consumerResourceName) == null, 5_000, 100);
+
+         assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesManagementResourcesForQueuePolicyConfigurations() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+         receiveFromQueue.setPriorityAdjustment(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+            final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+            final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "queue-policy");
+            final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeQueueReceiverResourceName(getTestName(), getTestName(), "queue-policy", getTestName() + "::" + getTestName());
+
+            final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+               server.getManagementService().getResource(brokerConnectionName);
+            final AMQPBridgeManagerControl bridgeControl =
+               (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+
+            assertNotNull(brokerConnection);
+            assertTrue(brokerConnection.isConnected());
+            assertNotNull(bridgeControl);
+            assertEquals(getTestName(), bridgeControl.getName());
+            assertEquals(0, bridgeControl.getMessagesReceived());
+            assertEquals(0, bridgeControl.getMessagesSent());
+
+            final AMQPBridgePolicyManagerControl queuePolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+
+            assertNotNull(queuePolicyControl);
+            assertEquals("queue-policy", queuePolicyControl.getName());
+            assertEquals(0, queuePolicyControl.getMessagesReceived());
+
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertNotNull(consumerControl);
+            assertEquals(getTestName(), consumerControl.getAddress());
+            assertEquals(getTestName(), consumerControl.getQueueName());
+            assertEquals(getTestName() + "::" + getTestName(), consumerControl.getFqqn());
+            assertEquals(0, consumerControl.getMessagesReceived());
+            assertEquals(1, consumerControl.getPriority());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            brokerConnection.stop();
+
+            // Stopping the connection should remove the bridge management objects.
+            Wait.assertTrue(() -> server.getManagementService().getResource(consumerResourceName) == null, 5_000, 100);
+
+            assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+            server.getBrokerConnections().forEach((brConnection) -> {
+               try {
+                  brConnection.shutdown();
+               } catch (Exception e) {
+                  fail("Broker connection shutdown should not have thrown an exception");
+               }
+            });
+
+            Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) == null, 5_000, 100);
+            Wait.assertTrue(() -> server.getManagementService().getResource(bridgeResourceName) == null, 5_000, 100);
+            Wait.assertTrue(() -> server.getManagementService().getResource(brokerConnectionName) == null, 5_000, 100);
+
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesQueueConsumerManagementWhenConnectionDrops() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+         receiveFromQueue.setPriorityAdjustment(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+            final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+            final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "queue-policy");
+            final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeQueueReceiverResourceName(getTestName(), getTestName(), "queue-policy", getTestName() + "::" + getTestName());
+
+            final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+               server.getManagementService().getResource(brokerConnectionName);
+            final AMQPBridgeManagerControl bridgeControl =
+               (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+            final AMQPBridgePolicyManagerControl queuePolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertNotNull(brokerConnection);
+            assertTrue(brokerConnection.isConnected());
+            assertNotNull(bridgeControl);
+            assertNotNull(queuePolicyControl);
+            assertNotNull(consumerControl);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.close();
+
+            // Closing the connection without a detach or close frame should still cleanup the management
+            // resources for the consumer but the policy views should still be in place
+            Wait.assertTrue(() -> server.getManagementService().getResource(consumerResourceName) == null, 5_000, 100);
+            Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesQueueConsumerManagementWhenBrokerConnectionStopped() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Connect test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+         receiveFromQueue.setPriorityAdjustment(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+            final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+            final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "queue-policy");
+            final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeQueueReceiverResourceName(getTestName(), getTestName(), "queue-policy", getTestName() + "::" + getTestName());
+
+            final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+               server.getManagementService().getResource(brokerConnectionName);
+            final AMQPBridgeManagerControl bridgeControl =
+               (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+            final AMQPBridgePolicyManagerControl queuePolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertNotNull(brokerConnection);
+            assertTrue(brokerConnection.isConnected());
+            assertNotNull(bridgeControl);
+            assertNotNull(queuePolicyControl);
+            assertNotNull(consumerControl);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectConnectionToDrop();
+
+            brokerConnection.stop();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            // Closing the connection without a detach or close frame should still cleanup the management
+            // resources for the consumer but the policy views should still be in place
+            Wait.assertTrue(() -> server.getManagementService().getResource(consumerResourceName) == null, 5_000, 100);
+
+            assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+            peer.close();
+         }
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testAddressManagementTracksMessagesAtPolicyAndConsumerLevels() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement receiveFromAddress = new AMQPBridgeAddressPolicyElement();
+         receiveFromAddress.setName("address-policy");
+         receiveFromAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromAddressPolicy(receiveFromAddress);
+         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "address-policy");
+         final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeAddressReceiverResourceName(getTestName(), getTestName(), "address-policy", getTestName());
+
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertInstanceOf(TextMessage.class, message);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final AMQPBridgePolicyManagerControl addressPolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertEquals(1, bridgeControl.getMessagesReceived());
+            assertEquals(1, addressPolicyControl.getMessagesReceived());
+            assertEquals(1, consumerControl.getMessagesReceived());
+
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Policy bean should still be active but consumer bean should be unregistered
+         {
+            final AMQPBridgePolicyManagerControl addressPolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertNotNull(addressPolicyControl);
+            assertNull(consumerControl);
+         }
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(1)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createTopic(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertInstanceOf(TextMessage.class, message);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final AMQPBridgePolicyManagerControl addressPolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertEquals(2, bridgeControl.getMessagesReceived());
+            assertEquals(2, addressPolicyControl.getMessagesReceived());
+            assertEquals(1, consumerControl.getMessagesReceived());
+
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testQueueManagementTracksMessagesAtPolicyAndConsumerLevels() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement receiveFromQueue = new AMQPBridgeQueuePolicyElement();
+         receiveFromQueue.setName("queue-policy");
+         receiveFromQueue.addToIncludes("#", getTestName());
+         receiveFromQueue.setPriorityAdjustment(1);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeFromQueuePolicy(receiveFromQueue);
+         element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(0)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "queue-policy");
+         final String consumerResourceName = AMQPBridgeManagementSupport.getBridgeQueueReceiverResourceName(getTestName(), getTestName(), "queue-policy", getTestName() + "::" + getTestName());
+
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertInstanceOf(TextMessage.class, message);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final AMQPBridgePolicyManagerControl queuePolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertEquals(1, bridgeControl.getMessagesReceived());
+            assertEquals(1, queuePolicyControl.getMessagesReceived());
+            assertEquals(1, consumerControl.getMessagesReceived());
+
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Policy bean should still be active but consumer bean should be unregistered
+         {
+            final AMQPBridgePolicyManagerControl queuePolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertNotNull(queuePolicyControl);
+            assertNull(consumerControl);
+         }
+
+         peer.expectAttach().ofReceiver()
+                            .withTarget().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-receiver"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.expectFlow().withLinkCredit(1000);
+         peer.remoteTransfer().withBody().withString("test-message")
+                              .also()
+                              .withDeliveryId(1)
+                              .queue();
+         peer.expectDisposition().withSettled(true).withState().accepted();
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageConsumer consumer = session.createConsumer(session.createQueue(getTestName()));
+
+            connection.start();
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final Message message = consumer.receive(5_000);
+            assertNotNull(message);
+            assertInstanceOf(TextMessage.class, message);
+            assertEquals("test-message", ((TextMessage) message).getText());
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            final AMQPBridgePolicyManagerControl queuePolicyControl =
+               (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+            final AMQPBridgeReceiverControl consumerControl = (AMQPBridgeReceiverControl)
+               server.getManagementService().getResource(consumerResourceName);
+
+            assertEquals(2, bridgeControl.getMessagesReceived());
+            assertEquals(2, queuePolicyControl.getMessagesReceived());
+            assertEquals(1, consumerControl.getMessagesReceived());
+
+            peer.expectFlow().withLinkCredit(999).withDrain(true)
+                             .respond()
+                             .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);
+            peer.expectDetach().respond(); // demand will be gone and receiver link should close.
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesManagementResourcesForToAddressPolicyConfigurations() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("to-address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "to-address-policy");
+         final String producerResourceName = AMQPBridgeManagementSupport.getBridgeAddressSenderResourceName(getTestName(), getTestName(), "to-address-policy", getTestName());
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+         final AMQPBridgePolicyManagerControl addressPolicyControl =
+            (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+         final AMQPBridgeSenderControl producerControl = (AMQPBridgeSenderControl)
+            server.getManagementService().getResource(producerResourceName);
+
+         assertNotNull(brokerConnection);
+         assertTrue(brokerConnection.isConnected());
+
+         assertNotNull(bridgeControl);
+         assertEquals(getTestName(), bridgeControl.getName());
+         assertEquals(0, bridgeControl.getMessagesReceived());
+         assertEquals(0, bridgeControl.getMessagesSent());
+
+         assertNotNull(addressPolicyControl);
+         assertEquals("to-address-policy", addressPolicyControl.getName());
+         assertEquals(0, addressPolicyControl.getMessagesReceived());
+
+         assertNotNull(producerControl);
+         assertEquals(getTestName(), producerControl.getAddress());
+         assertEquals(0, producerControl.getMessagesSent());
+
+         // Message sent to server is forwarded
+         peer.expectTransfer().accept();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createTopic(getTestName()));
+
+            producer.send(session.createMessage());
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         assertEquals(1, bridgeControl.getMessagesSent());
+         assertEquals(1, addressPolicyControl.getMessagesSent());
+         assertEquals(1, producerControl.getMessagesSent());
+
+         brokerConnection.stop();
+
+         // Stopping the connection should remove the bridge producer management objects.
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) == null, 5_000, 100);
+
+         assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+         server.getBrokerConnections().forEach((connection) -> {
+            try {
+               connection.shutdown();
+            } catch (Exception e) {
+               fail("Broker connection shutdown should not have thrown an exception");
+            }
+         });
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(bridgeResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(brokerConnectionName) == null, 5_000, 100);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesManagementResourcesForToQueuePolicyConfigurations() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("to-queue-policy");
+         sendToQueue.addToIncludes("#", getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).getConsumerCount() >= 1, 10_000);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "to-queue-policy");
+         final String producerResourceName = AMQPBridgeManagementSupport.getBridgeAddressSenderResourceName(getTestName(), getTestName(), "to-queue-policy", getTestName() + "::" + getTestName());
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) != null, 5_000, 100);
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+         final AMQPBridgePolicyManagerControl queuePolicyControl =
+            (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+         final AMQPBridgeSenderControl producerControl = (AMQPBridgeSenderControl)
+            server.getManagementService().getResource(producerResourceName);
+
+         assertNotNull(brokerConnection);
+         assertTrue(brokerConnection.isConnected());
+
+         assertNotNull(bridgeControl);
+         assertEquals(getTestName(), bridgeControl.getName());
+         assertEquals(0, bridgeControl.getMessagesReceived());
+         assertEquals(0, bridgeControl.getMessagesSent());
+
+         assertNotNull(queuePolicyControl);
+         assertEquals("to-queue-policy", queuePolicyControl.getName());
+         assertEquals(0, queuePolicyControl.getMessagesReceived());
+
+         assertNotNull(producerControl);
+         assertEquals(getTestName(), producerControl.getAddress());
+         assertEquals(0, producerControl.getMessagesSent());
+
+         // Message sent to server is forwarded
+         peer.expectTransfer().accept();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createQueue(getTestName()));
+
+            producer.send(session.createMessage());
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         assertEquals(1, bridgeControl.getMessagesSent());
+         assertEquals(1, queuePolicyControl.getMessagesSent());
+         assertEquals(1, producerControl.getMessagesSent());
+
+         brokerConnection.stop();
+
+         // Stopping the connection should remove the bridge producer management objects.
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) == null, 5_000, 100);
+
+         assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+         server.getBrokerConnections().forEach((connection) -> {
+            try {
+               connection.shutdown();
+            } catch (Exception e) {
+               fail("Broker connection shutdown should not have thrown an exception");
+            }
+         });
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(bridgeResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(brokerConnectionName) == null, 5_000, 100);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesAddressProducerManagementWhenConnectionDrops() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("to-address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "to-address-policy");
+         final String producerResourceName = AMQPBridgeManagementSupport.getBridgeAddressSenderResourceName(getTestName(), getTestName(), "to-address-policy", getTestName());
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+
+         assertNotNull(brokerConnection);
+         assertNotNull(bridgeControl);
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) != null, 5_000, 100);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+
+         // Closing the connection without a detach or close frame should still cleanup the management
+         // resources for the consumer but the policy views should still be in place
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesAddressProducerManagementWhenBrokerConnectionStopped() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("to-address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "to-address-policy");
+         final String producerResourceName = AMQPBridgeManagementSupport.getBridgeAddressSenderResourceName(getTestName(), getTestName(), "to-address-policy", getTestName());
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+
+         assertNotNull(brokerConnection);
+         assertNotNull(bridgeControl);
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) != null, 5_000, 100);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectConnectionToDrop();
+
+         brokerConnection.stop();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Closing the connection without a detach or close frame should still cleanup the management
+         // resources for the consumer but the policy views should still be in place
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) == null, 5_000, 100);
+
+         assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesQueueProducerManagementWhenConnectionDrops() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("to-queue-policy");
+         sendToQueue.addToIncludes("#", getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).getConsumerCount() >= 1, 10_000);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "to-queue-policy");
+         final String producerResourceName = AMQPBridgeManagementSupport.getBridgeAddressSenderResourceName(getTestName(), getTestName(), "to-queue-policy", getTestName() + "::" + getTestName());
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(brokerConnectionName) != null, 5_000, 100);
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+         final AMQPBridgeManagerControl bridgeControl =
+            (AMQPBridgeManagerControl) server.getManagementService().getResource(bridgeResourceName);
+         final AMQPBridgePolicyManagerControl queuePolicyControl =
+            (AMQPBridgePolicyManagerControl) server.getManagementService().getResource(policyResourceName);
+         final AMQPBridgeSenderControl producerControl = (AMQPBridgeSenderControl)
+            server.getManagementService().getResource(producerResourceName);
+
+         assertNotNull(brokerConnection);
+         assertNotNull(bridgeControl);
+         assertNotNull(queuePolicyControl);
+         assertNotNull(producerControl);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+
+         // Closing the connection without a detach or close frame should still cleanup the management
+         // resources for the consumer but the policy views should still be in place
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) == null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRemovesQueueProducerManagementWhenBrokerConnectionStopped() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("to-queue-policy");
+         sendToQueue.addToIncludes("#", getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).getConsumerCount() >= 1, 10_000);
+
+         final String brokerConnectionName = ResourceNames.BROKER_CONNECTION + getTestName();
+         final String bridgeResourceName = AMQPBridgeManagementSupport.getBridgeManagerResourceName(getTestName(), getTestName());
+         final String policyResourceName = AMQPBridgeManagementSupport.getBridgePolicyManagerResourceName(getTestName(), getTestName(), "to-queue-policy");
+         final String producerResourceName = AMQPBridgeManagementSupport.getBridgeAddressSenderResourceName(getTestName(), getTestName(), "to-queue-policy", getTestName() + "::" + getTestName());
+
+         Wait.assertTrue(() -> server.getManagementService().getResource(brokerConnectionName) != null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(bridgeResourceName) != null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(policyResourceName) != null, 5_000, 100);
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) != null, 5_000, 100);
+
+         final BrokerConnectionControl brokerConnection = (BrokerConnectionControl)
+            server.getManagementService().getResource(brokerConnectionName);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().optional();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+
+         brokerConnection.stop();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Closing the connection without a detach or close frame should still cleanup the management
+         // resources for the consumer but the policy views should still be in place
+         Wait.assertTrue(() -> server.getManagementService().getResource(producerResourceName) == null, 5_000, 100);
+
+         assertNotNull(server.getManagementService().getResource(policyResourceName));
+
+         peer.close();
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeServerToServerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeServerToServerTest.java
@@ -1,0 +1,912 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.lang.invoke.MethodHandles;
+import java.util.Arrays;
+import java.util.Map;
+
+import javax.jms.BytesMessage;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.DeliveryMode;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import javax.jms.Topic;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeAddressPolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeQueuePolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ComponentConfigurationRoutingType;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.jms.JmsConnectionFactory;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.RepeatedTest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test AMQP Bridge between two Artemis servers.
+ */
+class AMQPBridgeServerToServerTest extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private static final int SERVER_PORT = AMQP_PORT;
+   private static final int SERVER_PORT_REMOTE = AMQP_PORT + 1;
+
+   private static final int MIN_LARGE_MESSAGE_SIZE = 10 * 1024;
+
+   protected ActiveMQServer remoteServer;
+   protected ActiveMQServer remoteServer2; // Used in two hop tests
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      remoteServer = createServer(SERVER_PORT_REMOTE, false);
+
+      return createServer(SERVER_PORT, false);
+   }
+
+   @Override
+   protected void configureAMQPAcceptorParameters(Map<String, Object> params) {
+      params.put("amqpMinLargeMessageSize", MIN_LARGE_MESSAGE_SIZE);
+   }
+
+   @AfterEach
+   @Override
+   public void tearDown() throws Exception {
+      super.tearDown();
+
+      try {
+         if (remoteServer != null) {
+            remoteServer.stop();
+            remoteServer = null;
+         }
+      } catch (Exception e) {
+      }
+
+      try {
+         if (remoteServer2 != null) {
+            remoteServer2.stop();
+            remoteServer2 = null;
+         }
+      } catch (Exception e) {
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testAddresDemandOnLocalBrokerBridgesMessagesFromRemoteAMQP() throws Exception {
+      testAddresDemandOnLocalBrokerBridgesMessagesFromRemote("AMQP");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testAddresDemandOnLocalBrokerBridgesMessagesFromRemoteCORE() throws Exception {
+      testAddresDemandOnLocalBrokerBridgesMessagesFromRemote("CORE");
+   }
+
+   private void testAddresDemandOnLocalBrokerBridgesMessagesFromRemote(String clientProtocol) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeAddressPolicyElement bridgeAddressPolicy = new AMQPBridgeAddressPolicyElement();
+      bridgeAddressPolicy.setName("test-policy");
+      bridgeAddressPolicy.addToIncludes(getTestName());
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeFromAddressPolicy(bridgeAddressPolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      server.start();
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final Topic topic = sessionL.createTopic(getTestName());
+
+         final MessageConsumer consumerL = sessionL.createConsumer(topic);
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on local address should trigger receiver on remote.
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> remoteServer.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         // Captures state of JMS consumers and bridge consumers attached on each node
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+         Wait.assertTrue(() -> remoteServer.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         final MessageProducer producerR = sessionR.createProducer(topic);
+         final TextMessage message = sessionR.createTextMessage("Hello World");
+
+         message.setStringProperty("testProperty", "testValue");
+
+         producerR.send(message);
+
+         final Message received = consumerL.receive(5_000);
+         assertNotNull(received);
+         assertTrue(received instanceof TextMessage);
+         assertEquals("Hello World", ((TextMessage) received).getText());
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testDivertAddressDemandOnLocalBrokerBridgesMessagesFromRemoteAMQP() throws Exception {
+      testDivertAddresDemandOnLocalBrokerBridgesMessagesFromRemote("AMQP");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testDivertAddresDemandOnLocalBrokerBridgesMessagesFromRemoteCORE() throws Exception {
+      testDivertAddresDemandOnLocalBrokerBridgesMessagesFromRemote("CORE");
+   }
+
+   private void testDivertAddresDemandOnLocalBrokerBridgesMessagesFromRemote(String clientProtocol) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeAddressPolicyElement bridgeAddressPolicy = new AMQPBridgeAddressPolicyElement();
+      bridgeAddressPolicy.setName("test-policy");
+      bridgeAddressPolicy.addToIncludes(getTestName());
+      bridgeAddressPolicy.setIncludeDivertBindings(true);
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeFromAddressPolicy(bridgeAddressPolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      final DivertConfiguration divert = new DivertConfiguration();
+      divert.setName("test-divert");
+      divert.setAddress(getTestName());
+      divert.setForwardingAddress("target");
+      divert.setRoutingType(ComponentConfigurationRoutingType.MULTICAST);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      server.start();
+      server.deployDivert(divert);
+      // Currently the address must exist on the local before we will federate from the remote
+      server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final Topic target = sessionL.createTopic("target");
+         final Topic source = sessionL.createTopic(getTestName());
+
+         final MessageConsumer consumerL = sessionL.createConsumer(target);
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on local address should trigger receiver on remote.
+         Wait.assertTrue(() -> remoteServer.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         // Captures state of JMS consumers and bridge consumers attached on each node
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of("target"), false).getQueueNames().size() >= 1);
+         Wait.assertTrue(() -> remoteServer.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         final MessageProducer producerR = sessionR.createProducer(source);
+         final TextMessage message = sessionR.createTextMessage("Hello World");
+
+         message.setStringProperty("testProperty", "testValue");
+
+         producerR.send(message);
+
+         final Message received = consumerL.receive(5_000);
+         assertNotNull(received);
+         assertTrue(received instanceof TextMessage);
+         assertEquals("Hello World", ((TextMessage) received).getText());
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testQueueDemandOnLocalBrokerBridgesMessagesFromRemoteAMQP() throws Exception {
+      testQueueDemandOnLocalBrokerBridgesMessagesFromRemote("AMQP");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testQueueDemandOnLocalBrokerBridgesMessagesFromRemoteCORE() throws Exception {
+      testQueueDemandOnLocalBrokerBridgesMessagesFromRemote("CORE");
+   }
+
+   private void testQueueDemandOnLocalBrokerBridgesMessagesFromRemote(String clientProtocol) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeQueuePolicyElement bridgeQueuePolicy = new AMQPBridgeQueuePolicyElement();
+      bridgeQueuePolicy.setName("test-policy");
+      bridgeQueuePolicy.addToIncludes("#", getTestName());
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeFromQueuePolicy(bridgeQueuePolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      remoteServer.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                   .setAddress(getTestName())
+                                                                   .setAutoCreated(false));
+      server.start();
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final Queue queue = sessionL.createQueue(getTestName());
+
+         final MessageConsumer consumerL = sessionL.createConsumer(queue);
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on local queue should trigger receiver on remote.
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final MessageProducer producerR = sessionR.createProducer(queue);
+         final TextMessage message = sessionR.createTextMessage("Hello World");
+
+         message.setStringProperty("testProperty", "testValue");
+
+         producerR.send(message);
+
+         final Message received = consumerL.receive(5_000);
+         assertNotNull(received);
+         assertTrue(received instanceof TextMessage);
+         assertEquals("Hello World", ((TextMessage) received).getText());
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToAddressOnLocalBrokerBridgesMessagesFromLocalAMQP() throws Exception {
+      testBridgeToAddressOnLocalBrokerBridgesMessagesFromLocal("AMQP");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToAddressOnLocalBrokerBridgesMessagesFromLocalCore() throws Exception {
+      testBridgeToAddressOnLocalBrokerBridgesMessagesFromLocal("CORE");
+   }
+
+   private void testBridgeToAddressOnLocalBrokerBridgesMessagesFromLocal(String clientProtocol) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeAddressPolicyElement bridgeAddressPolicy = new AMQPBridgeAddressPolicyElement();
+      bridgeAddressPolicy.setName("test-policy");
+      bridgeAddressPolicy.addToIncludes(getTestName());
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeToAddressPolicy(bridgeAddressPolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      server.start();
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final Topic topic = sessionL.createTopic(getTestName());
+
+         final MessageConsumer consumerR = sessionR.createConsumer(topic);
+
+         connectionL.start();
+         connectionR.start();
+
+         // Remote consumer is attached and ready for the bridged message
+         Wait.assertTrue(() -> remoteServer.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> remoteServer.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         // We need to add the address before the bridge will start routing message to the remote.
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+         // The bridge has been notified and has created a local consumer to bridge to the remote.
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName()), false).getQueueNames().size() >= 1);
+
+         final MessageProducer producerL = sessionL.createProducer(topic);
+         final TextMessage message = sessionL.createTextMessage("Hello World");
+
+         message.setStringProperty("testProperty", "testValue");
+
+         producerL.send(message);
+
+         final Message received = consumerR.receive(5_000);
+         assertNotNull(received);
+         assertTrue(received instanceof TextMessage);
+         assertEquals("Hello World", ((TextMessage) received).getText());
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueToMessageFromLocalToRemoteAMQP() throws Exception {
+      testBridgeQueueToMessageFromLocalToRemote("AMQP");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueToMessageFromLocalToRemoteCore() throws Exception {
+      testBridgeQueueToMessageFromLocalToRemote("CORE");
+   }
+
+   public void testBridgeQueueToMessageFromLocalToRemote(String clientProtocol) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeQueuePolicyElement bridgeQueuePolicy = new AMQPBridgeQueuePolicyElement();
+      bridgeQueuePolicy.setName("test-policy");
+      bridgeQueuePolicy.addToIncludes("#", getTestName());
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeToQueuePolicy(bridgeQueuePolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      server.start();
+
+      // Need to define the right type on the remote in order to get expected results
+      remoteServer.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                   .setAddress(getTestName())
+                                                                   .setAutoCreated(false));
+
+      server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                             .setAddress(getTestName())
+                                                             .setAutoCreated(false));
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final Queue queue = sessionL.createQueue(getTestName());
+
+         final MessageConsumer consumerR = sessionR.createConsumer(queue);
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on remote queue should trigger receiver on remote.
+         Wait.assertTrue(() -> remoteServer.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final MessageProducer producerL = sessionL.createProducer(queue);
+         final TextMessage message = sessionL.createTextMessage("Hello World");
+
+         message.setStringProperty("testProperty", "testValue");
+
+         producerL.send(message);
+
+         final Message received = consumerR.receive(5_000);
+         assertNotNull(received);
+         assertTrue(received instanceof TextMessage);
+         assertEquals("Hello World", ((TextMessage) received).getText());
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testQueueDemandOnLocalBrokerBridgesMatchingFilteredMessagesFromRemoteAMQP() throws Exception {
+      testQueueDemandOnLocalBrokerBridgesMatchingFilteredMessagesFromRemote("AMQP");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testQueueDemandOnLocalBrokerBridgesMatchingFilteredMessagesFromRemoteCORE() throws Exception {
+      testQueueDemandOnLocalBrokerBridgesMatchingFilteredMessagesFromRemote("CORE");
+   }
+
+   private void testQueueDemandOnLocalBrokerBridgesMatchingFilteredMessagesFromRemote(String clientProtocol) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeQueuePolicyElement bridgeQueuePolicy = new AMQPBridgeQueuePolicyElement();
+      bridgeQueuePolicy.setName("test-policy");
+      bridgeQueuePolicy.addToIncludes("#", getTestName());
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeFromQueuePolicy(bridgeQueuePolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      remoteServer.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                   .setAddress(getTestName())
+                                                                   .setFilterString("color='red' OR color='green' OR color='blue'")
+                                                                   .setAutoCreated(false));
+      server.start();
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(clientProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final Queue queue = sessionL.createQueue(getTestName());
+
+         final MessageConsumer consumerL1 = sessionL.createConsumer(queue, "color='red'");
+         final MessageConsumer consumerL2 = sessionL.createConsumer(queue, "color='blue'");
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on local queue should trigger receiver on remote.
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final MessageProducer producerR = sessionR.createProducer(queue);
+
+         final TextMessage message1 = sessionR.createTextMessage("Hello World 1");
+         message1.setStringProperty("color", "green");
+         final TextMessage message2 = sessionR.createTextMessage("Hello World 2");
+         message2.setStringProperty("color", "red");
+         final TextMessage message3 = sessionR.createTextMessage("Hello World 3");
+         message3.setStringProperty("color", "blue");
+
+         producerR.send(message1);
+         producerR.send(message2);
+         producerR.send(message3);
+
+         final Message receivedL1 = consumerL1.receive(5_000);
+         assertNotNull(receivedL1);
+         assertTrue(receivedL1 instanceof TextMessage);
+         assertEquals("Hello World 2", ((TextMessage) receivedL1).getText());
+         assertTrue(receivedL1.propertyExists("color"));
+         assertEquals("red", receivedL1.getStringProperty("color"));
+
+         final Message receivedL2 = consumerL2.receive(5_000);
+         assertNotNull(receivedL2);
+         assertTrue(receivedL2 instanceof TextMessage);
+         assertEquals("Hello World 3", ((TextMessage) receivedL2).getText());
+         assertTrue(receivedL2.propertyExists("color"));
+         assertEquals("blue", receivedL2.getStringProperty("color"));
+
+         // See if the green message is still on the remote where it should be as the
+         // filter should prevent it from moving across the federation link(s)
+         final MessageConsumer consumerR = sessionR.createConsumer(queue, "color='green'");
+
+         final Message receivedR = consumerR.receive(5_000);
+         assertNotNull(receivedR);
+         assertTrue(receivedR instanceof TextMessage);
+         assertEquals("Hello World 1", ((TextMessage) receivedR).getText());
+         assertTrue(receivedR.propertyExists("color"));
+         assertEquals("green", receivedR.getStringProperty("color"));
+      }
+   }
+
+   @RepeatedTest(1)
+   @Timeout(20)
+   public void testTwoPullConsumerOnPullingBridgeConfigurationEachCanTakeOneMessageProduceOnLocal() throws Exception {
+      doTestTwoPullConsumerOnPullingBridgeConfigurationEachCanTakeOneMessage(true);
+   }
+
+   @RepeatedTest(1)
+   @Timeout(20)
+   public void testTwoPullConsumerOnPullingBridgeConfigurationEachCanTakeOneMessageProduceOnRemote() throws Exception {
+      doTestTwoPullConsumerOnPullingBridgeConfigurationEachCanTakeOneMessage(false);
+   }
+
+   public void doTestTwoPullConsumerOnPullingBridgeConfigurationEachCanTakeOneMessage(boolean produceLocal) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeQueuePolicyElement bridgeQueuePolicy = new AMQPBridgeQueuePolicyElement();
+      bridgeQueuePolicy.setName("bridge-queue-policy");
+      bridgeQueuePolicy.addToIncludes(getTestName(), getTestName());
+      bridgeQueuePolicy.addProperty(RECEIVER_CREDITS, 0);         // Enable Pull mode
+      bridgeQueuePolicy.addProperty(PULL_RECEIVER_BATCH_SIZE, 1); // Pull mode batch is one
+
+      final AMQPBridgeBrokerConnectionElement element1 = new AMQPBridgeBrokerConnectionElement();
+      element1.setName("Bridge-Messages-From-Remote");
+      element1.addBridgeFromQueuePolicy(bridgeQueuePolicy);
+
+      final AMQPBridgeBrokerConnectionElement element2 = new AMQPBridgeBrokerConnectionElement();
+      element2.setName("Bridge-Messages-From-Local");
+      element2.addBridgeFromQueuePolicy(bridgeQueuePolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection1 =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection1.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection1.addElement(element1);
+
+      final AMQPBrokerConnectConfiguration amqpConnection2 =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT);
+      amqpConnection2.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection2.addElement(element2);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection1);
+      remoteServer.getConfiguration().addAMQPConnection(amqpConnection2);
+
+      remoteServer.start();
+      remoteServer.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                   .setAddress(getTestName())
+                                                                   .setAutoCreated(false));
+      server.start();
+      server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                             .setAddress(getTestName())
+                                                             .setAutoCreated(false));
+
+      final int MESSAGE_COUNT = 2;
+      final JmsConnectionFactory factory;
+      if (produceLocal) {
+         factory = new JmsConnectionFactory("amqp://localhost:" + SERVER_PORT);
+      } else {
+         factory = new JmsConnectionFactory("amqp://localhost:" + SERVER_PORT_REMOTE);
+      }
+
+      try (Connection connection = factory.createConnection();
+           Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE)) {
+
+         final Queue queue = session.createQueue(getTestName());
+         final MessageProducer producer = session.createProducer(queue);
+
+         for (int i = 0; i < MESSAGE_COUNT; ++i) {
+            TextMessage message = session.createTextMessage("test-message:" + i);
+
+            message.setIntProperty("messageNo", i);
+
+            producer.send(message);
+         }
+      }
+
+      final JmsConnectionFactory factoryLocal = new JmsConnectionFactory(
+         "amqp://localhost:" + SERVER_PORT + "?jms.prefetchPolicy.all=0");
+      final JmsConnectionFactory factoryRemote = new JmsConnectionFactory(
+         "amqp://localhost:" + SERVER_PORT_REMOTE + "?jms.prefetchPolicy.all=0");
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection();
+           Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+           Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE)) {
+
+         connectionL.start();
+         connectionR.start();
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists(), 10_000);
+         Wait.assertTrue(() -> remoteServer.queueQuery(SimpleString.of(getTestName())).isExists(), 10_000);
+
+         final Queue queue = sessionL.createQueue(getTestName());
+         final MessageConsumer consumerL = sessionL.createConsumer(queue);
+         final MessageConsumer consumerR = sessionR.createConsumer(queue);
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).getConsumerCount() >= 2, 10_000);
+         Wait.assertTrue(() -> remoteServer.queueQuery(SimpleString.of(getTestName())).getConsumerCount() >= 2, 10_000);
+
+         final TextMessage messageL = (TextMessage) consumerL.receive(2_000); // Read from local
+         final TextMessage messageR = (TextMessage) consumerR.receive(2_000); // Read from remote after federated
+
+         assertNotNull(messageL);
+         assertNotNull(messageR);
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient() throws Exception {
+      testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient("CORE", "AMQP", false); // Tunneling doesn't matter here
+   }
+
+   @Test
+   @Timeout(20)
+   public void testCoreConsumerDemandOnLocalBrokerBridgesMessageFromCoreClientTunneled() throws Exception {
+      testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient("CORE", "CORE", true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testCoreConsumerDemandOnLocalBrokerBridgesMessageFromCoreClientUnTunneled() throws Exception {
+      testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient("CORE", "CORE", false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testAMQPConsumerDemandOnLocalBrokerBridgesMessageFromCoreClientTunneled() throws Exception {
+      testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient("AMQP", "CORE", true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testAMQPConsumerDemandOnLocalBrokerBridgesMessageFromCoreClientNotTunneled() throws Exception {
+      testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient("AMQP", "CORE", false);
+   }
+
+   private void testCoreConsumerDemandOnLocalBrokerBridgesMessageFromAMQPClient(String localProtocol,
+                                                                                String remoteProtocol,
+                                                                                boolean enableCoreTunneling) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeQueuePolicyElement localQueuePolicy = new AMQPBridgeQueuePolicyElement();
+      localQueuePolicy.setName("test-policy");
+      localQueuePolicy.addToIncludes("#", getTestName());
+      localQueuePolicy.addProperty(AmqpSupport.TUNNEL_CORE_MESSAGES, Boolean.toString(enableCoreTunneling));
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeFromQueuePolicy(localQueuePolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      remoteServer.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                   .setAddress(getTestName())
+                                                                   .setAutoCreated(false));
+      server.start();
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(localProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(remoteProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final MessageConsumer consumerL = sessionL.createConsumer(sessionL.createQueue(getTestName()));
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on local address should trigger receiver on remote.
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> remoteServer.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final MessageProducer producerR = sessionR.createProducer(sessionR.createQueue(getTestName()));
+         final BytesMessage message = sessionR.createBytesMessage();
+         final byte[] bodyBytes = new byte[(int)(MIN_LARGE_MESSAGE_SIZE * 1.5)];
+
+         Arrays.fill(bodyBytes, (byte)1);
+
+         message.writeBytes(bodyBytes);
+         message.setStringProperty("testProperty", "testValue");
+         message.setIntProperty("testIntProperty", 42);
+         message.setJMSCorrelationID("myCorrelationId");
+         message.setJMSReplyTo(sessionR.createTopic("reply-topic"));
+
+         producerR.setDeliveryMode(DeliveryMode.PERSISTENT);
+         producerR.send(message);
+
+         final Message received = consumerL.receive(5_000);
+         assertNotNull(received);
+         assertInstanceOf(BytesMessage.class, received);
+
+         final byte[] receivedBytes = new byte[bodyBytes.length];
+         final BytesMessage receivedBytesMsg = (BytesMessage) received;
+         receivedBytesMsg.readBytes(receivedBytes);
+
+         assertArrayEquals(bodyBytes, receivedBytes);
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+         assertTrue(message.propertyExists("testIntProperty"));
+         assertEquals(42, received.getIntProperty("testIntProperty"));
+         assertEquals("myCorrelationId", received.getJMSCorrelationID());
+         assertEquals("reply-topic", ((Topic) received.getJMSReplyTo()).getTopicName());
+         assertEquals(DeliveryMode.PERSISTENT, received.getJMSDeliveryMode());
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToCoreConsumerOnRemoteBrokerMessageFromAMQPClient() throws Exception {
+      testBridgeToConsumerOnRemoteBrokerMessageFromLocalProducer("AMQP", "CORE", false); // Tunneling doesn't matter here
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToCoreConsumerOnRemoteBrokerBridgesMessageFromCoreClientTunneled() throws Exception {
+      testBridgeToConsumerOnRemoteBrokerMessageFromLocalProducer("CORE", "CORE", true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToCoreConsumerOnRemoteBrokerBridgesMessageFromCoreClientUnTunneled() throws Exception {
+      testBridgeToConsumerOnRemoteBrokerMessageFromLocalProducer("CORE", "CORE", false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToAMQPConsumerOnRemoteBrokerBridgesMessageFromCoreClientTunneled() throws Exception {
+      testBridgeToConsumerOnRemoteBrokerMessageFromLocalProducer("CORE", "AMQP", true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeToAMQPConsumerOnRemoteBrokerBridgesMessageFromCoreClientNotTunneled() throws Exception {
+      testBridgeToConsumerOnRemoteBrokerMessageFromLocalProducer("CORE", "AMQP", false);
+   }
+
+   private void testBridgeToConsumerOnRemoteBrokerMessageFromLocalProducer(String localProtocol,
+                                                                           String remoteProtocol,
+                                                                           boolean enableCoreTunneling) throws Exception {
+      logger.info("Test started: {}", getTestName());
+
+      final AMQPBridgeQueuePolicyElement localQueuePolicy = new AMQPBridgeQueuePolicyElement();
+      localQueuePolicy.setName("test-policy");
+      localQueuePolicy.addToIncludes("#", getTestName());
+      localQueuePolicy.addProperty(AmqpSupport.TUNNEL_CORE_MESSAGES, Boolean.toString(enableCoreTunneling));
+
+      final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+      element.setName(getTestName());
+      element.addBridgeToQueuePolicy(localQueuePolicy);
+
+      final AMQPBrokerConnectConfiguration amqpConnection =
+         new AMQPBrokerConnectConfiguration(getTestName(), "tcp://localhost:" + SERVER_PORT_REMOTE);
+      amqpConnection.setReconnectAttempts(10);// Limit reconnects
+      amqpConnection.addElement(element);
+
+      server.getConfiguration().addAMQPConnection(amqpConnection);
+      remoteServer.start();
+      remoteServer.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                   .setAddress(getTestName())
+                                                                   .setAutoCreated(false));
+      server.start();
+      server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                             .setAddress(getTestName())
+                                                             .setAutoCreated(false));
+
+      final ConnectionFactory factoryLocal = CFUtil.createConnectionFactory(localProtocol, "tcp://localhost:" + SERVER_PORT);
+      final ConnectionFactory factoryRemote = CFUtil.createConnectionFactory(remoteProtocol, "tcp://localhost:" + SERVER_PORT_REMOTE);
+
+      try (Connection connectionL = factoryLocal.createConnection();
+           Connection connectionR = factoryRemote.createConnection()) {
+
+         final Session sessionL = connectionL.createSession(Session.AUTO_ACKNOWLEDGE);
+         final Session sessionR = connectionR.createSession(Session.AUTO_ACKNOWLEDGE);
+
+         final MessageConsumer consumerR = sessionR.createConsumer(sessionR.createQueue(getTestName()));
+
+         connectionL.start();
+         connectionR.start();
+
+         // Demand on local address should trigger receiver on remote.
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> remoteServer.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         final MessageProducer producerL = sessionL.createProducer(sessionL.createQueue(getTestName()));
+         final BytesMessage message = sessionL.createBytesMessage();
+         final byte[] bodyBytes = new byte[(int)(MIN_LARGE_MESSAGE_SIZE * 1.5)];
+
+         Arrays.fill(bodyBytes, (byte)1);
+
+         message.writeBytes(bodyBytes);
+         message.setStringProperty("testProperty", "testValue");
+         message.setIntProperty("testIntProperty", 42);
+         message.setJMSCorrelationID("myCorrelationId");
+         message.setJMSReplyTo(sessionL.createTopic("reply-topic"));
+
+         producerL.setDeliveryMode(DeliveryMode.PERSISTENT);
+         producerL.send(message);
+
+         final Message received = consumerR.receive(5_000);
+         assertNotNull(received);
+         assertInstanceOf(BytesMessage.class, received);
+
+         final byte[] receivedBytes = new byte[bodyBytes.length];
+         final BytesMessage receivedBytesMsg = (BytesMessage) received;
+         receivedBytesMsg.readBytes(receivedBytes);
+
+         assertArrayEquals(bodyBytes, receivedBytes);
+         assertTrue(message.propertyExists("testProperty"));
+         assertEquals("testValue", received.getStringProperty("testProperty"));
+         assertTrue(message.propertyExists("testIntProperty"));
+         assertEquals(42, received.getIntProperty("testIntProperty"));
+         assertEquals("myCorrelationId", received.getJMSCorrelationID());
+         assertEquals("reply-topic", ((Topic) received.getJMSReplyTo()).getTopicName());
+         assertEquals(DeliveryMode.PERSISTENT, received.getJMSDeliveryMode());
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToAddressTest.java
@@ -1,0 +1,1120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledMessageConstants.AMQP_TUNNELED_CORE_MESSAGE_FORMAT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.DETACH_FORCED;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.NOT_FOUND;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.RESOURCE_DELETED;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.TUNNEL_CORE_MESSAGES;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeAddressPolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test the AMQP Bridge to address configuration and protocol behaviors
+ */
+class AMQPBridgeToAddressTest  extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testLinkAttachTimeoutAppliedAndConnectionClosed() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.addProperty(LINK_ATTACH_TIMEOUT, 1); // Seconds
+         sendToAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 20); // Milliseconds
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())));
+         peer.expectDetach();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesAddressSenderWhenLocalAddressIsStaticlyDefined() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(1);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined address
+         // should be the thing that triggers the bridging. The connection should remain active and
+         // respond if the address is recreated later.
+         logger.info("Removing Address from bridged address to eliminate sender");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertFalse(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            session.createProducer(session.createTopic(getTestName()));
+
+            Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+            Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSenderRebuildAfterRemoteDetachForResourceDeleted() throws Exception {
+      doTestBridgeSenderRebuildAfterRemoteDetachForSpecificConditions(RESOURCE_DELETED.toString());
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSenderRebuildAfterRemoteDetachForResourceNotFound() throws Exception {
+      doTestBridgeSenderRebuildAfterRemoteDetachForSpecificConditions(NOT_FOUND.toString());
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSenderRebuildAfterRemoteDetachForForcedDetach() throws Exception {
+      doTestBridgeSenderRebuildAfterRemoteDetachForSpecificConditions(DETACH_FORCED.toString());
+   }
+
+   private void doTestBridgeSenderRebuildAfterRemoteDetachForSpecificConditions(String condition) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(1);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         // This should trigger recovery handling to try and reattach the link
+         peer.remoteDetach().withErrorCondition(condition, "resource issue")
+                            .withClosed(true).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressSenderRoutesMessageFromLocalProducerToTheRemote() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createTopic(getTestName()));
+
+            // Await bridge sender attach.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectTransfer().withMessageFormat(0)
+                                 .withMessage().withHeader().also()
+                                               .withMessageAnnotations().also()
+                                               .withProperties().also()
+                                               .withValue("Hello")
+                                               .and()
+                                 .respond()
+                                 .withSettled(true)
+                                 .withState().accepted();
+
+            connection.start();
+
+            Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+            Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+            producer.send(session.createTextMessage("Hello"));
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined address
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Address from bridged address to eliminate sender");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAddressSenderRoutesMessageMatchingFilterFromLocalProducerToTheRemote() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.setFilter("color = 'red'");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createTopic(getTestName()));
+
+            // Await bridge sender attach.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectTransfer().withMessageFormat(0)
+                                 .withMessage().withHeader().also()
+                                               .withMessageAnnotations().also()
+                                               .withProperties().also()
+                                               .withApplicationProperties().withProperty("color", "red").also()
+                                               .withValue("red")
+                                               .and()
+                                 .respond()
+                                 .withSettled(true)
+                                 .withState().accepted();
+
+            connection.start();
+
+            Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+            Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+            final TextMessage blue = session.createTextMessage("blue");
+            blue.setStringProperty("color", "blue");
+
+            final TextMessage red = session.createTextMessage("red");
+            red.setStringProperty("color", "red");
+
+            producer.send(blue); // Should be filtered out
+            producer.send(red);
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined address
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Address from bridged address to eliminate sender");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddressPrefix() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations("queue://", null, null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddress() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations(null, "alternate", null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddressSuffix() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations(null, null, "?consumer-priority=1");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations("queue://", "alternate", "?consumer-priority=1");
+   }
+
+   private void doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations(String prefix, String address, String suffix) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.setRemoteAddressPrefix(prefix);
+         sendToAddress.setRemoteAddress(address);
+         sendToAddress.setRemoteAddressSuffix(suffix);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final String expectedTargetAddress = (prefix != null ? prefix : "") +
+                                              (address != null ? address : getTestName()) +
+                                              (suffix != null ? suffix : "");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(expectedTargetAddress).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined address
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Address from bridged address to eliminate sender");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteTerminusCapabilities() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.setRemoteTerminusCapabilities(new String[] {"queue", "another"});
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue", "another")
+                                         .also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined address
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Address from bridged address to eliminate sender");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithSenderPresettledWhenConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.addProperty(PRESETTLE_SEND_MODE, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withSenderSettleModeSettled()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined address
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Address from bridged address to eliminate sender");
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+         Wait.assertFalse(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRecoversLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 1 millisecond initial recovery delay
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         // Retry after delay.
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAttemptsLimitedRecoveryLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.addToIncludes("another");
+         sendToAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 1);  // 1 millisecond initial recovery delay
+         sendToAddress.addProperty(LINK_RECOVERY_DELAY, 15);         // 15 millisecond continued recovery delay
+         sendToAddress.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 2);   // 2 attempts then stop trying
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         // Attempt #1
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         // Attempt #2
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress("another").also()
+                            .withSource().withAddress("another").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("another"),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+
+         // Add the alternate address to trigger an attach to that
+         server.addAddressInfo(new AddressInfo(SimpleString.of("another"), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of("another")).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of("another")).getQueueNames().size() > 0);
+
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // Remove and add the address again which should trigger new attempt
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() == 0);
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeDoesNotAttemptLimitedRecoveryAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.addToIncludes("another");
+         sendToAddress.addProperty(LINK_RECOVERY_INITIAL_DELAY, 1);  // 1 millisecond initial recovery delay
+         sendToAddress.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+         sendToAddress.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 0);   // No attempts
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress("another").also()
+                            .withSource().withAddress("another").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("another"),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // add the alternate and it should trigger an attach on that address.
+         server.addAddressInfo(new AddressInfo(SimpleString.of("another"), RoutingType.MULTICAST));
+         // Remove and later add the address again which should trigger new attempt
+         server.removeAddressInfo(SimpleString.of(getTestName()), null, true);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRebuildsAfterRemoteClosesLinkAfterSuccessfulAttach() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(3);
+         amqpConnection.setRetryInterval(10);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteDetach().withClosed(true).queue(); // Remote close after attach is terminal
+         peer.expectDetach().optional();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("address-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSendCoreMessageTunneleInAMQPMessageWhenSupported() throws Exception {
+      doTestBridgeSendMessagesAccordingToTunnelingState(true, true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSendCoreMessageConvertedToAMQPMessageWhenTunnelNotSupported() throws Exception {
+      doTestBridgeSendMessagesAccordingToTunnelingState(true, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSendCoreMessageConvertedToAMQPMessageWhenConfigurationDisabledTunneling() throws Exception {
+      doTestBridgeSendMessagesAccordingToTunnelingState(false, true);
+   }
+
+   public void doTestBridgeSendMessagesAccordingToTunnelingState(boolean enabled, boolean receiverSupport) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeAddressPolicyElement sendToAddress = new AMQPBridgeAddressPolicyElement();
+         sendToAddress.setName("address-policy");
+         sendToAddress.addToIncludes(getTestName());
+         sendToAddress.addProperty(TUNNEL_CORE_MESSAGES, Boolean.toString(enabled));
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToAddressPolicy(sendToAddress);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         if (receiverSupport && enabled) {
+            peer.expectAttach().ofSender()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withDesiredCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("address-sender"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond()
+                               .withOfferedCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString());
+         } else if (enabled) {
+            peer.expectAttach().ofSender()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withDesiredCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("address-sender"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+         } else {
+            peer.expectAttach().ofSender()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("address-sender"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+         }
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("CORE", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createTopic(getTestName()));
+
+            // Await bridge sender attach.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            if (enabled && receiverSupport) {
+               peer.expectTransfer().withMessageFormat(AMQP_TUNNELED_CORE_MESSAGE_FORMAT)
+                                    .withMessage().withData(notNullValue()).also()
+                                    .accept();
+            } else {
+               peer.expectTransfer().withMessageFormat(0)
+                                    .withMessage().withHeader().also()
+                                                  .withMessageAnnotations().also()
+                                                  .withApplicationProperties().also()
+                                                  .withProperties().also()
+                                                  .withValue("Hello")
+                                    .and()
+                                    .accept();
+            }
+
+            connection.start();
+
+            Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+            Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+            producer.send(session.createTextMessage("Hello"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToQueueTest.java
@@ -1,0 +1,1326 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.amqp.connect;
+
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledMessageConstants.AMQP_TUNNELED_CORE_MESSAGE_FORMAT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.DETACH_FORCED;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.NOT_FOUND;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.RESOURCE_DELETED;
+import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.TUNNEL_CORE_MESSAGES;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.lang.invoke.MethodHandles;
+import java.net.URI;
+import java.util.concurrent.TimeUnit;
+
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeBrokerConnectionElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBridgeQueuePolicyElement;
+import org.apache.activemq.artemis.core.config.amqpBrokerConnectivity.AMQPBrokerConnectConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.tests.integration.amqp.AmqpClientTestSupport;
+import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.proton.amqp.transport.AmqpError;
+import org.apache.qpid.protonj2.test.driver.ProtonTestServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test the AMQP Bridge to queue configuration and protocol behaviors
+ */
+class AMQPBridgeToQueueTest  extends AmqpClientTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP,CORE";
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testLinkAttachTimeoutAppliedAndConnectionClosed() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes("#", getTestName());
+         sendToQueue.addProperty(LINK_ATTACH_TIMEOUT, 1); // Seconds
+         sendToQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 20); // Milliseconds
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())));
+         peer.expectDetach();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueSenderLinkForQueueMatchAnycast() throws Exception {
+      doTestBridgeCreatesQueueSenderLinkForQueueMatch(RoutingType.ANYCAST);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueSenderLinkForQueueMatchMulticast() throws Exception {
+      doTestBridgeCreatesQueueSenderLinkForQueueMatch(RoutingType.MULTICAST);
+   }
+
+   private void doTestBridgeCreatesQueueSenderLinkForQueueMatch(RoutingType routingType) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(routingType)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testTargetAddressCarriesTheMatchedQueueName() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes("source", getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress("source::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress("source")
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueSenderRoutesMessageFromLocalProducerToTheRemote() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), "#");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createQueue(getTestName()));
+
+            // Await bridge sender attach.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectTransfer().withMessageFormat(0)
+                                 .withMessage().withHeader().also()
+                                               .withMessageAnnotations().also()
+                                               .withProperties().also()
+                                               .withValue("Hello")
+                                               .and()
+                                 .respond()
+                                 .withSettled(true)
+                                 .withState().accepted();
+
+            connection.start();
+
+            Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+            producer.send(session.createTextMessage("Hello"));
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeQueueSenderRoutesMessageMatchingFilterFromLocalProducerToTheRemote() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), "#");
+         sendToQueue.setFilter("color='red'");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("AMQP", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createQueue(getTestName()));
+
+            // Await bridge sender attach.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+            peer.expectTransfer().withMessageFormat(0)
+                                 .withMessage().withHeader().also()
+                                               .withMessageAnnotations().also()
+                                               .withProperties().also()
+                                               .withApplicationProperties().withProperty("color", "red").also()
+                                               .withValue("red")
+                                               .and()
+                                 .respond()
+                                 .withSettled(true)
+                                 .withState().accepted();
+
+            connection.start();
+
+            Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+            final TextMessage blue = session.createTextMessage("blue");
+            blue.setStringProperty("color", "blue");
+
+            final TextMessage red = session.createTextMessage("red");
+            red.setStringProperty("color", "red");
+
+            producer.send(blue); // Should be filtered out.
+            producer.send(red);
+         }
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueSenderLinkWithConfiguredLocalPriorityForQueueMatchAnycast() throws Exception {
+      doTestBridgeCreatesQueueSenderLinkWithConfiguredLocalPriorityForQueueMatch(RoutingType.ANYCAST);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesQueueSenderLinkWithConfiguredLocalPriorityForQueueMatchMulticast() throws Exception {
+      doTestBridgeCreatesQueueSenderLinkWithConfiguredLocalPriorityForQueueMatch(RoutingType.MULTICAST);
+   }
+
+   private void doTestBridgeCreatesQueueSenderLinkWithConfiguredLocalPriorityForQueueMatch(RoutingType routingType) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.setPriority(10);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(routingType)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         Wait.assertEquals(1, () -> server.locateQueue(SimpleString.of(getTestName())).getConsumers().size(), 5000, 100);
+         server.locateQueue(SimpleString.of(getTestName())).getConsumers().forEach((c) -> {
+            assertEquals(10, c.getPriority());
+         });
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddressPrefix() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations("queue://", null, null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddress() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations(null, "alternate", null);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddressSuffix() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations(null, null, "?consumer-priority=1");
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations() throws Exception {
+      doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations("queue://", "alternate", "?consumer-priority=1");
+   }
+
+   private void doTestBridgeCreatesSenderWithConfiguredRemoteAddressCustomizations(String prefix, String address, String suffix) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.setRemoteAddressPrefix(prefix);
+         sendToQueue.setRemoteAddress(address);
+         sendToQueue.setRemoteAddressSuffix(suffix);
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         final String expectedTargetAddress = (prefix != null ? prefix : "") +
+                                              (address != null ? address : getTestName()) +
+                                              (suffix != null ? suffix : "");
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(expectedTargetAddress).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithConfiguredRemoteTerminusCapabilities() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.setRemoteTerminusCapabilities(new String[] {"queue", "another"});
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue", "another")
+                                         .also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeCreatesSenderWithPresettledWhenConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.addProperty(PRESETTLE_SEND_MODE, "true");
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withSenderSettleModeSettled()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+
+         // This should trigger the bridged sender to be shut down as the statically defined queue
+         // should be the thing that triggers the bridging.
+         logger.info("Removing Queue from bridged queue to eliminate sender");
+         server.destroyQueue(SimpleString.of(getTestName()), null, false);
+         Wait.assertFalse(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRecoversLinkAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 1 millisecond initial recovery delay
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         // Retry after delay.
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeAttemptsLimitedRecoveryAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.addToIncludes("another", "another");
+         sendToQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 10 millisecond initial recovery delay
+         sendToQueue.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+         sendToQueue.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 2);   // 2 attempts then stop trying
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         // Recovery Attempt #1
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         // Recovery Attempt #2
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress("another").also()
+                            .withSource().withAddress("another::another").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // Add a binding to the alternate Queue and it should trigger new attach
+         server.createQueue(QueueConfiguration.of("another").setRoutingType(RoutingType.ANYCAST)
+                                                            .setAddress("another")
+                                                            .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of("another")).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of("another")).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // Remove and add the queue again which should trigger new attempt
+         server.destroyQueue(SimpleString.of(getTestName()), null, true);
+
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() == 0);
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeDoesNotAttemptLimitedRecoverAfterFirstReceiverFailsWithResourceNotFound() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.addToIncludes("another", "another");
+         sendToQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 1);  // 1 millisecond initial recovery delay
+         sendToQueue.addProperty(LINK_RECOVERY_DELAY, 10);         // 10 millisecond continued recovery delay
+         sendToQueue.addProperty(MAX_LINK_RECOVERY_ATTEMPTS, 0);   // No attempts
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond()
+                            .withNullTarget();
+         peer.remoteDetach().withClosed(true)
+                            .withErrorCondition(AmqpError.NOT_FOUND.toString(), "Resource Not Found").queue();
+         peer.expectDetach();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress("another").also()
+                            .withSource().withAddress("another::another").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("another"),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         // Add the alternate queue again which should trigger new attempt
+         server.createQueue(QueueConfiguration.of("another").setRoutingType(RoutingType.ANYCAST)
+                                                            .setAddress("another")
+                                                            .setAutoCreated(false));
+
+         // Remove and later add the queue again which should trigger new attempt
+         server.destroyQueue(SimpleString.of(getTestName()), null, true);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeRebuildsAfterRemoteClosesLinkAfterSuccessfulAttach() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+         sendToQueue.addProperty(LINK_RECOVERY_INITIAL_DELAY, 10); // 1 millisecond initial recovery delay
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(3);
+         amqpConnection.setRetryInterval(10);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteDetach().withClosed(true).queue(); // Remote close after attach is terminal
+         peer.expectDetach().optional();
+         peer.expectClose().optional();
+         peer.expectConnectionToDrop();
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists());
+
+         peer.waitForScriptToComplete(500, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSendCoreMessageTunneleInAMQPMessageWhenSupported() throws Exception {
+      doTestBridgeSendMessagesAccordingToTunnelingState(true, true);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSendCoreMessageConvertedToAMQPMessageWhenTunnelNotSupported() throws Exception {
+      doTestBridgeSendMessagesAccordingToTunnelingState(true, false);
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSendCoreMessageConvertedToAMQPMessageWhenConfigurationDisabledTunneling() throws Exception {
+      doTestBridgeSendMessagesAccordingToTunnelingState(false, true);
+   }
+
+   public void doTestBridgeSendMessagesAccordingToTunnelingState(boolean enabled, boolean receiverSupport) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes("#", getTestName());
+         sendToQueue.addProperty(TUNNEL_CORE_MESSAGES, Boolean.toString(enabled));
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         if (receiverSupport && enabled) {
+            peer.expectAttach().ofSender()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withDesiredCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-sender"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond()
+                               .withOfferedCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString());
+         } else if (enabled) {
+            peer.expectAttach().ofSender()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withDesiredCapabilities(CORE_MESSAGE_TUNNELING_SUPPORT.toString())
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-sender"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+         } else {
+            peer.expectAttach().ofSender()
+                               .withTarget().withAddress(getTestName()).also()
+                               .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                               .withName(allOf(containsString(getTestName()),
+                                               containsString("queue-sender"),
+                                               containsString("amqp-bridge"),
+                                               containsString(server.getNodeID().toString())))
+                               .respond();
+         }
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+         Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         final ConnectionFactory factory = CFUtil.createConnectionFactory("CORE", "tcp://localhost:" + AMQP_PORT);
+
+         // Producer connect should create the address and initiate the bridge sender attach
+         try (Connection connection = factory.createConnection()) {
+            final Session session = connection.createSession(Session.AUTO_ACKNOWLEDGE);
+            final MessageProducer producer = session.createProducer(session.createQueue(getTestName()));
+
+            // Await bridge sender attach.
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+            if (enabled && receiverSupport) {
+               peer.expectTransfer().withMessageFormat(AMQP_TUNNELED_CORE_MESSAGE_FORMAT)
+                                    .withMessage().withData(notNullValue()).also()
+                                    .accept();
+            } else {
+               peer.expectTransfer().withMessageFormat(0)
+                                    .withMessage().withHeader().also()
+                                                  .withMessageAnnotations().also()
+                                                  .withApplicationProperties().also()
+                                                  .withProperties().also()
+                                                  .withValue("Hello")
+                                    .and()
+                                    .accept();
+            }
+
+            connection.start();
+
+            Wait.assertTrue(() -> server.addressQuery(SimpleString.of(getTestName())).isExists());
+            Wait.assertTrue(() -> server.bindingQuery(SimpleString.of(getTestName())).getQueueNames().size() > 0);
+
+            producer.send(session.createTextMessage("Hello"));
+
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         }
+
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBrokerConnectionWithMoreThanOneBridgeConfigured() throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue1 = new AMQPBridgeQueuePolicyElement();
+         sendToQueue1.setName("queue-policy");
+         sendToQueue1.addToIncludes("source1", getTestName() + ":1");
+
+         final AMQPBridgeQueuePolicyElement sendToQueue2 = new AMQPBridgeQueuePolicyElement();
+         sendToQueue2.setName("queue-policy");
+         sendToQueue2.addToIncludes("source2", getTestName() + ":2");
+
+         final AMQPBridgeBrokerConnectionElement element1 = new AMQPBridgeBrokerConnectionElement();
+         element1.setName(getTestName() + ":1");
+         element1.addBridgeToQueuePolicy(sendToQueue1);
+
+         final AMQPBridgeBrokerConnectionElement element2 = new AMQPBridgeBrokerConnectionElement();
+         element2.setName(getTestName() + ":2");
+         element2.addBridgeToQueuePolicy(sendToQueue2);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(0);// No reconnects
+         amqpConnection.addElement(element1);
+         amqpConnection.addElement(element2);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName() + ":1").also()
+                            .withSource().withAddress("source1::" + getTestName() + ":1").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName() + ":1").setRoutingType(RoutingType.ANYCAST)
+                                                                       .setAddress("source1")
+                                                                       .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName() + ":1")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName() + ":2").also()
+                            .withSource().withAddress("source2::" + getTestName() + ":2").also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName() + ":2").setRoutingType(RoutingType.ANYCAST)
+                                                                       .setAddress("source2")
+                                                                       .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName() + ":2")).isExists());
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSenderRebuildAfterRemoteDetachForResourceDeleted() throws Exception {
+      doTestBridgeSenderRebuildAfterRemoteDetachForSpecificCondition(RESOURCE_DELETED.toString());
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSenderRebuildAfterRemoteDetachForResourceNotFound() throws Exception {
+      doTestBridgeSenderRebuildAfterRemoteDetachForSpecificCondition(NOT_FOUND.toString());
+   }
+
+   @Test
+   @Timeout(20)
+   public void testBridgeSenderRebuildAfterRemoteDetachForForcedDetach() throws Exception {
+      doTestBridgeSenderRebuildAfterRemoteDetachForSpecificCondition(DETACH_FORCED.toString());
+   }
+
+   private void doTestBridgeSenderRebuildAfterRemoteDetachForSpecificCondition(String condition) throws Exception {
+      try (ProtonTestServer peer = new ProtonTestServer()) {
+         peer.expectSASLAnonymousConnect();
+         peer.expectOpen().respond();
+         peer.expectBegin().respond();
+         peer.start();
+
+         final URI remoteURI = peer.getServerURI();
+         logger.info("Test started, peer listening on: {}", remoteURI);
+
+         final AMQPBridgeQueuePolicyElement sendToQueue = new AMQPBridgeQueuePolicyElement();
+         sendToQueue.setName("queue-policy");
+         sendToQueue.addToIncludes(getTestName(), getTestName());
+
+         final AMQPBridgeBrokerConnectionElement element = new AMQPBridgeBrokerConnectionElement();
+         element.setName(getTestName());
+         element.addBridgeToQueuePolicy(sendToQueue);
+
+         final AMQPBrokerConnectConfiguration amqpConnection =
+            new AMQPBrokerConnectConfiguration(getTestName(), "tcp://" + remoteURI.getHost() + ":" + remoteURI.getPort());
+         amqpConnection.setReconnectAttempts(1);
+         amqpConnection.addElement(element);
+
+         server.getConfiguration().addAMQPConnection(amqpConnection);
+         server.start();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                                .setAddress(getTestName())
+                                                                .setAutoCreated(false));
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+         peer.expectAttach().ofSender()
+                            .withTarget().withAddress(getTestName()).also()
+                            .withSource().withAddress(getTestName() + "::" + getTestName()).also()
+                            .withName(allOf(containsString(getTestName()),
+                                            containsString("queue-sender"),
+                                            containsString("amqp-bridge"),
+                                            containsString(server.getNodeID().toString())))
+                            .respond();
+         peer.remoteFlow().withLinkCredit(1).queue();
+
+         // This should trigger recovery handling to try and reattach the link
+         peer.remoteDetach().withErrorCondition(condition, "resource issue")
+                            .withClosed(true).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.close();
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBrokerConnectionReceiverTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBrokerConnectionReceiverTest.java
@@ -91,9 +91,9 @@ public class AMQPBrokerConnectionReceiverTest extends AmqpClientTestSupport {
 
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();
-         server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
-                                                          .setAddress("test")
-                                                          .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("test").setRoutingType(RoutingType.ANYCAST)
+                                                         .setAddress("test")
+                                                         .setAutoCreated(false));
 
          peer.waitForScriptToComplete();
          peer.expectClose();
@@ -254,9 +254,9 @@ public class AMQPBrokerConnectionReceiverTest extends AmqpClientTestSupport {
 
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();
-         server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
-                                                          .setAddress("test")
-                                                          .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("test").setRoutingType(RoutingType.ANYCAST)
+                                                         .setAddress("test")
+                                                         .setAutoCreated(false));
 
          peer.waitForScriptToComplete();
          peer.expectClose();
@@ -274,9 +274,9 @@ public class AMQPBrokerConnectionReceiverTest extends AmqpClientTestSupport {
          peer.expectBegin().respond();
          peer.execute(() -> {
             try {
-               server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
-                                                                .setAddress("test")
-                                                                .setAutoCreated(false));
+               server.createQueue(QueueConfiguration.of("test").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress("test")
+                                                               .setAutoCreated(false));
             } catch (Exception e) {
                LOG.warn("Error on creating server address and queue: ", e);
             }
@@ -293,9 +293,9 @@ public class AMQPBrokerConnectionReceiverTest extends AmqpClientTestSupport {
          peer.expectDetach().respond();
          peer.execute(() -> {
             try {
-               server.createQueue(new QueueConfiguration("test").setRoutingType(RoutingType.ANYCAST)
-                                                                .setAddress("test")
-                                                                .setAutoCreated(false));
+               server.createQueue(QueueConfiguration.of("test").setRoutingType(RoutingType.ANYCAST)
+                                                               .setAddress("test")
+                                                               .setAutoCreated(false));
             } catch (Exception e) {
                LOG.warn("Error on creating server address and queue: ", e);
             }


### PR DESCRIPTION
Adds a new broker connection AMQP bridge feature to allow for sending from existing addresses or queues or pulling from addresses or queues on the remote based on local demand or if configured to based solely on existence of local addresses or queues. The configuration model mimics the AMQP federation bits for consistency but adds a broad set if options to configure the remote senders and receivers to work with non-Artemis AMQP 1.0 peers where possible.