### PR TITLE
ARTEMIS-5121 drop regex for MQTT sub ID matching

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
@@ -55,38 +55,24 @@ public class Match<T> {
    public Match(final String match, final T value, final WildcardConfiguration wildcardConfiguration, final boolean literal) {
       this.match = match;
       this.value = value;
-      pattern = createPattern(match, wildcardConfiguration, false);
-      this.literal = literal;
-   }
-
-   /**
-    * @param direct setting true is useful for use-cases where you just want to know whether a message sent to a
-    *               particular address would match the pattern
-    */
-   public static Pattern createPattern(final String match, final WildcardConfiguration wildcardConfiguration, boolean direct) {
       String actMatch = match;
 
       if (wildcardConfiguration.getAnyWordsString().equals(match)) {
          // replace any regex characters
          actMatch = Match.WILDCARD_REPLACEMENT;
       } else {
-         if (!direct) {
-            // this is to match with what's documented
-            actMatch = actMatch.replace(wildcardConfiguration.getDelimiterString() + wildcardConfiguration.getAnyWordsString(), wildcardConfiguration.getAnyWordsString());
-         }
+         // this is to match with what's documented
+         actMatch = actMatch.replace(wildcardConfiguration.getDelimiterString() + wildcardConfiguration.getAnyWordsString(), wildcardConfiguration.getAnyWordsString());
          actMatch = actMatch.replace(Match.DOT, Match.DOT_REPLACEMENT);
          actMatch = actMatch.replace(Match.DOLLAR, Match.DOLLAR_REPLACEMENT);
          actMatch = actMatch.replace(wildcardConfiguration.getSingleWordString(), String.format(WORD_WILDCARD_REPLACEMENT_FORMAT, Pattern.quote(wildcardConfiguration.getDelimiterString())));
 
-         if (direct) {
-            actMatch = actMatch.replace(wildcardConfiguration.getAnyWordsString(), WILDCARD_REPLACEMENT);
-         } else {
-            // this one has to be done by last as we are using .* and it could be replaced wrongly if delimiter is '.'
-            actMatch = actMatch.replace(wildcardConfiguration.getAnyWordsString(), String.format(WILDCARD_CHILD_REPLACEMENT_FORMAT, Pattern.quote(wildcardConfiguration.getDelimiterString())));
-         }
+         // this one has to be done by last as we are using .* and it could be replaced wrongly if delimiter is '.'
+         actMatch = actMatch.replace(wildcardConfiguration.getAnyWordsString(), String.format(WILDCARD_CHILD_REPLACEMENT_FORMAT, Pattern.quote(wildcardConfiguration.getDelimiterString())));
       }
       // we need to anchor with eot to ensure we have a full match
-      return Pattern.compile(actMatch + "$");
+      pattern = Pattern.compile(actMatch + "$");
+      this.literal = literal;
    }
 
    public final String getMatch() {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/impl/MatchTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/settings/impl/MatchTest.java
@@ -17,14 +17,13 @@
 
 package org.apache.activemq.artemis.core.settings.impl;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.util.function.Predicate;
-import java.util.regex.Pattern;
 
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class MatchTest {
 
@@ -55,49 +54,9 @@ public class MatchTest {
    }
 
    @Test
-   public void patterDirectAnyChild() {
-
-      final Pattern pattern = Match.createPattern("test.#", new WildcardConfiguration(), true);
-      final Predicate<String> predicate = pattern.asPredicate();
-
-      assertTrue(predicate.test("test.A"));
-      assertTrue(predicate.test("test.A.B"));
-
-      assertFalse(predicate.test("testing.A"));
-      // see: org.apache.activemq.artemis.tests.integration.mqtt5.spec.controlpackets.PublishTests#testSubscriptionIdentifierMultiLevel
-      assertFalse(predicate.test("test"));
-   }
-
-   @Test
-   public void patterDirectAnyWord() {
-
-      final Pattern pattern = Match.createPattern("test.*", new WildcardConfiguration(), true);
-      final Predicate<String> predicate = pattern.asPredicate();
-
-      // no change with direct = true|false
-      assertTrue(predicate.test("test.A"));
-
-      assertFalse(predicate.test("testing.A"));
-      assertFalse(predicate.test("test"));
-      assertFalse(predicate.test("test.A.B"));
-   }
-
-   @Test
-   public void testDollarMatchingDirectTrue() {
-      final Pattern pattern = Match.createPattern("$test.#", new WildcardConfiguration(), true);
-      final Predicate<String> predicate = pattern.asPredicate();
-
-      assertTrue(predicate.test("$test.A"));
-      assertTrue(predicate.test("$test.A.B"));
-
-      assertFalse(predicate.test("$testing.A"));
-      assertFalse(predicate.test("$test"));
-   }
-
-   @Test
-   public void testDollarMatchingDirectFalse() {
-      final Pattern pattern = Match.createPattern("$test.#", new WildcardConfiguration(), false);
-      final Predicate<String> predicate = pattern.asPredicate();
+   public void testDollarMatching() {
+      final Match<?> underTest = new Match<>("$test.#", null, new WildcardConfiguration());
+      final Predicate<String> predicate = underTest.getPattern().asPredicate();
 
       assertTrue(predicate.test("$test"));
       assertTrue(predicate.test("$test.A"));


### PR DESCRIPTION
This commit replaces the matching logic for MQTT subscription IDs which uses regular expression for a bit of pre-existing logic that I didn't know about when this functionality was first implemented.

This saves the expense of generating an instance of `java.util.regex.Pattern` and uses basic `SimpleString` or `char` comparisons which are optimized for the wildcard address use-case.

This also removes the `createPattern` method from `o.a.a.a.c.s.i.Match` since the only code using that method has now also been removed. Related tests have also been removed.