### PR TITLE
ARTEMIS-5446 AckManager instances leaking on backup

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AckManagerProvider.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/mirror/AckManagerProvider.java
@@ -36,9 +36,13 @@ public class AckManagerProvider {
    }
 
    public static void remove(ActiveMQServer server) {
-      logger.debug("Removing {}", server);
+      AckManager ackManager = null;
       synchronized (managerHashMap) {
-         managerHashMap.remove(server);
+         ackManager = managerHashMap.remove(server);
+      }
+      logger.debug("Removed entry for {}: {}", server, ackManager);
+      if (ackManager != null) {
+         server.removeExternalComponent(ackManager);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -942,6 +942,8 @@ public interface ActiveMQServer extends ServiceComponent {
     */
    void addExternalComponent(ActiveMQComponent externalComponent, boolean start) throws Exception;
 
+   void removeExternalComponent(ActiveMQComponent externalComponent);
+
    List<ActiveMQComponent> getExternalComponents();
 
    boolean addClientConnection(String clientId, boolean unique);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1010,6 +1010,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    }
 
    @Override
+   public void removeExternalComponent(ActiveMQComponent externalComponent) {
+      synchronized (externalComponents) {
+         externalComponents.remove(externalComponent);
+      }
+   }
+
+   @Override
    public ExecutorService getThreadPool() {
       return threadPool;
    }

--- a/tests/leak-tests/src/test/java/org/apache/activemq/artemis/tests/leak/AckManagerLeakTest.java
+++ b/tests/leak-tests/src/test/java/org/apache/activemq/artemis/tests/leak/AckManagerLeakTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.leak;
+
+import io.github.checkleak.core.CheckLeak;
+import org.apache.activemq.artemis.core.postoffice.impl.PostOfficeImpl;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.protocol.amqp.connect.mirror.AckManager;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class AckManagerLeakTest extends ActiveMQTestBase {
+
+   @Test
+   public void testAckManagerLeak() throws Throwable {
+      CheckLeak checkLeak = new CheckLeak();
+
+      ActiveMQServer server = createServer(false, true);
+      for (int i = 0; i < 5; i++) {
+         server.start();
+         MemoryAssertions.assertMemory(checkLeak, 1, AckManager.class.getName());
+         server.stop(false);
+         MemoryAssertions.assertMemory(checkLeak, 0, AckManager.class.getName());
+      }
+
+      MemoryAssertions.assertMemory(checkLeak, 1, PostOfficeImpl.class.getName());
+      MemoryAssertions.assertMemory(checkLeak, 0, AckManager.class.getName());
+      assertEquals(0, server.getExternalComponents().size());
+      MemoryAssertions.basicMemoryAsserts();
+   }
+}


### PR DESCRIPTION
When the broker starts with AMQP protocol support an AckManager instance is automatically created and added to the broker's list of "external components." However, this component is not removed when the broker is stopped (e.g. when an active backup shuts down due to fail-back). Over time these instances can accumulate and cause memory issues.