### PR TITLE
NO-JIRA enable squash+merge on GitHub

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -35,8 +35,11 @@ github:
     - java
     - jms
   enabled_merge_buttons:
-    # disable squash button:
-    squash:  false
+    # enable squash button:
+    squash: true
+    # default commit message when merging with a squash commit
+    # can be: DEFAULT | PR_TITLE | PR_TITLE_AND_COMMIT_DETAILS | PR_TITLE_AND_DESC
+    squash_commit_message: PR_TITLE_AND_DESC
     # disable merge button:
     merge:   false
     # enable rebase button:


### PR DESCRIPTION
Currently we usually ask PR authors to squash their commits before we merge. However, it's possible for GitHub to automate this which would speed up the merging process and reduce busy-work for PR authors.

Furthermore, incremental commits throughout the review process can be useful as previous comments are preserved in context and changes are more clear.