### PR TITLE
ARTEMIS-5483: New option - jmsMaxTextMessageSize

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/FilterConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/FilterConstants.java
@@ -63,6 +63,11 @@ public final class FilterConstants {
    public static final SimpleString ACTIVEMQ_SIZE = SimpleString.of("AMQSize");
 
    /**
+    * Name of the Apache Artemis Message full size header.
+    */
+   public static final SimpleString ACTIVEMQ_FULL_SIZE = SimpleString.of("AMQFullSize");
+
+   /**
     * Name of the Apache Artemis Address header
     */
    public static final SimpleString ACTIVEMQ_ADDRESS = SimpleString.of("AMQAddress");

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/FilterConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/FilterConstants.java
@@ -63,7 +63,7 @@ public final class FilterConstants {
    public static final SimpleString ACTIVEMQ_SIZE = SimpleString.of("AMQSize");
 
    /**
-    * Name of the Apache Artemis Message full size header.
+    * Name of the Apache Artemis Message full size filter property.
     */
    public static final SimpleString ACTIVEMQ_FULL_SIZE = SimpleString.of("AMQFullSize");
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
@@ -50,6 +50,7 @@ import static org.apache.activemq.artemis.api.core.FilterConstants.NATIVE_MESSAG
  * <li>{@code AMQDurable} - "DURABLE" or "NON_DURABLE"
  * <li>{@code AMQExpiration} - the expiration of the message
  * <li>{@code AMQSize} - the encoded size of the full message in bytes
+ * <li>{@code AMQFullSize} - the whole size of the full message in bytes
  * <li>{@code AMQUserID} - the user specified ID string (if any)
  * <li>Any other identifiers that appear in a filter expression represent header values for the message
  * </ul>
@@ -177,6 +178,8 @@ public class FilterImpl implements Filter {
          return msg.getExpiration();
       } else if (FilterConstants.ACTIVEMQ_SIZE.equals(fieldName)) {
          return msg.getEncodeSize();
+      } else if (FilterConstants.ACTIVEMQ_FULL_SIZE.equals(fieldName)) {
+         return msg.getWholeMessageSize();
       } else if (FilterConstants.ACTIVEMQ_ADDRESS.equals(fieldName)) {
          return msg.getAddress();
       } else if (FilterConstants.ACTIVEMQ_GROUP_ID.equals(fieldName)) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/filter/impl/FilterTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/filter/impl/FilterTest.java
@@ -703,6 +703,25 @@ public class FilterTest extends SilentTestCase {
       assertTrue(filter.match(message));
    }
 
+   @Test
+   public void testAMQFullSize() throws Exception {
+      message.setAddress(RandomUtil.randomUUIDSimpleString());
+
+      long wholeSize = message.getWholeMessageSize();
+
+      Filter moreThanSmall = FilterImpl.createFilter(SimpleString.of("AMQFullSize > " + (wholeSize - 1)));
+      Filter lessThanLarge = FilterImpl.createFilter(SimpleString.of("AMQFullSize < " + (wholeSize + 1)));
+
+      Filter lessThanSmall = FilterImpl.createFilter(SimpleString.of("AMQFullSize < " + wholeSize));
+      Filter moreThanLarge = FilterImpl.createFilter(SimpleString.of("AMQFullSize > " + wholeSize));
+
+      assertTrue(moreThanSmall.match(message));
+      assertTrue(lessThanLarge.match(message));
+
+      assertFalse(lessThanSmall.match(message));
+      assertFalse(moreThanLarge.match(message));
+   }
+
    // TODO: re-implement this.
    //
    //   @Test

--- a/docs/user-manual/filter-expressions.adoc
+++ b/docs/user-manual/filter-expressions.adoc
@@ -55,6 +55,10 @@ AMQSize::
 The size of a message in bytes.
 The value is an integer.
 
+AMQFullSize::
+The whole size of a message in bytes.
+The value is a long integer.
+
 Any other identifiers used in core filter expressions will be assumed to be properties of the message.
 
 == Property Identifier Constraints

--- a/docs/user-manual/filter-expressions.adoc
+++ b/docs/user-manual/filter-expressions.adoc
@@ -52,14 +52,13 @@ The timestamp of when the message was created.
 The value is a long integer.
 
 AMQSize::
-The size of a message in bytes.
+Broker calculated size of a message in bytes. For large messages, the body size may not be fully included.
 The value is an integer.
 
 AMQFullSize::
-The whole size of a message in bytes.
+Total size of the encoded message in bytes as it would be transmitted over the wire, including headers, properties, and the full body.
+Can be used in filters to select messages based on their size.
 The value is a long integer.
-
-Any other identifiers used in core filter expressions will be assumed to be properties of the message.
 
 == Property Identifier Constraints
 


### PR DESCRIPTION
Adds a new configuration option for Jakarta client consumers. When this configuration is set, the consumer will throw a ``javax.jms.JMSException`` on receiving large text(type 3) message that would exceed the specified size (in bytes) when creating ``javax.jms.TextMessage``

``jmsMaxTextMessageSize`` is intended to prevent consumers of ``javax.jms.TextMessage`` from crashing due to out-of-memory when receiving messages that are larger than consumers memory.

The configuration is provided as a URL property when establishing a connection to the broker.

Example:
Throw on large text messages exceeding 10MB in size: ``tcp://localhost:61616?jmsMaxTextMessageSize=10000000``

Note:
This option relies on how core client consumer works. When message is above certain size threshold (default 100KB) it will be considered as a large message and be delivered in parts with headers first. With the help of headers we're able to determine the size of the incoming body and reject if it is above ``jmsMaxTextMessageSize``.

If the message is below large message threshold then this option has no real defensive effect since the message will be read into memory anyway.