### PR TITLE
ARTEMIS-5493 MQTT max in-flight messages setting

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTProtocolManager.java
@@ -72,6 +72,8 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
 
    private boolean allowLinkStealing = true;
 
+   private int defaultMaximumInFlightPublishMessages = MQTTUtil.DEFAULT_MAXIMUM_IN_FLIGHT_PUBLISH_MESSAGES;
+
    private final MQTTRoutingHandler routingHandler;
 
    private MQTTStateManager sessionStateManager;
@@ -152,6 +154,14 @@ public class MQTTProtocolManager extends AbstractProtocolManager<MqttMessage, MQ
 
    public void setAllowLinkStealing(boolean allowLinkStealing) {
       this.allowLinkStealing = allowLinkStealing;
+   }
+
+   public int getDefaultMaximumInFlightPublishMessages() {
+      return defaultMaximumInFlightPublishMessages;
+   }
+
+   public void setDefaultMaximumInFlightPublishMessages(int defaultMaximumInFlightPublishMessages) {
+      this.defaultMaximumInFlightPublishMessages = defaultMaximumInFlightPublishMessages;
    }
 
    @Override

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -89,7 +89,7 @@ public class MQTTSession {
 
       mqttConnectionManager = new MQTTConnectionManager(this);
       mqttPublishManager = new MQTTPublishManager(this, protocolManager.isCloseMqttConnectionOnPublishAuthorizationFailure());
-      sessionCallback = new MQTTSessionCallback(this, connection);
+      sessionCallback = new MQTTSessionCallback(this, connection, protocolManager.getDefaultMaximumInFlightPublishMessages());
       subscriptionManager = new MQTTSubscriptionManager(this, stateManager);
       retainMessageManager = new MQTTRetainMessageManager(this);
 

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionCallback.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionCallback.java
@@ -26,10 +26,12 @@ public class MQTTSessionCallback implements SessionCallback {
 
    private final MQTTSession session;
    private final MQTTConnection connection;
+   private final int defaultMaximumInFlightPublishMessages;
 
-   public MQTTSessionCallback(MQTTSession session, MQTTConnection connection) throws Exception {
+   public MQTTSessionCallback(MQTTSession session, MQTTConnection connection, int defaultMaximumInFlightPublishMessages) throws Exception {
       this.session = session;
       this.connection = connection;
+      this.defaultMaximumInFlightPublishMessages = defaultMaximumInFlightPublishMessages;
    }
 
    @Override
@@ -107,7 +109,8 @@ public class MQTTSessionCallback implements SessionCallback {
        *
        * Therefore, enforce flow-control based on the number of pending QoS 1 & 2 messages
        */
-      if (ref != null && ref.isDurable() == true && connection.getReceiveMaximum() != -1 && session.getState().getOutboundStore().getSendQuota() >= connection.getReceiveMaximum()) {
+      int maxInFlightPublishMessages = connection.getReceiveMaximum() > 0 ? connection.getReceiveMaximum() : defaultMaximumInFlightPublishMessages;
+      if (ref != null && ref.isDurable() == true && maxInFlightPublishMessages > 0 && session.getState().getOutboundStore().getSendQuota() >= maxInFlightPublishMessages) {
          return false;
       } else {
          return true;

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTUtil.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTUtil.java
@@ -139,6 +139,8 @@ public class MQTTUtil {
 
    public static final int DEFAULT_MAXIMUM_PACKET_SIZE = MAX_PACKET_SIZE;
 
+   public static final int DEFAULT_MAXIMUM_IN_FLIGHT_PUBLISH_MESSAGES = TWO_BYTE_INT_MAX;
+
    public static final WildcardConfiguration MQTT_WILDCARD = new WildcardConfiguration().setDelimiter(SLASH).setAnyWords(HASH).setSingleWord(PLUS);
 
    /**

--- a/docs/user-manual/mqtt.adoc
+++ b/docs/user-manual/mqtt.adoc
@@ -217,10 +217,12 @@ This can be changed using the `mqtt-session-scan-interval` element set in the `c
 
 == Flow Control
 
+MQTT 3.x lacks a flow control mechanism. The sending party determines how many QoS 1 & 2 messages can be published without acknowledgment. On the broker side, this is controlled by the `defaultMaximumInFlightPublishMessages` URL parameter on the MQTT `acceptor` in `broker.xml`, which defaults to `65535`.
+
 MQTT 5 introduced a simple form of https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Flow_Control[flow control].
 In short, a broker can tell a client how many QoS 1 & 2 messages it can receive before being acknowledged and vice versa.
 
-This is controlled on the broker by setting the `receiveMaximum` URL parameter on the MQTT `acceptor` in `broker.xml`.
+This is controlled on the broker by setting the `receiveMaximum` URL parameter on the MQTT `acceptor`.
 
 The default value is `65535` (the maximum value of the 2-byte integer used by  MQTT).
 
@@ -228,6 +230,8 @@ A value of `0` is prohibited by the MQTT 5 specification.
 
 A value of `-1` will prevent the broker from informing the client of any receive maximum which means flow-control will be disabled from clients to the broker.
 This is effectively the same as setting the value to `65535`, but reduces the size of the `CONNACK` packet by a few bytes.
+
+If the MQTT 5 client doesn't send the https://docs.oasis-open.org/mqtt/mqtt/v5.0/os/mqtt-v5.0-os.html#_Toc3901049[Receive Maximum] property to the broker, the broker uses its `defaultMaximumInFlightPublishMessages` setting to determine the maximum number of QoS 1 & 2 messages it can send without acknowledgment.
 
 == Topic Alias Maximum
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTMaxInFlightPublishesTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTMaxInFlightPublishesTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.mqtt;
+
+import org.fusesource.mqtt.client.BlockingConnection;
+import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.Message;
+import org.fusesource.mqtt.client.QoS;
+import org.fusesource.mqtt.client.Topic;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.invoke.MethodHandles;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+public class MQTTMaxInFlightPublishesTest extends MQTTTestSupport {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   @Test
+   @Timeout(60)
+   public void testCustomDefaultMaximumInFlightPublishMessages() throws Exception {
+      final MQTT subscriberClient = createMQTTConnection("MQTT-Sub-Client", false);
+      final MQTT publisherClient = createMQTTConnection("MQTT-Pub-Client", false);
+
+      BlockingConnection subscriberConn = subscriberClient.blockingConnection();
+      subscriberConn.connect();
+
+      String topic = "TopicA";
+      subscriberConn.subscribe(new Topic[]{new Topic(topic, QoS.AT_LEAST_ONCE)});
+
+      BlockingConnection publisherConn = publisherClient.blockingConnection();
+      publisherConn.connect();
+
+      publisherConn.publish(topic, new byte[]{1}, QoS.AT_LEAST_ONCE, false);
+      publisherConn.publish(topic, new byte[]{2}, QoS.AT_LEAST_ONCE, false);
+      publisherConn.publish(topic, new byte[]{3}, QoS.AT_LEAST_ONCE, false);
+      publisherConn.publish(topic, new byte[]{4}, QoS.AT_LEAST_ONCE, false);
+
+      Message msg1 = subscriberConn.receive();
+      assertEquals(1, msg1.getPayload()[0]);
+      Message msg2 = subscriberConn.receive();
+      assertEquals(2, msg2.getPayload()[0]);
+
+      Message msg3 = subscriberConn.receive(100, TimeUnit.MILLISECONDS);
+      assertNull(msg3);
+
+      msg1.ack();
+      msg3 = subscriberConn.receive();
+      assertEquals(3, msg3.getPayload()[0]);
+
+      Message msg4 = subscriberConn.receive(100, TimeUnit.MILLISECONDS);
+      assertNull(msg4);
+
+      msg3.ack();
+      msg4 = subscriberConn.receive();
+      assertEquals(4, msg4.getPayload()[0]);
+
+
+      subscriberConn.disconnect();
+      publisherConn.disconnect();
+
+   }
+
+   @Override
+   protected void addMQTTConnector() throws Exception {
+      server.getConfiguration().addAcceptorConfiguration("MQTT", "tcp://localhost:" + port + "?protocols=MQTT;anycastPrefix=anycast:;multicastPrefix=multicast:;defaultMaximumInFlightPublishMessages=2");
+
+      logger.debug("Added MQTT connector to broker");
+   }
+}


### PR DESCRIPTION
Most of MQTT brokers have setting for maximum number of QoS 1 and QoS 2 messages that are allowed to be delivered simultaneously before completing the acknowledgment.

This setting have relatively small value (10,20,32) and it's good so I propose to make this setting in the Artemis.