### PR TITLE
ARTEMIS-5499 refactor MQTT subscription persistence

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -689,6 +689,9 @@ public final class ActiveMQDefaultConfiguration {
    // How long (in ms) to wait to persist MQTT session state
    private static long DEFAULT_MQTT_SESSION_STATE_PERSISTENCE_TIMEOUT = 5000;
 
+   // Whether to persist MQTT subscriptions
+   private static boolean DEFAULT_MQTT_SUBSCRIPTION_PERSISTENCE_ENABLED = true;
+
    // If SESSION-notifications should be suppressed or not
    public static boolean DEFAULT_SUPPRESS_SESSION_NOTIFICATIONS = false;
 
@@ -1951,6 +1954,13 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static long getMqttSessionStatePersistenceTimeout() {
       return DEFAULT_MQTT_SESSION_STATE_PERSISTENCE_TIMEOUT;
+   }
+
+   /**
+    * Whether to persist MQTT subscriptions
+    */
+   public static boolean getMqttSubscriptionPersistenceEnabled() {
+      return DEFAULT_MQTT_SUBSCRIPTION_PERSISTENCE_ENABLED;
    }
 
    public static boolean getDefaultSuppressSessionNotifications() {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
@@ -168,7 +168,7 @@ public class MQTTConnectionManager {
                                                          null,
                                                          session.getSessionCallback(),
                                                          MQTTUtil.SESSION_AUTO_CREATE_QUEUE,
-                                                         server.newOperationContext(),
+                                                         session.getSessionContext(),
                                                          session.getProtocolManager().getPrefixes(),
                                                          session.getProtocolManager().getSecurityDomain(),
                                                          validatedUser,

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -27,6 +27,7 @@ import io.netty.handler.codec.mqtt.MqttQoS;
 import org.apache.activemq.artemis.api.core.ActiveMQSecurityException;
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
 import org.apache.activemq.artemis.core.persistence.CoreMessageObjectPools;
+import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.ServerSessionImpl;
 import org.apache.activemq.artemis.spi.core.protocol.SessionCallback;
@@ -76,16 +77,19 @@ public class MQTTSession {
 
    private boolean usingServerKeepAlive = false;
 
+   private OperationContext sessionContext;
+
    public MQTTSession(MQTTProtocolHandler protocolHandler,
                       MQTTConnection connection,
                       MQTTProtocolManager protocolManager,
-                      WildcardConfiguration wildcardConfiguration) throws Exception {
+                      WildcardConfiguration wildcardConfiguration,
+                      OperationContext sessionContext) throws Exception {
       this.protocolHandler = protocolHandler;
       this.protocolManager = protocolManager;
       this.stateManager = protocolManager.getStateManager();
       this.wildcardConfiguration = wildcardConfiguration;
-
       this.connection = connection;
+      this.sessionContext = sessionContext;
 
       mqttConnectionManager = new MQTTConnectionManager(this);
       mqttPublishManager = new MQTTPublishManager(this, protocolManager.isCloseMqttConnectionOnPublishAuthorizationFailure());
@@ -249,6 +253,10 @@ public class MQTTSession {
 
    public void setWildcardConfiguration(WildcardConfiguration wildcardConfiguration) {
       this.wildcardConfiguration = wildcardConfiguration;
+   }
+
+   public OperationContext getSessionContext() {
+      return sessionContext;
    }
 
    public CoreMessageObjectPools getCoreMessageObjectPools() {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionState.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSessionState.java
@@ -100,7 +100,7 @@ public class MQTTSessionState {
    }
 
    /**
-    * This constructor deserializes session data from a message. The format is as follows.
+    * This constructor deserializes subscription data from a message. The format is as follows.
     * <ul>
     * <li>byte: version
     * <li>int: subscription count
@@ -118,7 +118,7 @@ public class MQTTSessionState {
     * @param message the message holding the MQTT session data
     */
    public MQTTSessionState(CoreMessage message) {
-      logger.debug("Deserializing MQTT session state from {}", message);
+      logger.debug("Deserializing MQTT subscriptions from {}", message);
       this.clientId = message.getStringProperty(Message.HDR_LAST_VALUE_NAME);
       ActiveMQBuffer buf = message.getDataBuffer();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/Configuration.java
@@ -1420,17 +1420,28 @@ public interface Configuration {
    long getMqttSessionScanInterval();
 
    /**
-    * This is necessary because MQTT sessions and handled on a broker-wide basis so this can't be set on a per-connector
-    * basis like most of the other MQTT-specific settings.
+    * @deprecated This is no longer used by the broker. See
+    * {@link Configuration#setMqttSubscriptionPersistenceEnabled(boolean)}.
     */
+   @Deprecated(forRemoval = true)
    Configuration setMqttSessionStatePersistenceTimeout(long mqttSessionStatePersistenceTimeout);
 
    /**
-    * Get the MQTT session state persistence timeout
-    *
-    * @see Configuration#setMqttSessionStatePersistenceTimeout
+    * @deprecated This is no longer used by the broker. See {@link Configuration#isMqttSubscriptionPersistenceEnabled}.
     */
+   @Deprecated(forRemoval = true)
    long getMqttSessionStatePersistenceTimeout();
+
+   /**
+    * This is necessary because MQTT subsriptions are handled on a broker-wide basis so this can't be set on a
+    * per-connector basis like most of the other MQTT-specific settings.
+    */
+   Configuration setMqttSubscriptionPersistenceEnabled(boolean mqttSubscriptionPersistenceEnabled);
+
+   /**
+    * @see Configuration#setMqttSubscriptionPersistenceEnabled
+    */
+   boolean isMqttSubscriptionPersistenceEnabled();
 
    /**
     * {@return whether suppression of session-notifications is enabled for this server; default is {@link

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -446,6 +446,8 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    private long mqttSessionStatePersistenceTimeout = ActiveMQDefaultConfiguration.getMqttSessionStatePersistenceTimeout();
 
+   private boolean mqttSessionStatePersistenceEnabled = ActiveMQDefaultConfiguration.getMqttSubscriptionPersistenceEnabled();
+
    private boolean suppressSessionNotifications = ActiveMQDefaultConfiguration.getDefaultSuppressSessionNotifications();
 
    private String literalMatchMarkers = ActiveMQDefaultConfiguration.getLiteralMatchMarkers();
@@ -3501,6 +3503,17 @@ public class ConfigurationImpl implements Configuration, Serializable {
    @Override
    public Configuration setMqttSessionStatePersistenceTimeout(long mqttSessionStatePersistenceTimeout) {
       this.mqttSessionStatePersistenceTimeout = mqttSessionStatePersistenceTimeout;
+      return this;
+   }
+
+   @Override
+   public boolean isMqttSubscriptionPersistenceEnabled() {
+      return mqttSessionStatePersistenceEnabled;
+   }
+
+   @Override
+   public Configuration setMqttSubscriptionPersistenceEnabled(boolean mqttSubscriptionPersistenceEnabled) {
+      this.mqttSessionStatePersistenceEnabled = mqttSubscriptionPersistenceEnabled;
       return this;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -400,6 +400,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
    private static final String INITIAL_QUEUE_BUFFER_SIZE = "initial-queue-buffer-size";
 
+   private static final String MQTT_SUBSCRIPTION_PERSISTENCE_ENABLED = "mqtt-subscription-persistence-enabled";
+
    private boolean validateAIO = false;
 
    private boolean printPageMaxSizeUsed = false;
@@ -511,7 +513,9 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
 
       config.setMqttSessionScanInterval(getLong(e, "mqtt-session-scan-interval", config.getMqttSessionScanInterval(), GT_ZERO));
 
-      config.setMqttSessionStatePersistenceTimeout(getLong(e, "mqtt-session-state-persistence-timeout", config.getMqttSessionStatePersistenceTimeout(), GT_ZERO));
+      config.setMqttSessionStatePersistenceTimeout(getLong(e, "mqtt-session-state-persistence-timeout", config.getMqttSessionStatePersistenceTimeout(), GT_ZERO, MQTT_SUBSCRIPTION_PERSISTENCE_ENABLED));
+
+      config.setMqttSubscriptionPersistenceEnabled(getBoolean(e, MQTT_SUBSCRIPTION_PERSISTENCE_ENABLED, config.isMqttSubscriptionPersistenceEnabled()));
 
       config.setGlobalMaxSizePercentOfJvmMaxMemory(getInteger(e, GLOBAL_MAX_SIZE_PERCENT_JVM_MAX_MEM, config.getGlobalMaxSizePercentOfJvmMaxMemory(), GT_ZERO));
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -763,7 +763,9 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
       AddressSettings as = server.getAddressSettingsRepository().getMatch(queueConfiguration.getAddress().toString());
 
-      if (as.isAutoCreateAddresses() && (server.getAddressInfo(queueConfiguration.getAddress()) == null || !server.getAddressInfo(queueConfiguration.getAddress()).getRoutingTypes().contains(queueConfiguration.getRoutingType()))) {
+      AddressInfo addressInfo = server.getAddressInfo(queueConfiguration.getAddress());
+
+      if (as.isAutoCreateAddresses() && addressInfo == null || !addressInfo.getRoutingTypes().contains(queueConfiguration.getRoutingType())) {
          securityCheck(queueConfiguration.getAddress(), queueConfiguration.getName(), CheckType.CREATE_ADDRESS, this);
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/utils/XMLConfigurationUtil.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/utils/XMLConfigurationUtil.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.utils;
 
+import org.apache.activemq.artemis.core.server.ActiveMQServerLogger;
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -69,8 +70,19 @@ public class XMLConfigurationUtil {
                                     final String name,
                                     final long def,
                                     final Validator<Number> validator) {
+      return getLong(e, name, def, validator, null);
+   }
+
+   public static final Long getLong(final Element e,
+                                    final String name,
+                                    final long def,
+                                    final Validator<Number> validator,
+                                    final String alternativeForDeprecated) {
       NodeList nl = e.getElementsByTagName(name);
       if (nl.getLength() > 0) {
+         if (alternativeForDeprecated != null) {
+            ActiveMQServerLogger.LOGGER.deprecatedConfigurationOption(name, alternativeForDeprecated);
+         }
          return (Long) validator.validate(name, XMLUtil.parseLong(nl.item(0)));
       } else {
          return def;

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -466,7 +466,15 @@
          <xsd:element name="mqtt-session-state-persistence-timeout" type="xsd:long" default="5000" maxOccurs="1" minOccurs="0">
             <xsd:annotation>
                <xsd:documentation>
-                  how long (in ms) to wait to persist MQTT session state
+                  DEPRECATED: how long (in ms) to wait to persist MQTT session state
+               </xsd:documentation>
+            </xsd:annotation>
+         </xsd:element>
+
+         <xsd:element name="mqtt-subscription-persistence-enabled" type="xsd:boolean" default="true" maxOccurs="1" minOccurs="0">
+            <xsd:annotation>
+               <xsd:documentation>
+                  whether to persist MQTT subscriptions
                </xsd:documentation>
             </xsd:annotation>
          </xsd:element>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -246,6 +246,7 @@ public class FileConfigurationTest extends AbstractConfigurationTestBase {
       assertFalse(configInstance.isRejectEmptyValidatedUser());
       assertEquals(123456, configInstance.getMqttSessionScanInterval());
       assertEquals(567890, configInstance.getMqttSessionStatePersistenceTimeout());
+      assertFalse(configInstance.isMqttSubscriptionPersistenceEnabled());
       assertEquals(98765, configInstance.getConnectionTtlCheckInterval());
       assertEquals(1234567, configInstance.getConfigurationFileRefreshPeriod());
       assertEquals("UUID", configInstance.getTemporaryQueueNamespace());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -58,6 +58,7 @@
       <reject-empty-validated-user>false</reject-empty-validated-user>
       <mqtt-session-scan-interval>123456</mqtt-session-scan-interval>
       <mqtt-session-state-persistence-timeout>567890</mqtt-session-state-persistence-timeout>
+      <mqtt-subscription-persistence-enabled>false</mqtt-subscription-persistence-enabled>
       <connection-ttl-check-interval>98765</connection-ttl-check-interval>
       <configuration-file-refresh-period>1234567</configuration-file-refresh-period>
       <temporary-queue-namespace>TEMP</temporary-queue-namespace>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -59,6 +59,7 @@
       <reject-empty-validated-user>false</reject-empty-validated-user>
       <mqtt-session-scan-interval>123456</mqtt-session-scan-interval>
       <mqtt-session-state-persistence-timeout>567890</mqtt-session-state-persistence-timeout>
+      <mqtt-subscription-persistence-enabled>false</mqtt-subscription-persistence-enabled>
       <connection-ttl-check-interval>98765</connection-ttl-check-interval>
       <configuration-file-refresh-period>1234567</configuration-file-refresh-period>
       <temporary-queue-namespace>TEMP</temporary-queue-namespace>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config.xml
@@ -59,6 +59,7 @@
       <reject-empty-validated-user>false</reject-empty-validated-user>
       <mqtt-session-scan-interval>123456</mqtt-session-scan-interval>
       <mqtt-session-state-persistence-timeout>567890</mqtt-session-state-persistence-timeout>
+      <mqtt-subscription-persistence-enabled>false</mqtt-subscription-persistence-enabled>
       <connection-ttl-check-interval>98765</connection-ttl-check-interval>
       <configuration-file-refresh-period>1234567</configuration-file-refresh-period>
       <temporary-queue-namespace>TEMP</temporary-queue-namespace>

--- a/docs/user-manual/mqtt.adoc
+++ b/docs/user-manual/mqtt.adoc
@@ -92,29 +92,29 @@ Payload logging is limited to avoid filling the logs with potentially hundreds o
 
 == Persistent Subscriptions
 
-The subscription information for MQTT sessions is stored in an internal queue named `$sys.mqtt.sessions` and persisted to storage (assuming persistence is enabled).
-The information is durable so that MQTT subscribers can reconnect and resume their subscriptions seamlessly after a broker restart, failure, etc.
+The subscription information for MQTT sessions is kept in an internal queue named `$sys.mqtt.sessions` and persisted to storage (assuming persistence is enabled).
+The information is durable so that MQTT subscribers can reconnect and resume their subscriptions seamlessly after a broker restart, failure, etc. without having to resend a `SUBSCRIBE` packet.
 When brokers are configured for high availability this information will be available on the backup so even in the case of a broker fail-over subscribers will be able to resume their subscriptions.
 
-While persistent subscriptions can be convenient they impose a performance penalty since data must be written to storage.
-If you don't need the convenience (e.g. you always use clean sessions) and/or you don't want the performance penalty then you can disable it by disabling the `$sys.mqtt.sessions` queue in `broker.xml`, e.g.:
+While persistent subscriptions can be convenient they impose a performance penalty since data must be written to and removed from storage.
+If you don't need the convenience (e.g. you always use clean sessions) and/or you don't want the performance penalty then you can disable it by setting `mqtt-subscription-persistence-enabled` to `false` in `broker.xml`, e.g.:
 
 [,xml]
 ----
-<addresses>
+<core>
    ...
-   <address name="$sys.mqtt.sessions">
-      <anycast>
-         <queue name="$sys.mqtt.sessions" enabled="false"/>
-      </anycast>
-   </address>
+   <mqtt-subscription-persistence-enabled>false</mqtt-subscription-persistence-enabled>
    ...
-</addresses>
+</core>
 ----
 
-The setting `mqtt-session-state-persistence-timeout` controls how long the broker will wait for the data to be written to storage before throwing an error.
-It is measured in milliseconds.
-The default is `5000`.
+The default is `true`.
+
+[NOTE]
+====
+Even if `mqtt-subscription-persistence-enabled` is `false` the broker will still keep track of QoS 1 & 2 messages.
+The _only_ impact of disabling MQTT subscription persistence is that clients will have to resend `SUBSCRIBE` packets as necessary in order to continue receiving messages after reconnecting after the server is restarted.
+====
 
 == Custom Client ID Handling
 


### PR DESCRIPTION
This commit refactors how the broker persists MQTT subscription data since the current implementation was resulting in timeout issues and might eventually lead to thread starvation due to a blocking call.

Since the code that might lead to timeouts was removed the associated configuration property was deprecated.

Previously, disabling subscription persistence involved disabling the underlying queue. This commit also adds a new configuration parameter to disable subscription persistence is a more elegant way and updates the documentation accordingly.