### PR TITLE
ARTEMIS-5458 fixed invalid constant name(docs)

### DIFF
--- a/docs/user-manual/connection-ttl.adoc
+++ b/docs/user-manual/connection-ttl.adoc
@@ -82,11 +82,11 @@ Basically, the TTL determines how long the server will keep a connection alive i
 The client will automatically send "ping" packets periodically to prevent the server from closing it down.
 If the server doesn't receive any packets on a connection for the connection TTL time, then it will automatically close all the sessions on the server that relate to that connection.
 
-The connection TTL is configured on the URI using the `connectionTTL` parameter.
+The connection TTL is configured on the URI using the `connectionTtl` parameter.
 
 The default value for connection ttl on an "unreliable" connection (e.g. a Netty connection using the `tcp` URL scheme) is ``60000``ms, i.e. 1 minute.
 The default value for connection ttl on a "reliable" connection (e.g. an in-vm connection using the `vm` URL scheme) is `-1`.
-A value of `-1` for `connectionTTL` means the server will never time out the connection on the server side.
+A value of `-1` for `connectionTtl` means the server will never time out the connection on the server side.
 
 If you do not wish clients to be able to specify their own connection TTL, you can override all values used by a global value set on the server side.
 This can be done by specifying the `connection-ttl-override` attribute in the server side configuration.


### PR DESCRIPTION
Fixed incorrect transport constants name (connectionTTL) in the documentation.