### PR TITLE
ARTEMIS-5485 Enforce the queue address before deploying

### DIFF
--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
@@ -339,6 +339,10 @@ public class QueueConfiguration implements Serializable {
       return address == null ? getName() : address;
    }
 
+   public boolean isAddressNull() {
+      return address == null;
+   }
+
    /**
     * Set the address. If the fully-qualified queue name is used then it will be parsed and the corresponding values for
     * {@code address} and {@code name} will be set automatically. For example if "myAddress::myQueue" is passed then the

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -3822,7 +3822,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
             addOrUpdateAddressInfo(merged);
 
-            deployQueuesFromListQueueConfiguration(config.getQueueConfigs());
+            deployQueuesFromListQueueConfiguration(config.getQueueConfigs(), address);
 
             //Now all queues updated we apply the actual address info expected tobe.
             addOrUpdateAddressInfo(tobe);
@@ -3842,8 +3842,13 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       return new AddressInfo(address, mergedRoutingTypes);
    }
 
-   private void deployQueuesFromListQueueConfiguration(List<QueueConfiguration> queues) throws Exception {
+   private void deployQueuesFromListQueueConfiguration(List<QueueConfiguration> queues, SimpleString address) throws Exception {
       for (QueueConfiguration config : queues) {
+         // set the address for queue configs from broker properties
+         if (address != null && config.isAddressNull()) {
+            config.setAddress(address);
+         }
+
          try {
             QueueConfigurationUtils.applyDynamicDefaults(config, addressSettingsRepository.getMatch(config.getAddress().toString()));
 
@@ -3873,7 +3878,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
    }
 
    private void deployQueuesFromConfiguration() throws Exception {
-      deployQueuesFromListQueueConfiguration(configuration.getQueueConfigs());
+      deployQueuesFromListQueueConfiguration(configuration.getQueueConfigs(), null);
    }
 
    private void checkForPotentialOOMEInAddressConfiguration() {
@@ -4790,7 +4795,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("addresses");
          undeployAddressesAndQueueNotInConfiguration(configuration);
          deployAddressesFromConfiguration(configuration);
-         deployQueuesFromListQueueConfiguration(configuration.getQueueConfigs());
+         deployQueuesFromListQueueConfiguration(configuration.getQueueConfigs(), null);
 
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("bridges");
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ConfigurationTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/server/ConfigurationTest.java
@@ -91,6 +91,18 @@ public class ConfigurationTest extends ActiveMQTestBase {
 
       config.put("addressConfigurations.mytopic_3.queueConfigs.\"queue.B3\".address", "mytopic_3");
       config.put("addressConfigurations.mytopic_3.queueConfigs.\"queue.B3\".routingType", "MULTICAST");
+
+      config.put("addressConfigurations.myqueue_1.routingTypes", "ANYCAST");
+      config.put("addressConfigurations.myqueue_1.queueConfigs.\"myqueue_1\".routingType", "ANYCAST");
+
+      config.put("addressConfigurations.myqueue_2.routingTypes", "ANYCAST");
+      config.put("addressConfigurations.myqueue_2.queueConfigs.\"queue.Q1\".routingType", "ANYCAST");
+      config.put("addressConfigurations.myqueue_2.queueConfigs.\"queue.Q2\".routingType", "ANYCAST");
+
+      config.put("addressConfigurations.mytopic_4.routingTypes", "MULTICAST");
+      config.put("addressConfigurations.mytopic_4.queueConfigs.\"queue.A4\".routingType", "MULTICAST");
+      config.put("addressConfigurations.mytopic_4.queueConfigs.\"queue.B4\".routingType", "MULTICAST");
+
       config.put("status", "{\"generation\": \"1\"}");
 
       try (FileOutputStream outStream = new FileOutputStream(propsFile)) {
@@ -112,6 +124,14 @@ public class ConfigurationTest extends ActiveMQTestBase {
          Bindings mytopic_3 = server.getPostOffice().getBindingsForAddress(SimpleString.of("mytopic_3"));
          assertEquals(2, mytopic_3.getBindings().size());
 
+         Bindings myqueue_1 = server.getPostOffice().getBindingsForAddress(SimpleString.of("myqueue_1"));
+         assertEquals(1, myqueue_1.getBindings().size());
+
+         Bindings myqueue_2 = server.getPostOffice().getBindingsForAddress(SimpleString.of("myqueue_2"));
+         assertEquals(2, myqueue_2.getBindings().size());
+
+         Bindings mytopic_4 = server.getPostOffice().getBindingsForAddress(SimpleString.of("mytopic_4"));
+         assertEquals(2, mytopic_4.getBindings().size());
 
          // add new binding from props update
          config.put("addressConfigurations.mytopic_3.queueConfigs.\"queue.C3\".address", "mytopic_3");


### PR DESCRIPTION
The queue configs loaded from broker properties use the queue name as the default value for the address if it is not set. Enforcing the queue address with the parent address before deploying them removes the requirement to set the address when it doesn't match the queue name.