### PR TITLE
ARTEMIS-5534 use Objects.requireNonNullElse() where sensible

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfClientCommand.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/messages/perf/PerfClientCommand.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.cli.commands.messages.perf;
 import javax.jms.ConnectionFactory;
 import javax.jms.Destination;
 import java.util.Collections;
+import java.util.Objects;
 import java.util.Queue;
 import java.util.concurrent.Executor;
 import java.util.concurrent.LinkedTransferQueue;
@@ -95,8 +96,8 @@ public class PerfClientCommand extends PerfCommand {
 
    @Override
    protected void onExecuteBenchmark(final ConnectionFactory producerConnectionFactory, final Destination[] jmsDestinations, final ActionContext context) throws Exception {
-      final ConnectionProtocol listenerProtocol = this.consumerProtocol != null ? this.consumerProtocol : protocol;
-      final String listenerUrl = this.consumerUrl != null ? this.consumerUrl : brokerURL;
+      final ConnectionProtocol listenerProtocol = Objects.requireNonNullElse(this.consumerProtocol, protocol);
+      final String listenerUrl = Objects.requireNonNullElse(this.consumerUrl, brokerURL);
       final ConnectionFactory consumerConnectionFactory = createConnectionFactory(listenerUrl, user, password, null, listenerProtocol);
       if (consumerConnections == 0) {
          if (sharedSubscription > 0) {

--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/PrintData.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -305,7 +306,7 @@ public class PrintData extends DBOption {
                            out.print("pg=" + pgid + ", msg=" + msgID + ",pgTX=" + msg.getTransactionID() + ", msg=" + msg.getMessage().getClass().getSimpleName() + "(safe data)");
                         }
                      } else {
-                        out.print("pg=" + pgid + ", msg=" + msgID + ",pgTX=" + msg.getTransactionID() + ",userMessageID=" + (msg.getMessage().getUserID() != null ? msg.getMessage().getUserID() : "") + ", msg=" + msg.getMessage());
+                        out.print("pg=" + pgid + ", msg=" + msgID + ",pgTX=" + msg.getTransactionID() + ",userMessageID=" + Objects.requireNonNullElse(msg.getMessage().getUserID(), "") + ", msg=" + msg.getMessage());
                      }
                      out.print(",Queues = ");
                      long[] q = msg.getQueueIDs();

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
@@ -336,7 +336,7 @@ public class QueueConfiguration implements Serializable {
     * {@return the name of the address; if the address is {@code null} then return the value of {@link #getName()}}
     */
    public SimpleString getAddress() {
-      return address == null ? getName() : address;
+      return Objects.requireNonNullElse(address, getName());
    }
 
    public boolean isAddressNull() {
@@ -445,7 +445,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code true}
     */
    public Boolean isDurable() {
-      return durable == null ? true : durable;
+      return Objects.requireNonNullElse(durable, true);
    }
 
    public QueueConfiguration setDurable(Boolean durable) {
@@ -641,7 +641,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code false}
     */
    public Boolean isConfigurationManaged() {
-      return configurationManaged == null ? false : configurationManaged;
+      return Objects.requireNonNullElse(configurationManaged, false);
    }
 
    public QueueConfiguration setConfigurationManaged(Boolean configurationManaged) {
@@ -653,7 +653,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code false}
     */
    public Boolean isTemporary() {
-      return temporary == null ? false : temporary;
+      return Objects.requireNonNullElse(temporary, false);
    }
 
    public QueueConfiguration setTemporary(Boolean temporary) {
@@ -674,7 +674,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code false}
     */
    public Boolean isInternal() {
-      return internal == null ? false : internal;
+      return Objects.requireNonNullElse(internal, false);
    }
 
    public QueueConfiguration setInternal(Boolean internal) {
@@ -686,7 +686,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code false}
     */
    public Boolean isTransient() {
-      return _transient == null ? false : _transient;
+      return Objects.requireNonNullElse(_transient, false);
    }
 
    public QueueConfiguration setTransient(Boolean _transient) {
@@ -698,7 +698,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code false}
     */
    public Boolean isAutoCreated() {
-      return autoCreated == null ? false : autoCreated;
+      return Objects.requireNonNullElse(autoCreated, false);
    }
 
    public QueueConfiguration setAutoCreated(Boolean autoCreated) {
@@ -712,7 +712,7 @@ public class QueueConfiguration implements Serializable {
     * defaults to {@code false}
     */
    public Boolean isFqqn() {
-      return fqqn == null ? Boolean.FALSE : fqqn;
+      return Objects.requireNonNullElse(fqqn, Boolean.FALSE);
    }
 
    /**

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/logs/AuditLogger.java
@@ -29,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 /**
@@ -86,7 +87,7 @@ public interface AuditLogger {
       String user = "anonymous";
       String roles = "";
       List<String> principalRoles = new ArrayList<>();
-      String url = remoteAddress == null ? (AuditLogger.remoteAddress.get() == null ? "@unknown" : AuditLogger.remoteAddress.get()) : formatRemoteAddress(remoteAddress);
+      String url = remoteAddress == null ? Objects.requireNonNullElse(AuditLogger.remoteAddress.get(), "@unknown") : formatRemoteAddress(remoteAddress);
       if (subject != null) {
          Set<Principal> principals = subject.getPrincipals();
          for (Principal principal : principals) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ICoreMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/ICoreMessage.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.api.core;
 
 import java.io.InputStream;
 import java.util.Map;
+import java.util.Objects;
 
 import io.netty.buffer.ByteBuf;
 import org.apache.activemq.artemis.core.message.LargeBodyReader;
@@ -106,7 +107,7 @@ public interface ICoreMessage extends Message {
          map.put("userID", "ID:" + userID.toString());
       }
 
-      map.put("address", getAddress() == null ? "" : getAddress());
+      map.put("address", Objects.requireNonNullElse(getAddress(), ""));
       map.put("type", getType());
       map.put("durable", isDurable());
       map.put("expiration", getExpiration());

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/Message.java
@@ -21,6 +21,7 @@ import javax.management.openmbean.OpenDataException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
 
@@ -824,7 +825,7 @@ public interface Message {
          map.put("userID", "ID:" + userID.toString());
       }
 
-      map.put("address", getAddress() == null ? "" : getAddress());
+      map.put("address", Objects.requireNonNullElse(getAddress(), ""));
       map.put("durable", isDurable());
       map.put("expiration", getExpiration());
       map.put("timestamp", getTimestamp());

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientMessageImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientMessageImpl.java
@@ -20,6 +20,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQPropertyConversionException;
@@ -178,7 +179,7 @@ public class ClientMessageImpl extends CoreMessage implements ClientMessageInter
 
    @Override
    public String toString() {
-      return getClass().getSimpleName() + "[messageID=" + messageID + ", durable=" + durable + ", address=" + getAddress() + ",userID=" + (getUserID() != null ? getUserID() : "null") + ",properties=" + getProperties().toString() + "]";
+      return getClass().getSimpleName() + "[messageID=" + messageID + ", durable=" + durable + ", address=" + getAddress() + ",userID=" + Objects.requireNonNullElse(getUserID(), "null") + ", properties=" + getProperties().toString() + "]";
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -336,7 +336,7 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
                              final TransportConfiguration[] transportConfigs) {
       traceException.fillInStackTrace();
 
-      this.topology = topology == null ? new Topology(this) : topology;
+      this.topology = Objects.requireNonNullElseGet(topology, () -> new Topology(this));
 
       this.ha = useHA;
 
@@ -1585,12 +1585,12 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       if (identity != null) {
          return "ServerLocatorImpl (identity=" + identity +
             ") [initialConnectors=" +
-            Arrays.toString(initialConnectors == null ? new TransportConfiguration[0] : initialConnectors) +
+            Arrays.toString(Objects.requireNonNullElseGet(initialConnectors, () -> new TransportConfiguration[0])) +
             ", discoveryGroupConfiguration=" +
             discoveryGroupConfiguration +
             "]";
       }
-      return "ServerLocatorImpl [initialConnectors=" + Arrays.toString(initialConnectors == null ? new TransportConfiguration[0] : initialConnectors) +
+      return "ServerLocatorImpl [initialConnectors=" + Arrays.toString(Objects.requireNonNullElseGet(initialConnectors, () -> new TransportConfiguration[0])) +
          ", discoveryGroupConfiguration=" +
          discoveryGroupConfiguration +
          "]";

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/openmbean/MessageOpenTypeFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/message/openmbean/MessageOpenTypeFactory.java
@@ -36,6 +36,7 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 public class MessageOpenTypeFactory<M extends Message> {
 
@@ -132,7 +133,7 @@ public class MessageOpenTypeFactory<M extends Message> {
       } else {
          rc.put(CompositeDataConstants.USER_ID, "");
       }
-      rc.put(CompositeDataConstants.ADDRESS, m.getAddress() == null ? "" : m.getAddress());
+      rc.put(CompositeDataConstants.ADDRESS, Objects.requireNonNullElse(m.getAddress(), ""));
       rc.put(CompositeDataConstants.DURABLE, m.isDurable());
       rc.put(CompositeDataConstants.EXPIRATION, m.getExpiration());
       rc.put(CompositeDataConstants.TIMESTAMP, m.getTimestamp());

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQSessionContext.java
@@ -25,6 +25,7 @@ import java.security.PrivilegedAction;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
@@ -999,8 +1000,7 @@ public class ActiveMQSessionContext extends SessionContext {
    @Override
    public int getDefaultConsumerWindowSize(SessionQueueQueryResponseMessage response) throws ActiveMQException {
       if (response instanceof SessionQueueQueryResponseMessage_V3 v3) {
-         final Integer defaultConsumerWindowSize = v3.getDefaultConsumerWindowSize();
-         return defaultConsumerWindowSize != null ? defaultConsumerWindowSize : ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
+         return Objects.requireNonNullElse(v3.getDefaultConsumerWindowSize(), ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE);
       } else {
          return ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/TransportConfigurationUtil.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/TransportConfigurationUtil.java
@@ -20,6 +20,7 @@ import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.TransportConfigurationHelper;
@@ -86,8 +87,8 @@ public class TransportConfigurationUtil {
       if (NettyConnectorFactory.class.getName().equals(tc1.getFactoryClassName())) {
          String host1 = tc1.getParams().get("host") != null ? tc1.getParams().get("host").toString() : TransportConstants.DEFAULT_HOST;
          String host2 = tc2.getParams().get("host") != null ? tc2.getParams().get("host").toString() : TransportConstants.DEFAULT_HOST;
-         String port1 = String.valueOf(tc1.getParams().get("port") != null ? tc1.getParams().get("port") : TransportConstants.DEFAULT_PORT);
-         String port2 = String.valueOf(tc2.getParams().get("port") != null ? tc2.getParams().get("port") : TransportConstants.DEFAULT_PORT);
+         String port1 = String.valueOf(Objects.requireNonNullElse(tc1.getParams().get("port"), TransportConstants.DEFAULT_PORT));
+         String port2 = String.valueOf(Objects.requireNonNullElse(tc2.getParams().get("port"), TransportConstants.DEFAULT_PORT));
          return host1.equals(host2) && port1.equals(port2);
       } else if ("org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory".equals(tc1.getFactoryClassName())) {
          String serverId1 = tc1.getParams().get("serverId") != null ? tc1.getParams().get("serverId").toString() : "0";

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQSession.java
@@ -1055,8 +1055,8 @@ public class ActiveMQSession implements QueueSession, TopicSession {
    }
 
    private ClientConsumer createClientConsumer(ActiveMQDestination destination, SimpleString queueName, SimpleString coreFilterString) throws ActiveMQException {
-      QueueAttributes queueAttributes = destination.getQueueAttributes() == null ? new QueueAttributes() : destination.getQueueAttributes();
-      int priority = queueAttributes.getConsumerPriority() == null ? ActiveMQDefaultConfiguration.getDefaultConsumerPriority() : queueAttributes.getConsumerPriority();
+      QueueAttributes queueAttributes = Objects.requireNonNullElseGet(destination.getQueueAttributes(), () -> new QueueAttributes());
+      int priority = Objects.requireNonNullElse(queueAttributes.getConsumerPriority(), ActiveMQDefaultConfiguration.getDefaultConsumerPriority());
       return session.createConsumer(queueName == null ? destination.getSimpleAddress() : queueName, coreFilterString, priority, false);
    }
 
@@ -1418,19 +1418,19 @@ public class ActiveMQSession implements QueueSession, TopicSession {
    }
 
    void createTemporaryQueue(ActiveMQDestination destination, RoutingType routingType, SimpleString queueName, SimpleString filter, ClientSession.AddressQuery addressQuery) throws ActiveMQException {
-      QueueConfiguration queueConfiguration = destination.getQueueConfiguration() == null ? QueueConfiguration.of(queueName) : destination.getQueueConfiguration();
+      QueueConfiguration queueConfiguration = Objects.requireNonNullElse(destination.getQueueConfiguration(), QueueConfiguration.of(queueName));
       AutoCreateUtil.setRequiredQueueConfigurationIfNotSet(queueConfiguration, addressQuery, routingType, filter, false);
       session.createQueue(queueConfiguration.setName(queueName).setAddress(destination.getAddress()).setDurable(false).setTemporary(true));
    }
 
    void createSharedQueue(ActiveMQDestination destination, RoutingType routingType, SimpleString queueName, SimpleString filter, boolean durable, ClientSession.AddressQuery addressQuery) throws ActiveMQException {
-      QueueConfiguration queueConfiguration = destination.getQueueConfiguration() == null ? QueueConfiguration.of(queueName) : destination.getQueueConfiguration();
+      QueueConfiguration queueConfiguration = Objects.requireNonNullElseGet(destination.getQueueConfiguration(), () -> QueueConfiguration.of(queueName));
       AutoCreateUtil.setRequiredQueueConfigurationIfNotSet(queueConfiguration, addressQuery, routingType, filter, durable);
       session.createSharedQueue(queueConfiguration.setName(queueName).setAddress(destination.getAddress()).setDurable(durable));
    }
 
    void createQueue(ActiveMQDestination destination, RoutingType routingType, SimpleString queueName, SimpleString filter, boolean durable, boolean autoCreated, ClientSession.AddressQuery addressQuery) throws ActiveMQException {
-      QueueConfiguration queueConfiguration = destination.getQueueConfiguration() == null ? QueueConfiguration.of(queueName) : destination.getQueueConfiguration();
+      QueueConfiguration queueConfiguration = Objects.requireNonNullElseGet(destination.getQueueConfiguration(), () -> QueueConfiguration.of(queueName));
       AutoCreateUtil.setRequiredQueueConfigurationIfNotSet(queueConfiguration, addressQuery, routingType, filter, durable);
       session.createQueue(queueConfiguration.setName(queueName).setAddress(destination.getAddress()).setAutoCreated(autoCreated).setDurable(durable));
    }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnectionManager.java
@@ -20,6 +20,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Function;
@@ -103,8 +104,7 @@ public class AMQPBrokerConnectionManager implements ActiveMQComponent, ClientCon
     * @param configurations A list of broker connection configurations after a broker configuration update.
     */
    public void updateConfiguration(List<AMQPBrokerConnectConfiguration> configurations) throws Exception {
-      final List<AMQPBrokerConnectConfiguration> updatedConfigurations =
-         configurations != null ? configurations : Collections.emptyList();
+      final List<AMQPBrokerConnectConfiguration> updatedConfigurations = Objects.requireNonNullElse(configurations, Collections.emptyList());
 
       // We want to shutdown all broker connections before starting any new ones just to ensure
       // we do not have any overlapping connections to the same broker from old to new configurations.

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeAddressPolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeAddressPolicy.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -62,8 +63,8 @@ public final class AMQPBridgeAddressPolicy extends AMQPBridgePolicy implements B
       this.includeDivertBindings = includeDivertBindings;
       this.useDurableSubscriptions = useDurableSubscriptions;
 
-      this.includes = Collections.unmodifiableCollection(includeAddresses == null ? Collections.emptyList() : includeAddresses);
-      this.excludes = Collections.unmodifiableCollection(excludeAddresses == null ? Collections.emptyList() : excludeAddresses);
+      this.includes = Collections.unmodifiableCollection(Objects.requireNonNullElse(includeAddresses, Collections.emptyList()));
+      this.excludes = Collections.unmodifiableCollection(Objects.requireNonNullElse(excludeAddresses, Collections.emptyList()));
 
       // Create Matchers from configured includes and excludes for use when matching broker resources
       includes.forEach((address) -> includesMatchers.add(new AddressMatcher(address, wildcardConfig)));

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeQueuePolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeQueuePolicy.java
@@ -20,6 +20,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.LinkedHashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.BiPredicate;
 import java.util.function.Predicate;
@@ -52,8 +53,8 @@ public final class AMQPBridgeQueuePolicy extends AMQPBridgePolicy implements BiP
 
       this.priorityAdjustment = priorityAdjustment;
 
-      this.includes = Collections.unmodifiableCollection(includeQueues == null ? Collections.emptyList() : includeQueues);
-      this.excludes = Collections.unmodifiableCollection(excludeQueues == null ? Collections.emptyList() : excludeQueues);
+      this.includes = Collections.unmodifiableCollection(Objects.requireNonNullElse(includeQueues, Collections.emptyList()));
+      this.excludes = Collections.unmodifiableCollection(Objects.requireNonNullElse(excludeQueues, Collections.emptyList()));
 
       // Create Matchers from configured includes and excludes for use when matching broker resources
       includes.forEach((entry) -> includeMatchers.add(new QueueMatcher(entry.getKey(), entry.getValue(), wildcardConfig)));

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCapabilities.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationCapabilities.java
@@ -21,6 +21,7 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.engine.Link;
@@ -50,8 +51,8 @@ public final class AMQPFederationCapabilities {
       if (!initialized) {
          initialized = true;
 
-         final Map<Symbol, Object> localProperties = controlLink.getProperties() != null ? controlLink.getProperties() : Collections.emptyMap();
-         final Map<Symbol, Object> remoteProperties = controlLink.getRemoteProperties() != null ? controlLink.getRemoteProperties() : Collections.emptyMap();
+         final Map<Symbol, Object> localProperties = Objects.requireNonNullElseGet(controlLink.getProperties(), () -> Collections.emptyMap());
+         final Map<Symbol, Object> remoteProperties = Objects.requireNonNullElseGet(controlLink.getRemoteProperties(), () -> Collections.emptyMap());
 
          final Object local = localProperties.getOrDefault(FEDERATION_VERSION, FEDERATION_V1);
          final Object remote = remoteProperties.getOrDefault(FEDERATION_VERSION, FEDERATION_V1);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationPolicySupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationPolicySupport.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -474,11 +475,11 @@ public final class AMQPFederationPolicySupport {
 
       final FederationReceiveFromAddressPolicy policy = new FederationReceiveFromAddressPolicy(
          element.getName(),
-         element.getAutoDelete() == null ? false : element.getAutoDelete(),
-         element.getAutoDeleteDelay() == null ? 0 : element.getAutoDeleteDelay(),
-         element.getAutoDeleteMessageCount() == null ? 0 : element.getAutoDeleteMessageCount(),
+         Objects.requireNonNullElse(element.getAutoDelete(), false),
+         Objects.requireNonNullElse(element.getAutoDeleteDelay(), 0L),
+         Objects.requireNonNullElse(element.getAutoDeleteMessageCount(), 0L),
          element.getMaxHops(),
-         element.isEnableDivertBindings() == null ? false : element.isEnableDivertBindings(),
+         Objects.requireNonNullElse(element.isEnableDivertBindings(), false),
          includes,
          excludes,
          element.getProperties(),
@@ -526,7 +527,7 @@ public final class AMQPFederationPolicySupport {
       final FederationReceiveFromQueuePolicy policy = new FederationReceiveFromQueuePolicy(
          element.getName(),
          element.isIncludeFederated(),
-         element.getPriorityAdjustment() == null ? DEFAULT_QUEUE_RECEIVER_PRIORITY_ADJUSTMENT : element.getPriorityAdjustment(),
+         Objects.requireNonNullElse(element.getPriorityAdjustment(), DEFAULT_QUEUE_RECEIVER_PRIORITY_ADJUSTMENT),
          includes,
          excludes,
          element.getProperties(),

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromAddressPolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromAddressPolicy.java
@@ -70,8 +70,8 @@ public class FederationReceiveFromAddressPolicy implements FederationReceiveFrom
       this.maxHops = maxHops;
       this.enableDivertBindings = enableDivertBindings;
       this.transformerConfig = transformerConfig;
-      this.includes = Collections.unmodifiableCollection(includeAddresses == null ? Collections.emptyList() : includeAddresses);
-      this.excludes = Collections.unmodifiableCollection(excludeAddresses == null ? Collections.emptyList() : excludeAddresses);
+      this.includes = Collections.unmodifiableCollection(Objects.requireNonNullElse(includeAddresses, Collections.emptyList()));
+      this.excludes = Collections.unmodifiableCollection(Objects.requireNonNullElse(excludeAddresses, Collections.emptyList()));
 
       if (properties == null || properties.isEmpty()) {
          this.properties = Collections.emptyMap();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromQueuePolicy.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/federation/FederationReceiveFromQueuePolicy.java
@@ -61,8 +61,8 @@ public class FederationReceiveFromQueuePolicy implements FederationReceiveFromRe
       this.includeFederated = includeFederated;
       this.priorityAdjustment = priorotyAdjustment;
       this.transformerConfig = transformerConfig;
-      this.includes = Collections.unmodifiableCollection(includeQueues == null ? Collections.emptyList() : includeQueues);
-      this.excludes = Collections.unmodifiableCollection(excludeQueues == null ? Collections.emptyList() : excludeQueues);
+      this.includes = Collections.unmodifiableCollection(Objects.requireNonNullElse(includeQueues, Collections.emptyList()));
+      this.excludes = Collections.unmodifiableCollection(Objects.requireNonNullElse(excludeQueues, Collections.emptyList()));
 
       if (properties == null || properties.isEmpty()) {
          this.properties = Collections.emptyMap();

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContext.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
@@ -672,7 +673,7 @@ public class AMQPConnectionContext extends ProtonInitializable implements EventH
          } catch (ActiveMQSecurityException e) {
             ErrorCondition error = new ErrorCondition();
             error.setCondition(AmqpError.UNAUTHORIZED_ACCESS);
-            error.setDescription(e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+            error.setDescription(Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()));
             connection.setCondition(error);
             connection.setProperties(Collections.singletonMap(AmqpSupport.CONNECTION_OPEN_FAILED, true));
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPSessionContext.java
@@ -23,6 +23,7 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.BiFunction;
@@ -436,8 +437,7 @@ public class AMQPSessionContext extends ProtonInitializable {
                   "Unexpected federation instance found on connection when creating control link processor");
             }
 
-            final Map<Symbol, Object> receiverProperties =
-               receiver.getRemoteProperties() != null ? receiver.getRemoteProperties() : Collections.emptyMap();
+            final Map<Symbol, Object> receiverProperties = Objects.requireNonNullElseGet(receiver.getRemoteProperties(), () -> Collections.emptyMap());
             final Map<String, Object> federationConfigurationMap =
                (Map<String, Object>) receiverProperties.getOrDefault(FEDERATION_CONFIGURATION, Collections.emptyMap());
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
@@ -285,13 +285,10 @@ public class AmqpSupport {
     * @return {@code true} if the desired capabilities were found in the offered set
     */
    public static boolean verifyCapabilities(final Symbol[] offered, final Symbol... desired) {
-      final Symbol[] desiredCapabilites = desired == null ? EMPTY_CAPABILITIES : desired;
-      final Symbol[] offeredCapabilites = offered == null ? EMPTY_CAPABILITIES : offered;
-
-      for (Symbol desiredCapability : desiredCapabilites) {
+      for (Symbol desiredCapability : Objects.requireNonNullElse(desired, EMPTY_CAPABILITIES)) {
          boolean foundCurrent = false;
 
-         for (Symbol offeredCapability : offeredCapabilites) {
+         for (Symbol offeredCapability : Objects.requireNonNullElse(offered, EMPTY_CAPABILITIES)) {
             if (desiredCapability.equals(offeredCapability)) {
                foundCurrent = true;
                break;

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/DefaultSenderController.java
@@ -284,8 +284,7 @@ public class DefaultSenderController implements SenderController {
             // Set this to the broker configured default for the address prior to the lookup so that
             // an auto create will actually use the configured defaults.  The actual query result will
             // contain the true answer on what routing type the address actually has though.
-            final RoutingType routingType = sessionSPI.getDefaultRoutingType(addressToUse);
-            routingTypeToUse = routingType == null ? ActiveMQDefaultConfiguration.getDefaultRoutingType() : routingType;
+            routingTypeToUse = Objects.requireNonNullElse(sessionSPI.getDefaultRoutingType(addressToUse), ActiveMQDefaultConfiguration.getDefaultRoutingType());
 
             try {
                addressQueryResult = sessionSPI.addressQuery(addressToUse, routingTypeToUse, true);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContext.java
@@ -20,6 +20,7 @@ import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -262,8 +263,7 @@ public class ProtonServerReceiverContext extends ProtonAbstractReceiver {
    }
 
    private static RoutingType getDefaultRoutingType(AMQPSessionCallback sessionSPI, SimpleString address) {
-      RoutingType defaultRoutingType = sessionSPI.getRoutingTypeFromPrefix(address, sessionSPI.getDefaultRoutingType(address));
-      return defaultRoutingType == null ? ActiveMQDefaultConfiguration.getDefaultRoutingType() : defaultRoutingType;
+      return Objects.requireNonNullElse(sessionSPI.getRoutingTypeFromPrefix(address, sessionSPI.getDefaultRoutingType(address)), ActiveMQDefaultConfiguration.getDefaultRoutingType());
    }
 
    private static DeliveryState determineDeliveryState(final Source source, final boolean useModified, final Exception e) {

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
@@ -584,14 +585,14 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
                   logger.warn(e.getMessage(), e);
                   ErrorCondition error = new ErrorCondition();
                   error.setCondition(AmqpError.UNAUTHORIZED_ACCESS);
-                  error.setDescription(e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage());
+                  error.setDescription(Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName()));
                   connection.setCondition(error);
                   connection.close();
                } catch (Exception e) {
                   logger.warn(e.getMessage(), e);
                   ErrorCondition error = new ErrorCondition();
                   error.setCondition(AmqpError.INTERNAL_ERROR);
-                  error.setDescription("Unrecoverable error: " + (e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
+                  error.setDescription("Unrecoverable error: " + (Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName())));
                   connection.setCondition(error);
                   connection.close();
                }
@@ -622,7 +623,7 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
       logger.warn(e.getMessage(), e);
       ErrorCondition error = new ErrorCondition();
       error.setCondition(AmqpError.INTERNAL_ERROR);
-      error.setDescription("Unrecoverable error: " + (e.getMessage() == null ? e.getClass().getSimpleName() : e.getMessage()));
+      error.setDescription("Unrecoverable error: " + (Objects.requireNonNullElse(e.getMessage(), e.getClass().getSimpleName())));
       connection.setCondition(error);
       connection.close();
       flush();

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnection.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnection.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.protocol.mqtt;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Future;
 import java.util.concurrent.FutureTask;
 
@@ -113,7 +114,7 @@ public class MQTTConnection extends AbstractRemotingConnection {
 
    @Override
    public String getProtocolName() {
-      return MQTTProtocolManagerFactory.MQTT_PROTOCOL_NAME + (protocolVersion != null ? protocolVersion : "");
+      return MQTTProtocolManagerFactory.MQTT_PROTOCOL_NAME + Objects.requireNonNullElse(protocolVersion, "");
    }
 
    public int getReceiveMaximum() {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTPublishManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTPublishManager.java
@@ -51,6 +51,7 @@ import org.apache.activemq.artemis.utils.UUIDGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 import static io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType.CONTENT_TYPE;
 import static io.netty.handler.codec.mqtt.MqttProperties.MqttPropertyType.CORRELATION_DATA;
@@ -389,7 +390,7 @@ public class MQTTPublishManager {
    }
 
    private boolean publishToClient(int messageId, ICoreMessage message, int deliveryCount, int qos, long consumerId) throws Exception {
-      String topic = MQTTUtil.getMqttTopicFromCoreAddress(message.getAddress() == null ? "" : message.getAddress(), session.getWildcardConfiguration());
+      String topic = MQTTUtil.getMqttTopicFromCoreAddress(Objects.requireNonNullElse(message.getAddress(), ""), session.getWildcardConfiguration());
 
       ByteBuf payload;
       switch (message.getType()) {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSubscriptionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSubscriptionManager.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 
@@ -222,7 +223,7 @@ public class MQTTSubscriptionManager {
    }
 
    private void createConsumerForSubscriptionQueue(Queue queue, String topicFilter, int qos, boolean noLocal, Long existingConsumerId) throws Exception {
-      long cid = existingConsumerId != null ? existingConsumerId : session.getServer().getStorageManager().generateID();
+      long cid = Objects.requireNonNullElseGet(existingConsumerId, () -> session.getServer().getStorageManager().generateID());
 
       // for noLocal support we use the MQTT *client id* rather than the connection ID, but we still use the existing property name
       ServerConsumer consumer = session.getServerSession().createConsumer(cid, queue.getName(), noLocal ? SimpleString.of(CONNECTION_ID_PROPERTY_NAME_STRING + " <> '" + session.getState().getClientId() + "'") : null, false, false, -1);

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -1935,7 +1936,7 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
             message.append("OUT >> ");
          }
 
-         message.append((command == null ? "NULL" : command));
+         message.append((Objects.requireNonNullElse(command, "NULL")));
 
          logger.trace(message.toString());
       }

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompConnection.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.StringTokenizer;
 import java.util.concurrent.Future;
@@ -176,7 +177,7 @@ public final class StompConnection extends AbstractRemotingConnection {
          SimpleString simpleDestination = SimpleString.of(destination);
          AddressInfo addressInfo = manager.getServer().getAddressInfo(simpleDestination);
          AddressSettings addressSettings = manager.getServer().getAddressSettingsRepository().getMatch(destination);
-         RoutingType effectiveAddressRoutingType = routingType == null ? addressSettings.getDefaultAddressRoutingType() : routingType;
+         RoutingType effectiveAddressRoutingType = Objects.requireNonNullElse(routingType, addressSettings.getDefaultAddressRoutingType());
          ServerSession session = getSession().getCoreSession();
          /*
           * If the address doesn't exist then it is created if possible.

--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/StompUtils.java
@@ -21,6 +21,7 @@ import static org.apache.activemq.artemis.api.core.Message.HDR_SCHEDULED_DELIVER
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.activemq.artemis.api.core.Message;
@@ -105,7 +106,7 @@ public class StompUtils {
                                                             StompFrame command,
                                                             int deliveryCount) {
       SimpleString prefix = message.getSimpleStringProperty(Message.HDR_PREFIX);
-      command.addHeader(Stomp.Headers.Message.DESTINATION,  (prefix == null ? "" : prefix) + message.getAddress());
+      command.addHeader(Stomp.Headers.Message.DESTINATION, Objects.requireNonNullElse(prefix, "") + message.getAddress());
 
       if (message.getObjectProperty(MessageUtil.CORRELATIONID_HEADER_NAME) != null) {
          command.addHeader(Stomp.Headers.Message.CORRELATION_ID, message.getObjectProperty(MessageUtil.CORRELATIONID_HEADER_NAME).toString());

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
@@ -23,6 +23,7 @@ import org.apache.activemq.artemis.jms.client.ConnectionFactoryOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
 
@@ -731,7 +732,7 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
    }
 
    public boolean isEnableSharedClientID() {
-      return enableSharedClientID != null ? enableSharedClientID : false;
+      return Objects.requireNonNullElse(enableSharedClientID, false);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.config;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -159,7 +160,7 @@ public class CoreQueueConfiguration implements Serializable {
          .setAddress(queueConfiguration.getAddress() != null ? queueConfiguration.getAddress().toString() : null)
          .setName(queueConfiguration.getName() != null ? queueConfiguration.getName().toString() : null)
          .setFilterString(queueConfiguration.getFilterString() != null ? queueConfiguration.getFilterString().toString() : null)
-         .setDurable(queueConfiguration.isDurable() != null ? queueConfiguration.isDurable() : true)
+         .setDurable(Objects.requireNonNullElse(queueConfiguration.isDurable(), true))
          .setUser(queueConfiguration.getUser() != null ? queueConfiguration.getUser().toString() : null)
          .setExclusive(queueConfiguration.isExclusive())
          .setGroupRebalance(queueConfiguration.isGroupRebalance())
@@ -171,10 +172,10 @@ public class CoreQueueConfiguration implements Serializable {
          .setMaxConsumers(queueConfiguration.getMaxConsumers())
          .setConsumersBeforeDispatch(queueConfiguration.getConsumersBeforeDispatch())
          .setDelayBeforeDispatch(queueConfiguration.getDelayBeforeDispatch())
-         .setRingSize(queueConfiguration.getRingSize() != null ? queueConfiguration.getRingSize() : ActiveMQDefaultConfiguration.getDefaultRingSize())
-         .setEnabled(queueConfiguration.isEnabled() != null ? queueConfiguration.isEnabled() : ActiveMQDefaultConfiguration.getDefaultEnabled())
-         .setPurgeOnNoConsumers(queueConfiguration.isPurgeOnNoConsumers() != null ? queueConfiguration.isPurgeOnNoConsumers() : ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers())
-         .setRoutingType(queueConfiguration.getRoutingType() != null ? queueConfiguration.getRoutingType() : ActiveMQDefaultConfiguration.getDefaultRoutingType());
+         .setRingSize(Objects.requireNonNullElse(queueConfiguration.getRingSize(), ActiveMQDefaultConfiguration.getDefaultRingSize()))
+         .setEnabled(Objects.requireNonNullElse(queueConfiguration.isEnabled(), ActiveMQDefaultConfiguration.getDefaultEnabled()))
+         .setPurgeOnNoConsumers(Objects.requireNonNullElse(queueConfiguration.isPurgeOnNoConsumers(), ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers()))
+         .setRoutingType(Objects.requireNonNullElse(queueConfiguration.getRoutingType(), ActiveMQDefaultConfiguration.getDefaultRoutingType()));
    }
 
    public CoreQueueConfiguration setAddress(final String address) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -54,6 +54,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Properties;
 import java.util.Set;
 import java.util.Stack;
@@ -2804,7 +2805,7 @@ public class ConfigurationImpl implements Configuration, Serializable {
          TransportConfiguration connector = getConnectorConfigurations().get(connectorName);
 
          if (connector == null) {
-            ActiveMQServerLogger.LOGGER.connectionConfigurationIsNull(connectorName == null ? "null" : connectorName);
+            ActiveMQServerLogger.LOGGER.connectionConfigurationIsNull(Objects.requireNonNullElse(connectorName, "null"));
             return null;
          }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/ActiveMQServerControlImpl.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.concurrent.CountDownLatch;
@@ -363,7 +364,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       clearIO();
       try {
          return configuration.getBrokerPlugins().stream()
-            .map(brokerPlugin -> brokerPlugin.getClass().getCanonicalName() != null ? brokerPlugin.getClass().getCanonicalName() : brokerPlugin.getClass().getName())
+            .map(brokerPlugin -> Objects.requireNonNullElse(brokerPlugin.getClass().getCanonicalName(), brokerPlugin.getClass().getName()))
             .toArray(String[]::new);
       } finally {
          blockOnIO();
@@ -3504,8 +3505,8 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
       }
 
       AddressSettings addressSettings = new AddressSettings();
-      addressSettings.setDeadLetterAddress(DLA == null ? null : SimpleString.of(DLA));
-      addressSettings.setExpiryAddress(expiryAddress == null ? null : SimpleString.of(expiryAddress));
+      addressSettings.setDeadLetterAddress(SimpleString.of(DLA));
+      addressSettings.setExpiryAddress(SimpleString.of(expiryAddress));
       addressSettings.setExpiryDelay(expiryDelay);
       addressSettings.setMinExpiryDelay(minExpiryDelay);
       addressSettings.setMaxExpiryDelay(maxExpiryDelay);
@@ -3617,7 +3618,7 @@ public class ActiveMQServerControlImpl extends AbstractControl implements Active
 
       clearIO();
       try {
-         postOffice.sendQueueInfoToQueue(SimpleString.of(queueName), SimpleString.of(address == null ? "" : address));
+         postOffice.sendQueueInfoToQueue(SimpleString.of(queueName), SimpleString.of(Objects.requireNonNullElse(address, "")));
 
          GroupingHandler handler = server.getGroupingHandler();
          if (handler != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/QueueControlImpl.java
@@ -67,6 +67,7 @@ import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 public class QueueControlImpl extends AbstractControl implements QueueControl {
 
@@ -1049,8 +1050,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
          AuditLogger.countMessages(queue, filterStr);
       }
 
-      Long value = internalCountMessages(filterStr, null).get(null);
-      return value == null ? 0 : value;
+      return Objects.requireNonNullElse(internalCountMessages(filterStr, null).get(null), 0L);
    }
 
    @Override
@@ -1117,8 +1117,7 @@ public class QueueControlImpl extends AbstractControl implements QueueControl {
          AuditLogger.countDeliveringMessages(queue, filterStr);
       }
 
-      Long value = internalCountDeliveryMessages(filterStr, null).get(null);
-      return value == null ? 0 : value;
+      return Objects.requireNonNullElse(internalCountDeliveryMessages(filterStr, null).get(null), 0L);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConnectionView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConnectionView.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.management.impl.view;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.TreeSet;
 
@@ -52,8 +53,7 @@ public class ConnectionView extends ActiveMQAbstractView<RemotingConnection> {
       List<ServerSession> sessions = server.getSessions(connection.getID().toString());
       Set<String> users = new TreeSet<>();
       for (ServerSession session : sessions) {
-         String username = session.getUsername() == null ? "" : session.getUsername();
-         users.add(username);
+         users.add(Objects.requireNonNullElse(session.getUsername(), ""));
       }
 
       return JsonLoader.createObjectBuilder()
@@ -81,8 +81,7 @@ public class ConnectionView extends ActiveMQAbstractView<RemotingConnection> {
             Set<String> users = new TreeSet<>();
             List<ServerSession> sessions = server.getSessions(connection.getID().toString());
             for (ServerSession session : sessions) {
-               String username = session.getUsername() == null ? "" : session.getUsername();
-               users.add(username);
+               users.add(Objects.requireNonNullElse(session.getUsername(), ""));
             }
             return StringUtil.joinStringList(users, ",");
          case CREATION_TIME:

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ProducerView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ProducerView.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.management.impl.view;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.core.management.impl.view.predicate.ProducerFilterPredicate;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ServerProducer;
@@ -57,7 +59,7 @@ public class ProducerView extends ActiveMQAbstractView<ServerProducer> {
          .add(ProducerField.USER.getName(), toString(session.getUsername()))
          .add(ProducerField.VALIDATED_USER.getName(), toString(session.getValidatedUser()))
          .add(ProducerField.PROTOCOL.getName(), toString(session.getRemotingConnection().getProtocolName()))
-         .add(ProducerField.ADDRESS.getName(), toString(producer.getAddress() != null ? producer.getAddress() : session.getDefaultAddress()))
+         .add(ProducerField.ADDRESS.getName(), toString(Objects.requireNonNullElse(producer.getAddress(), session.getDefaultAddress())))
          .add(ProducerField.LOCAL_ADDRESS.getName(), toString(session.getRemotingConnection().getTransportConnection().getLocalAddress()))
          .add(ProducerField.REMOTE_ADDRESS.getName(), toString(session.getRemotingConnection().getTransportConnection().getRemoteAddress()))
          .add(ProducerField.CREATION_TIME.getName(), toString(producer.getCreationTime()))
@@ -85,7 +87,7 @@ public class ProducerView extends ActiveMQAbstractView<ServerProducer> {
          case VALIDATED_USER -> session.getValidatedUser();
          case CLIENT_ID -> session.getRemotingConnection().getClientID();
          case PROTOCOL -> session.getRemotingConnection().getProtocolName();
-         case ADDRESS -> producer.getAddress() != null ? producer.getAddress() : session.getDefaultAddress();
+         case ADDRESS -> Objects.requireNonNullElse(producer.getAddress(), session.getDefaultAddress());
          case LOCAL_ADDRESS -> session.getRemotingConnection().getTransportConnection().getLocalAddress();
          case REMOTE_ADDRESS -> session.getRemotingConnection().getTransportConnection().getRemoteAddress();
          case CREATION_TIME -> producer.getCreationTime();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/SessionView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/SessionView.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.management.impl.view;
 
 import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import java.util.Date;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.core.management.impl.view.predicate.SessionFilterPredicate;
 import org.apache.activemq.artemis.core.server.ServerSession;
@@ -47,7 +48,7 @@ public class SessionView extends ActiveMQAbstractView<ServerSession> {
          .add(SessionField.CONSUMER_COUNT.getName(), session.getConsumerCount())
          .add(SessionField.PRODUCER_COUNT.getName(), session.getProducerCount())
          .add(SessionField.CONNECTION_ID.getName(), session.getConnectionID().toString())
-         .add(SessionField.CLIENT_ID.getName(), session.getRemotingConnection().getClientID() != null ? session.getRemotingConnection().getClientID() : "");
+         .add(SessionField.CLIENT_ID.getName(), Objects.requireNonNullElse(session.getRemotingConnection().getClientID(), ""));
       return obj;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ConnectionFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ConnectionFilterPredicate.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.management.impl.view.predicate;
 
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.function.Function;
 
@@ -60,7 +61,7 @@ public class ConnectionFilterPredicate extends ActiveMQFilterPredicate<RemotingC
       Set<String> sessionAttributes = new HashSet<>();
       for (ServerSession session : sessions) {
          String value = getter.apply(session);
-         String string = value == null ? "" : value;
+         String string = Objects.requireNonNullElse(value, "");
          sessionAttributes.add(string);
       }
       return sessionAttributes;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -25,6 +25,7 @@ import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -1768,7 +1769,7 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
          ConcurrentMap<String, PersistedKeyValuePair> newMap = new ConcurrentHashMap<>();
          Map<String, PersistedKeyValuePair> existingMap = mapPersistedKeyValuePairs.putIfAbsent(keyValuePair.getMapId(), newMap);
 
-         persistedKeyValuePairs = existingMap == null ? newMap : existingMap;
+         persistedKeyValuePairs = Objects.requireNonNullElse(existingMap, newMap);
       }
 
       persistedKeyValuePairs.put(keyValuePair.getKey(), keyValuePair);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -797,7 +797,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
             }
             final SimpleString empty = SimpleString.of("");
             Filter oldFilter = FilterImpl.createFilter(queue.getFilter() == null ? empty : queue.getFilter().getFilterString());
-            Filter newFilter = FilterImpl.createFilter(queueConfiguration.getFilterString() == null ? empty : queueConfiguration.getFilterString());
+            Filter newFilter = FilterImpl.createFilter(Objects.requireNonNullElse(queueConfiguration.getFilterString(), empty));
             if ((forceUpdate || newFilter != oldFilter) && !Objects.equals(oldFilter, newFilter)) {
                changed = true;
                queue.setFilter(newFilter);
@@ -1455,8 +1455,7 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    }
 
    private int resolveIdCacheSize(SimpleString address) {
-      final AddressSettings addressSettings = addressSettingsRepository.getMatch(address.toString());
-      return addressSettings.getIDCacheSize() == null ? idCacheSize : addressSettings.getIDCacheSize();
+      return Objects.requireNonNullElse(addressSettingsRepository.getMatch(address.toString()).getIDCacheSize(), idCacheSize);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -22,6 +22,7 @@ import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -101,7 +102,7 @@ public class SimpleAddressManager implements AddressManager {
          throw ActiveMQMessageBundle.BUNDLE.bindingAlreadyExists(binding);
       }
       directBindingMap.compute(binding.getAddress(), (key, value) -> {
-         Collection<Binding> bindingList = value == null ? new ArrayList<>() : value;
+         Collection<Binding> bindingList = Objects.requireNonNullElseGet(value, () -> new ArrayList<>());
          bindingList.add(binding);
          return bindingList;
       });

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/impl/SecurityStoreImpl.java
@@ -23,6 +23,7 @@ import java.security.AccessControlContext;
 import java.security.AccessController;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
@@ -395,7 +396,7 @@ public class SecurityStoreImpl implements SecurityStore, HierarchicalRepositoryC
             set = new ConcurrentHashSet<>();
             putAuthorizationCacheEntry(set, key);
          }
-         set.add(fqqn != null ? fqqn : bareAddress);
+         set.add(Objects.requireNonNullElse(fqqn, bareAddress));
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.server;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -373,7 +375,7 @@ public final class QueueConfig {
    }
 
    public static QueueConfig fromQueueConfiguration(QueueConfiguration queueConfiguration) throws ActiveMQException {
-      return new QueueConfig(queueConfiguration.getId() == null ? 0 : queueConfiguration.getId(),
+      return new QueueConfig(Objects.requireNonNullElse(queueConfiguration.getId(), 0L),
                              queueConfiguration.getAddress(),
                              queueConfiguration.getName(),
                              queueConfiguration.getFilterString() == null ? null : FilterImpl.createFilter(queueConfiguration.getFilterString()),

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/cluster/ClusterManager.java
@@ -25,6 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
@@ -616,7 +617,7 @@ public class ClusterManager implements ActiveMQComponent {
             logger.debug("{} Starting a Discovery Group Cluster Connection, name={}, dg={}", this, config.getDiscoveryGroupName(), dg);
          }
 
-         clusterConnection = new ClusterConnectionImpl(this, dg, connector, SimpleString.of(config.getName()), SimpleString.of(config.getAddress() != null ? config.getAddress() : ""), config.getMinLargeMessageSize(), config.getClientFailureCheckPeriod(), config.getConnectionTTL(), config.getRetryInterval(), config.getRetryIntervalMultiplier(), config.getMaxRetryInterval(), config.getInitialConnectAttempts(), config.getReconnectAttempts(), config.getCallTimeout(), config.getCallFailoverTimeout(), config.isDuplicateDetection(), config.getMessageLoadBalancingType(), config.getConfirmationWindowSize(), config.getProducerWindowSize(), executorFactory, server, postOffice, managementService, scheduledExecutor, config.getMaxHops(), nodeManager, server.getConfiguration().getClusterUser(), server.getConfiguration().getClusterPassword(), config.isAllowDirectConnectionsOnly(), config.getClusterNotificationInterval(), config.getClusterNotificationAttempts(), config.getClientId(), config.getTopologyScannerAttempts());
+         clusterConnection = new ClusterConnectionImpl(this, dg, connector, SimpleString.of(config.getName()), SimpleString.of(Objects.requireNonNullElse(config.getAddress(), "")), config.getMinLargeMessageSize(), config.getClientFailureCheckPeriod(), config.getConnectionTTL(), config.getRetryInterval(), config.getRetryIntervalMultiplier(), config.getMaxRetryInterval(), config.getInitialConnectAttempts(), config.getReconnectAttempts(), config.getCallTimeout(), config.getCallFailoverTimeout(), config.isDuplicateDetection(), config.getMessageLoadBalancingType(), config.getConfirmationWindowSize(), config.getProducerWindowSize(), executorFactory, server, postOffice, managementService, scheduledExecutor, config.getMaxHops(), nodeManager, server.getConfiguration().getClusterUser(), server.getConfiguration().getClusterPassword(), config.isAllowDirectConnectionsOnly(), config.getClusterNotificationInterval(), config.getClusterNotificationAttempts(), config.getClientId(), config.getTopologyScannerAttempts());
 
          clusterController.addClusterConnection(clusterConnection.getName(), dg, config, connector);
       } else {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/AbstractFederationStream.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/AbstractFederationStream.java
@@ -50,7 +50,7 @@ public abstract class AbstractFederationStream implements FederationStream {
       Objects.requireNonNull(config.getName());
       this.name = SimpleString.of(config.getName());
       this.config = config;
-      this.connection = connection != null ? connection : new FederationConnection(server.getConfiguration(), name, config.getConnectionConfiguration());
+      this.connection = Objects.requireNonNullElseGet(connection, () -> new FederationConnection(server.getConfiguration(), name, config.getConnectionConfiguration()));
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/FederatedAbstract.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/FederatedAbstract.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.server.federation;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
@@ -43,7 +44,7 @@ public abstract class FederatedAbstract implements ActiveMQServerBasePlugin {
       this.federation = federation;
       this.server = server;
       this.upstream = upstream;
-      this.wildcardConfiguration = server.getConfiguration().getWildcardConfiguration() == null ? DEFAULT_WILDCARD_CONFIGURATION : server.getConfiguration().getWildcardConfiguration();
+      this.wildcardConfiguration = Objects.requireNonNullElse(server.getConfiguration().getWildcardConfiguration(), DEFAULT_WILDCARD_CONFIGURATION);
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/address/FederatedAddress.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/address/FederatedAddress.java
@@ -295,9 +295,9 @@ public class FederatedAddress extends FederatedAbstract implements ActiveMQServe
                                       .setRoutingType(key.getRoutingType())
                                       .setFilterString(key.getQueueFilterString())
                                       .setDurable(true)
-                                      .setAutoDelete(config.getAutoDelete() == null ? true : config.getAutoDelete())
-                                      .setAutoDeleteDelay(config.getAutoDeleteDelay() == null ? TimeUnit.HOURS.toMillis(1) : config.getAutoDeleteDelay())
-                                      .setAutoDeleteMessageCount(config.getAutoDeleteMessageCount() == null ? -1 : config.getAutoDeleteMessageCount())
+                                      .setAutoDelete(Objects.requireNonNullElse(config.getAutoDelete(), true))
+                                      .setAutoDeleteDelay(Objects.requireNonNullElse(config.getAutoDeleteDelay(), TimeUnit.HOURS.toMillis(1)))
+                                      .setAutoDeleteMessageCount(Objects.requireNonNullElse(config.getAutoDeleteMessageCount(), -1L))
                                       .setMaxConsumers(-1)
                                       .setPurgeOnNoConsumers(false)
                                       .setAutoCreated(false));

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/queue/FederatedQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/queue/FederatedQueue.java
@@ -62,7 +62,7 @@ public class FederatedQueue extends FederatedAbstract implements ActiveMQServerC
       super(federation, server, federationUpstream);
       Objects.requireNonNull(config.getName());
       this.config = config;
-      this.priorityAdjustment = federationUpstream.getPriorityAdjustment() + (config.getPriorityAdjustment() == null ? -1 : config.getPriorityAdjustment());
+      this.priorityAdjustment = federationUpstream.getPriorityAdjustment() + Objects.requireNonNullElse(config.getPriorityAdjustment(), -1);
       String metaDataFilterString = config.isIncludeFederated() ? null : "hyphenated_props:" + FederatedQueueConsumer.FEDERATION_NAME +  " IS NOT NULL";
       metaDataFilter = FilterImpl.createFilter(metaDataFilterString);
       if (config.getIncludes().isEmpty()) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -39,6 +39,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
@@ -513,7 +514,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
       this.parentServer = parentServer;
 
-      this.serviceRegistry = serviceRegistry == null ? new ServiceRegistryImpl() : serviceRegistry;
+      this.serviceRegistry = Objects.requireNonNullElseGet(serviceRegistry, () -> new ServiceRegistryImpl());
 
       this.serverStatus = ServerStatus.starting(this);
    }
@@ -789,7 +790,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             activationThread = new ActivationThread(activation, ActiveMQMessageBundle.BUNDLE.activationForServer(this));
             activationThread.start();
          } else {
-            ActiveMQServerLogger.LOGGER.serverStarted(getVersion().getFullVersion(), configuration.getName(), nodeManager.getNodeId(), identity != null ? identity : "");
+            ActiveMQServerLogger.LOGGER.serverStarted(getVersion().getFullVersion(), configuration.getName(), nodeManager.getNodeId(), Objects.requireNonNullElse(identity, ""));
          }
          // start connector service
          connectorsService = new ConnectorsService(configuration, storageManager, scheduledPool, postOffice, serviceRegistry);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/AddressInfo.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.json.JsonValue;
 import java.io.StringReader;
 import java.util.EnumSet;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicLongFieldUpdater;
 
 import org.apache.activemq.artemis.api.core.RoutingType;
@@ -152,7 +153,7 @@ public class AddressInfo {
    }
 
    public EnumSet<RoutingType> getRoutingTypes() {
-      return routingTypes == null ? createEmptySet() : routingTypes;
+      return Objects.requireNonNullElseGet(routingTypes, () -> createEmptySet());
    }
 
    public AddressInfo setRoutingTypes(final EnumSet<RoutingType> routingTypes) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -28,6 +28,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Executor;
@@ -915,20 +916,20 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
       if (exclusive == null || groupRebalance == null || groupBuckets == null || groupFirstKey == null || lastValue == null || lastValueKey == null || nonDestructive == null || consumersBeforeDispatch == null || delayBeforeDispatch == null || autoDelete == null || autoDeleteDelay == null || autoDeleteMessageCount == null || ringSize == null) {
          AddressSettings as = server.getAddressSettingsRepository().getMatch(address.toString());
          return createQueue(new AddressInfo(address, routingType), name, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers,
-                 exclusive == null ? as.isDefaultExclusiveQueue() : exclusive,
-                 groupRebalance == null ? as.isDefaultGroupRebalance() : groupRebalance,
-                 groupBuckets == null ? as.getDefaultGroupBuckets() : groupBuckets,
-                 groupFirstKey == null ? as.getDefaultGroupFirstKey() : groupFirstKey,
-                 lastValue == null ? as.isDefaultLastValueQueue() : lastValue,
-                 lastValueKey == null ? as.getDefaultLastValueKey() : lastValueKey,
-                 nonDestructive == null ? as.isDefaultNonDestructive() : nonDestructive,
-                 consumersBeforeDispatch == null ? as.getDefaultConsumersBeforeDispatch() : consumersBeforeDispatch,
-                 delayBeforeDispatch == null ? as.getDefaultDelayBeforeDispatch() : delayBeforeDispatch,
-                 autoDelete == null ? ActiveMQServerImpl.isAutoDelete(autoCreated, as) : autoDelete,
-                 autoDeleteDelay == null ? as.getAutoDeleteQueuesDelay() : autoDeleteDelay,
-                 autoDeleteMessageCount == null ? as.getAutoDeleteQueuesMessageCount() : autoDeleteMessageCount,
+                 Objects.requireNonNullElse(exclusive, as.isDefaultExclusiveQueue()),
+                 Objects.requireNonNullElse(groupRebalance, as.isDefaultGroupRebalance()),
+                 Objects.requireNonNullElse(groupBuckets, as.getDefaultGroupBuckets()),
+                 Objects.requireNonNullElse(groupFirstKey, as.getDefaultGroupFirstKey()),
+                 Objects.requireNonNullElse(lastValue, as.isDefaultLastValueQueue()),
+                 Objects.requireNonNullElse(lastValueKey, as.getDefaultLastValueKey()),
+                 Objects.requireNonNullElse(nonDestructive, as.isDefaultNonDestructive()),
+                 Objects.requireNonNullElse(consumersBeforeDispatch, as.getDefaultConsumersBeforeDispatch()),
+                 Objects.requireNonNullElse(delayBeforeDispatch, as.getDefaultDelayBeforeDispatch()),
+                 Objects.requireNonNullElse(autoDelete, ActiveMQServerImpl.isAutoDelete(autoCreated, as)),
+                 Objects.requireNonNullElse(autoDeleteDelay, as.getAutoDeleteQueuesDelay()),
+                 Objects.requireNonNullElse(autoDeleteMessageCount, as.getAutoDeleteQueuesMessageCount()),
                  autoCreated,
-                 ringSize == null ? as.getDefaultRingSize() : ringSize);
+                 Objects.requireNonNullElse(ringSize, as.getDefaultRingSize()));
       } else {
          return createQueue(new AddressInfo(address, routingType), name, filterString, temporary, durable, maxConsumers, purgeOnNoConsumers,
                  exclusive, groupRebalance, groupBuckets, groupFirstKey, lastValue, lastValueKey, nonDestructive, consumersBeforeDispatch, delayBeforeDispatch, autoDelete, autoDeleteDelay, autoDeleteMessageCount, autoCreated, ringSize);
@@ -2517,7 +2518,7 @@ public class ServerSessionImpl implements ServerSession, FailureListener {
 
    @Override
    public void addProducer(String name, String protocol, String address) {
-      ServerProducer producer = new ServerProducerImpl(name, protocol, address != null ? address : ServerProducer.ANONYMOUS);
+      ServerProducer producer = new ServerProducerImpl(name, protocol, Objects.requireNonNullElse(address, ServerProducer.ANONYMOUS));
       producer.setSessionID(getName());
       producer.setConnectionID(getConnectionID() != null ? getConnectionID().toString() : null);
       serverProducers.put(name, producer);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -961,8 +961,7 @@ public class ManagementServiceImpl implements ManagementService {
          // CoreMessage#getUserId returns UUID, so to implement this part a alternative API that returned object. This part of the
          // change is a nice to have for my point of view. I suggested it for completeness.  The application could
          // always supply unique correl ids on the request and achieve the same effect.  I'd be happy to drop this part.
-         Object underlying = request.getStringProperty(NATIVE_MESSAGE_ID) != null ? request.getStringProperty(NATIVE_MESSAGE_ID) : request.getUserID();
-         correlationId = underlying == null ? null : String.valueOf(underlying);
+         correlationId = String.valueOf(request.getStringProperty(NATIVE_MESSAGE_ID) != null ? request.getStringProperty(NATIVE_MESSAGE_ID) : request.getUserID());
       }
 
       return correlationId;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/LoggingActiveMQServerPlugin.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/plugin/impl/LoggingActiveMQServerPlugin.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.server.plugin.impl;
 
 import java.io.Serializable;
+import java.lang.invoke.MethodHandles;
 import java.util.Map;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -44,7 +45,6 @@ import org.apache.activemq.artemis.spi.core.protocol.SessionCallback;
 import org.apache.activemq.artemis.utils.critical.CriticalComponent;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 /**
  * plugin to log various events within the broker, configured with the following booleans:
@@ -536,7 +536,7 @@ public class LoggingActiveMQServerPlugin implements ActiveMQServerPlugin, Serial
          Queue queue = (ref == null ? null : ref.getQueue());
 
          LoggingActiveMQServerPluginLogger.LOGGER.messageAcknowledgedDetails((message == null ? UNAVAILABLE : Long.toString(message.getMessageID())),
-                                                                             (consumer == null ? UNAVAILABLE : consumer.getSessionID() != null ? consumer.getSessionID() : null),
+                                                                             (consumer == null ? UNAVAILABLE : consumer.getSessionID()),
                                                                              (consumer == null ? UNAVAILABLE : Long.toString(consumer.getID())),
                                                                              (queue == null ? UNAVAILABLE : queue.getName().toString()),
                                                                              (tx == null ? UNAVAILABLE : tx.toString()),

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouter.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/routing/ConnectionRouter.java
@@ -29,6 +29,7 @@ import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 public class ConnectionRouter implements ActiveMQComponent {
@@ -230,6 +231,6 @@ public class ConnectionRouter implements ActiveMQComponent {
          }
       }
 
-      return result != null ? result : TargetResult.REFUSED_UNAVAILABLE_RESULT;
+      return Objects.requireNonNullElse(result, TargetResult.REFUSED_UNAVAILABLE_RESULT);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -560,7 +560,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoCreateJmsQueues() {
-      return autoCreateJmsQueues != null ? autoCreateJmsQueues : AddressSettings.DEFAULT_AUTO_CREATE_JMS_QUEUES;
+      return Objects.requireNonNullElse(autoCreateJmsQueues, AddressSettings.DEFAULT_AUTO_CREATE_JMS_QUEUES);
    }
 
    public String toJSON() {
@@ -581,7 +581,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoDeleteJmsQueues() {
-      return autoDeleteJmsQueues != null ? autoDeleteJmsQueues : AddressSettings.DEFAULT_AUTO_DELETE_JMS_QUEUES;
+      return Objects.requireNonNullElse(autoDeleteJmsQueues, AddressSettings.DEFAULT_AUTO_DELETE_JMS_QUEUES);
    }
 
    @Deprecated
@@ -592,7 +592,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoCreateJmsTopics() {
-      return autoCreateJmsTopics != null ? autoCreateJmsTopics : AddressSettings.DEFAULT_AUTO_CREATE_TOPICS;
+      return Objects.requireNonNullElse(autoCreateJmsTopics, AddressSettings.DEFAULT_AUTO_CREATE_TOPICS);
    }
 
    @Deprecated
@@ -603,7 +603,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public boolean isAutoDeleteJmsTopics() {
-      return autoDeleteJmsTopics != null ? autoDeleteJmsTopics : AddressSettings.DEFAULT_AUTO_DELETE_TOPICS;
+      return Objects.requireNonNullElse(autoDeleteJmsTopics, AddressSettings.DEFAULT_AUTO_DELETE_TOPICS);
    }
 
    @Deprecated
@@ -613,7 +613,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isAutoCreateQueues() {
-      return autoCreateQueues != null ? autoCreateQueues : AddressSettings.DEFAULT_AUTO_CREATE_QUEUES;
+      return Objects.requireNonNullElse(autoCreateQueues, AddressSettings.DEFAULT_AUTO_CREATE_QUEUES);
    }
 
    public AddressSettings setAutoCreateQueues(Boolean autoCreateQueues) {
@@ -622,7 +622,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isAutoDeleteQueues() {
-      return autoDeleteQueues != null ? autoDeleteQueues : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES;
+      return Objects.requireNonNullElse(autoDeleteQueues, AddressSettings.DEFAULT_AUTO_DELETE_QUEUES);
    }
 
    public AddressSettings setAutoDeleteQueues(Boolean autoDeleteQueues) {
@@ -636,12 +636,12 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isAutoDeleteCreatedQueues() {
-      return autoDeleteCreatedQueues != null ? autoDeleteCreatedQueues : AddressSettings.DEFAULT_AUTO_DELETE_CREATED_QUEUES;
+      return Objects.requireNonNullElse(autoDeleteCreatedQueues, AddressSettings.DEFAULT_AUTO_DELETE_CREATED_QUEUES);
    }
 
 
    public long getAutoDeleteQueuesDelay() {
-      return autoDeleteQueuesDelay != null ? autoDeleteQueuesDelay : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_DELAY;
+      return Objects.requireNonNullElse(autoDeleteQueuesDelay, AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_DELAY);
    }
 
    public AddressSettings setAutoDeleteQueuesDelay(final long autoDeleteQueuesDelay) {
@@ -650,7 +650,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean getAutoDeleteQueuesSkipUsageCheck() {
-      return autoDeleteQueuesSkipUsageCheck != null ? autoDeleteQueuesSkipUsageCheck : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_SKIP_USAGE_CHECK;
+      return Objects.requireNonNullElse(autoDeleteQueuesSkipUsageCheck, AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_SKIP_USAGE_CHECK);
    }
 
    public AddressSettings setAutoDeleteQueuesSkipUsageCheck(final boolean autoDeleteQueuesSkipUsageCheck) {
@@ -659,7 +659,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getAutoDeleteQueuesMessageCount() {
-      return autoDeleteQueuesMessageCount != null ? autoDeleteQueuesMessageCount : AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_MESSAGE_COUNT;
+      return Objects.requireNonNullElse(autoDeleteQueuesMessageCount, AddressSettings.DEFAULT_AUTO_DELETE_QUEUES_MESSAGE_COUNT);
    }
 
    public AddressSettings setAutoDeleteQueuesMessageCount(final long autoDeleteQueuesMessageCount) {
@@ -668,7 +668,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public DeletionPolicy getConfigDeleteQueues() {
-      return configDeleteQueues != null ? configDeleteQueues : AddressSettings.DEFAULT_CONFIG_DELETE_QUEUES;
+      return Objects.requireNonNullElse(configDeleteQueues, AddressSettings.DEFAULT_CONFIG_DELETE_QUEUES);
    }
 
    public AddressSettings setConfigDeleteQueues(DeletionPolicy configDeleteQueues) {
@@ -677,7 +677,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isAutoCreateAddresses() {
-      return autoCreateAddresses != null ? autoCreateAddresses : AddressSettings.DEFAULT_AUTO_CREATE_ADDRESSES;
+      return Objects.requireNonNullElse(autoCreateAddresses, AddressSettings.DEFAULT_AUTO_CREATE_ADDRESSES);
    }
 
    public AddressSettings setAutoCreateAddresses(Boolean autoCreateAddresses) {
@@ -686,7 +686,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isAutoDeleteAddresses() {
-      return autoDeleteAddresses != null ? autoDeleteAddresses : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES;
+      return Objects.requireNonNullElse(autoDeleteAddresses, AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES);
    }
 
    public AddressSettings setAutoDeleteAddresses(Boolean autoDeleteAddresses) {
@@ -695,7 +695,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getAutoDeleteAddressesDelay() {
-      return autoDeleteAddressesDelay != null ? autoDeleteAddressesDelay : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES_DELAY;
+      return Objects.requireNonNullElse(autoDeleteAddressesDelay, AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES_DELAY);
    }
 
    public AddressSettings setAutoDeleteAddressesDelay(final long autoDeleteAddressesDelay) {
@@ -704,7 +704,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoDeleteAddressesSkipUsageCheck() {
-      return autoDeleteAddressesSkipUsageCheck != null ? autoDeleteAddressesSkipUsageCheck : AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES_SKIP_USAGE_CHECK;
+      return Objects.requireNonNullElse(autoDeleteAddressesSkipUsageCheck, AddressSettings.DEFAULT_AUTO_DELETE_ADDRESSES_SKIP_USAGE_CHECK);
    }
 
    public AddressSettings setAutoDeleteAddressesSkipUsageCheck(final boolean autoDeleteAddressesSkipUsageCheck) {
@@ -713,7 +713,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public DeletionPolicy getConfigDeleteAddresses() {
-      return configDeleteAddresses != null ? configDeleteAddresses : AddressSettings.DEFAULT_CONFIG_DELETE_ADDRESSES;
+      return Objects.requireNonNullElse(configDeleteAddresses, AddressSettings.DEFAULT_CONFIG_DELETE_ADDRESSES);
    }
 
    public AddressSettings setConfigDeleteAddresses(DeletionPolicy configDeleteAddresses) {
@@ -727,11 +727,11 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public DeletionPolicy getConfigDeleteDiverts() {
-      return configDeleteDiverts != null ? configDeleteDiverts : AddressSettings.DEFAULT_CONFIG_DELETE_DIVERTS;
+      return Objects.requireNonNullElse(configDeleteDiverts, AddressSettings.DEFAULT_CONFIG_DELETE_DIVERTS);
    }
 
    public Integer getDefaultMaxConsumers() {
-      return defaultMaxConsumers != null ? defaultMaxConsumers : ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers();
+      return Objects.requireNonNullElse(defaultMaxConsumers, ActiveMQDefaultConfiguration.getDefaultMaxQueueConsumers());
    }
 
    public AddressSettings setDefaultMaxConsumers(Integer defaultMaxConsumers) {
@@ -740,7 +740,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Integer getDefaultConsumersBeforeDispatch() {
-      return defaultConsumersBeforeDispatch != null ? defaultConsumersBeforeDispatch : ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch();
+      return Objects.requireNonNullElse(defaultConsumersBeforeDispatch, ActiveMQDefaultConfiguration.getDefaultConsumersBeforeDispatch());
    }
 
    public AddressSettings setDefaultConsumersBeforeDispatch(Integer defaultConsumersBeforeDispatch) {
@@ -749,7 +749,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Long getDefaultDelayBeforeDispatch() {
-      return defaultDelayBeforeDispatch != null ? defaultDelayBeforeDispatch : ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch();
+      return Objects.requireNonNullElse(defaultDelayBeforeDispatch, ActiveMQDefaultConfiguration.getDefaultDelayBeforeDispatch());
    }
 
    public AddressSettings setDefaultDelayBeforeDispatch(Long defaultDelayBeforeDispatch) {
@@ -758,7 +758,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isDefaultPurgeOnNoConsumers() {
-      return defaultPurgeOnNoConsumers != null ? defaultPurgeOnNoConsumers : ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers();
+      return Objects.requireNonNullElse(defaultPurgeOnNoConsumers, ActiveMQDefaultConfiguration.getDefaultPurgeOnNoConsumers());
    }
 
    public AddressSettings setDefaultPurgeOnNoConsumers(Boolean defaultPurgeOnNoConsumers) {
@@ -767,7 +767,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public RoutingType getDefaultQueueRoutingType() {
-      return defaultQueueRoutingType != null ? defaultQueueRoutingType : ActiveMQDefaultConfiguration.getDefaultRoutingType();
+      return Objects.requireNonNullElse(defaultQueueRoutingType, ActiveMQDefaultConfiguration.getDefaultRoutingType());
    }
 
    public AddressSettings setDefaultQueueRoutingType(RoutingType defaultQueueRoutingType) {
@@ -776,7 +776,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public RoutingType getDefaultAddressRoutingType() {
-      return defaultAddressRoutingType != null ? defaultAddressRoutingType : ActiveMQDefaultConfiguration.getDefaultRoutingType();
+      return Objects.requireNonNullElse(defaultAddressRoutingType, ActiveMQDefaultConfiguration.getDefaultRoutingType());
    }
 
    public AddressSettings setDefaultAddressRoutingType(RoutingType defaultAddressRoutingType) {
@@ -785,7 +785,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultLastValueQueue() {
-      return defaultLastValueQueue != null ? defaultLastValueQueue : AddressSettings.DEFAULT_LAST_VALUE_QUEUE;
+      return Objects.requireNonNullElse(defaultLastValueQueue, AddressSettings.DEFAULT_LAST_VALUE_QUEUE);
    }
 
    public AddressSettings setDefaultLastValueQueue(final boolean defaultLastValueQueue) {
@@ -803,7 +803,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultNonDestructive() {
-      return defaultNonDestructive != null ? defaultNonDestructive : ActiveMQDefaultConfiguration.getDefaultNonDestructive();
+      return Objects.requireNonNullElse(defaultNonDestructive, ActiveMQDefaultConfiguration.getDefaultNonDestructive());
    }
 
    public AddressSettings setDefaultNonDestructive(final boolean defaultNonDestructive) {
@@ -812,7 +812,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isDefaultExclusiveQueue() {
-      return defaultExclusiveQueue != null ? defaultExclusiveQueue : ActiveMQDefaultConfiguration.getDefaultExclusive();
+      return Objects.requireNonNullElse(defaultExclusiveQueue, ActiveMQDefaultConfiguration.getDefaultExclusive());
    }
 
    public AddressSettings setDefaultExclusiveQueue(Boolean defaultExclusiveQueue) {
@@ -821,7 +821,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public AddressFullMessagePolicy getAddressFullMessagePolicy() {
-      return addressFullMessagePolicy != null ? addressFullMessagePolicy : AddressSettings.DEFAULT_ADDRESS_FULL_MESSAGE_POLICY;
+      return Objects.requireNonNullElse(addressFullMessagePolicy, AddressSettings.DEFAULT_ADDRESS_FULL_MESSAGE_POLICY);
    }
 
    public AddressSettings setAddressFullMessagePolicy(final AddressFullMessagePolicy addressFullMessagePolicy) {
@@ -830,7 +830,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getPageSizeBytes() {
-      return pageSizeBytes != null ? pageSizeBytes : AddressSettings.DEFAULT_PAGE_SIZE;
+      return Objects.requireNonNullElse(pageSizeBytes, AddressSettings.DEFAULT_PAGE_SIZE);
    }
 
    public AddressSettings setPageSizeBytes(final int pageSize) {
@@ -839,7 +839,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getPageCacheMaxSize() {
-      return pageCacheMaxSize != null ? pageCacheMaxSize : AddressSettings.DEFAULT_PAGE_MAX_CACHE;
+      return Objects.requireNonNullElse(pageCacheMaxSize, AddressSettings.DEFAULT_PAGE_MAX_CACHE);
    }
 
    public AddressSettings setPageCacheMaxSize(final int pageCacheMaxSize) {
@@ -848,11 +848,11 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getMaxSizeBytes() {
-      return maxSizeBytes != null ? maxSizeBytes : AddressSettings.DEFAULT_MAX_SIZE_BYTES;
+      return Objects.requireNonNullElse(maxSizeBytes, AddressSettings.DEFAULT_MAX_SIZE_BYTES);
    }
 
    public long getMaxSizeMessages() {
-      return maxSizeMessages != null ? maxSizeMessages : AddressSettings.DEFAULT_MAX_SIZE_MESSAGES;
+      return Objects.requireNonNullElse(maxSizeMessages, AddressSettings.DEFAULT_MAX_SIZE_MESSAGES);
    }
 
    private Integer testForNull(int value) {
@@ -870,7 +870,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getMaxReadPageMessages() {
-      return maxReadPageMessages != null ? maxReadPageMessages : AddressSettings.DEFAULT_MAX_READ_PAGE_MESSAGES;
+      return Objects.requireNonNullElse(maxReadPageMessages, AddressSettings.DEFAULT_MAX_READ_PAGE_MESSAGES);
    }
 
    public AddressSettings setMaxReadPageMessages(final int maxReadPageMessages) {
@@ -880,7 +880,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
 
    public int getPrefetchPageMessages() {
-      return prefetchPageMessages != null ? prefetchPageMessages : getMaxReadPageMessages();
+      return Objects.requireNonNullElse(prefetchPageMessages, getMaxReadPageMessages());
    }
 
    public AddressSettings setPrefetchPageMessages(final int prefetchPageMessages) {
@@ -916,7 +916,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getMaxReadPageBytes() {
-      return maxReadPageBytes != null ? maxReadPageBytes : 2 * getPageSizeBytes();
+      return Objects.requireNonNullElse(maxReadPageBytes, 2 * getPageSizeBytes());
    }
 
    public AddressSettings setMaxReadPageBytes(final int maxReadPageBytes) {
@@ -925,7 +925,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getPrefetchPageBytes() {
-      return prefetchPageBytes != null ? prefetchPageBytes : getMaxReadPageBytes();
+      return Objects.requireNonNullElse(prefetchPageBytes, getMaxReadPageBytes());
    }
 
    public AddressSettings setPrefetchPageBytes(final int prefetchPageBytes) {
@@ -934,7 +934,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getMaxDeliveryAttempts() {
-      return maxDeliveryAttempts != null ? maxDeliveryAttempts : AddressSettings.DEFAULT_MAX_DELIVERY_ATTEMPTS;
+      return Objects.requireNonNullElse(maxDeliveryAttempts, AddressSettings.DEFAULT_MAX_DELIVERY_ATTEMPTS);
    }
 
    public AddressSettings setMaxDeliveryAttempts(final int maxDeliveryAttempts) {
@@ -943,7 +943,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getMessageCounterHistoryDayLimit() {
-      return messageCounterHistoryDayLimit != null ? messageCounterHistoryDayLimit : AddressSettings.DEFAULT_MESSAGE_COUNTER_HISTORY_DAY_LIMIT;
+      return Objects.requireNonNullElse(messageCounterHistoryDayLimit, AddressSettings.DEFAULT_MESSAGE_COUNTER_HISTORY_DAY_LIMIT);
    }
 
    public AddressSettings setMessageCounterHistoryDayLimit(final int messageCounterHistoryDayLimit) {
@@ -952,7 +952,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getRedeliveryDelay() {
-      return redeliveryDelay != null ? redeliveryDelay : AddressSettings.DEFAULT_REDELIVER_DELAY;
+      return Objects.requireNonNullElse(redeliveryDelay, AddressSettings.DEFAULT_REDELIVER_DELAY);
    }
 
    public AddressSettings setRedeliveryDelay(final long redeliveryDelay) {
@@ -961,7 +961,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public double getRedeliveryMultiplier() {
-      return redeliveryMultiplier != null ? redeliveryMultiplier : AddressSettings.DEFAULT_REDELIVER_MULTIPLIER;
+      return Objects.requireNonNullElse(redeliveryMultiplier, AddressSettings.DEFAULT_REDELIVER_MULTIPLIER);
    }
 
    public AddressSettings setRedeliveryMultiplier(final double redeliveryMultiplier) {
@@ -970,7 +970,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public double getRedeliveryCollisionAvoidanceFactor() {
-      return redeliveryCollisionAvoidanceFactor != null ? redeliveryCollisionAvoidanceFactor : AddressSettings.DEFAULT_REDELIVER_COLLISION_AVOIDANCE_FACTOR;
+      return Objects.requireNonNullElse(redeliveryCollisionAvoidanceFactor, AddressSettings.DEFAULT_REDELIVER_COLLISION_AVOIDANCE_FACTOR);
    }
 
    public AddressSettings setRedeliveryCollisionAvoidanceFactor(final double redeliveryCollisionAvoidanceFactor) {
@@ -979,7 +979,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getMaxRedeliveryDelay() {
-      return maxRedeliveryDelay != null ? maxRedeliveryDelay : (getRedeliveryDelay() * 10);
+      return Objects.requireNonNullElse(maxRedeliveryDelay, (getRedeliveryDelay() * 10));
    }
 
    public AddressSettings setMaxRedeliveryDelay(final long maxRedeliveryDelay) {
@@ -1006,7 +1006,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoCreateExpiryResources() {
-      return autoCreateExpiryResources != null ? autoCreateExpiryResources : AddressSettings.DEFAULT_AUTO_CREATE_EXPIRY_RESOURCES;
+      return Objects.requireNonNullElse(autoCreateExpiryResources, AddressSettings.DEFAULT_AUTO_CREATE_EXPIRY_RESOURCES);
    }
 
    public AddressSettings setAutoCreateExpiryResources(final boolean value) {
@@ -1015,7 +1015,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SimpleString getExpiryQueuePrefix() {
-      return expiryQueuePrefix != null ? expiryQueuePrefix : AddressSettings.DEFAULT_EXPIRY_QUEUE_PREFIX;
+      return Objects.requireNonNullElse(expiryQueuePrefix, AddressSettings.DEFAULT_EXPIRY_QUEUE_PREFIX);
    }
 
    public AddressSettings setExpiryQueuePrefix(final SimpleString value) {
@@ -1024,7 +1024,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SimpleString getExpiryQueueSuffix() {
-      return expiryQueueSuffix != null ? expiryQueueSuffix : AddressSettings.DEFAULT_EXPIRY_QUEUE_SUFFIX;
+      return Objects.requireNonNullElse(expiryQueueSuffix, AddressSettings.DEFAULT_EXPIRY_QUEUE_SUFFIX);
    }
 
    public AddressSettings setExpiryQueueSuffix(final SimpleString value) {
@@ -1033,7 +1033,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Long getExpiryDelay() {
-      return expiryDelay != null ? expiryDelay : AddressSettings.DEFAULT_EXPIRY_DELAY;
+      return Objects.requireNonNullElse(expiryDelay, AddressSettings.DEFAULT_EXPIRY_DELAY);
    }
 
    public AddressSettings setExpiryDelay(final Long expiryDelay) {
@@ -1042,7 +1042,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Long getMinExpiryDelay() {
-      return minExpiryDelay != null ? minExpiryDelay : AddressSettings.DEFAULT_MIN_EXPIRY_DELAY;
+      return Objects.requireNonNullElse(minExpiryDelay, AddressSettings.DEFAULT_MIN_EXPIRY_DELAY);
    }
 
    public AddressSettings setMinExpiryDelay(final Long minExpiryDelay) {
@@ -1051,7 +1051,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Long getMaxExpiryDelay() {
-      return maxExpiryDelay != null ? maxExpiryDelay : AddressSettings.DEFAULT_MAX_EXPIRY_DELAY;
+      return Objects.requireNonNullElse(maxExpiryDelay, AddressSettings.DEFAULT_MAX_EXPIRY_DELAY);
    }
 
    public AddressSettings setMaxExpiryDelay(final Long maxExpiryDelay) {
@@ -1060,7 +1060,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public Boolean isNoExpiry() {
-      return noExpiry != null ? noExpiry : AddressSettings.DEFAULT_NO_EXPIRY;
+      return Objects.requireNonNullElse(noExpiry, AddressSettings.DEFAULT_NO_EXPIRY);
    }
 
    public AddressSettings setNoExpiry(final Boolean noExpiry) {
@@ -1069,7 +1069,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isSendToDLAOnNoRoute() {
-      return sendToDLAOnNoRoute != null ? sendToDLAOnNoRoute : AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE;
+      return Objects.requireNonNullElse(sendToDLAOnNoRoute, AddressSettings.DEFAULT_SEND_TO_DLA_ON_NO_ROUTE);
    }
 
    public AddressSettings setSendToDLAOnNoRoute(final boolean value) {
@@ -1078,7 +1078,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isAutoCreateDeadLetterResources() {
-      return autoCreateDeadLetterResources != null ? autoCreateDeadLetterResources : AddressSettings.DEFAULT_AUTO_CREATE_DEAD_LETTER_RESOURCES;
+      return Objects.requireNonNullElse(autoCreateDeadLetterResources, AddressSettings.DEFAULT_AUTO_CREATE_DEAD_LETTER_RESOURCES);
    }
 
    public AddressSettings setAutoCreateDeadLetterResources(final boolean value) {
@@ -1087,7 +1087,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SimpleString getDeadLetterQueuePrefix() {
-      return deadLetterQueuePrefix != null ? deadLetterQueuePrefix : AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_PREFIX;
+      return Objects.requireNonNullElse(deadLetterQueuePrefix, AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_PREFIX);
    }
 
    public AddressSettings setDeadLetterQueuePrefix(final SimpleString value) {
@@ -1096,7 +1096,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SimpleString getDeadLetterQueueSuffix() {
-      return deadLetterQueueSuffix != null ? deadLetterQueueSuffix : AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_SUFFIX;
+      return Objects.requireNonNullElse(deadLetterQueueSuffix, AddressSettings.DEFAULT_DEAD_LETTER_QUEUE_SUFFIX);
    }
 
    public AddressSettings setDeadLetterQueueSuffix(final SimpleString value) {
@@ -1105,7 +1105,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getRedistributionDelay() {
-      return redistributionDelay != null ? redistributionDelay : AddressSettings.DEFAULT_REDISTRIBUTION_DELAY;
+      return Objects.requireNonNullElse(redistributionDelay, AddressSettings.DEFAULT_REDISTRIBUTION_DELAY);
    }
 
    public AddressSettings setRedistributionDelay(final long redistributionDelay) {
@@ -1114,7 +1114,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getSlowConsumerThreshold() {
-      return slowConsumerThreshold != null ? slowConsumerThreshold : AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD;
+      return Objects.requireNonNullElse(slowConsumerThreshold, AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD);
    }
 
    public AddressSettings setSlowConsumerThreshold(final long slowConsumerThreshold) {
@@ -1123,7 +1123,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SlowConsumerThresholdMeasurementUnit getSlowConsumerThresholdMeasurementUnit() {
-      return slowConsumerThresholdMeasurementUnit != null ? slowConsumerThresholdMeasurementUnit : AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD_MEASUREMENT_UNIT;
+      return Objects.requireNonNullElse(slowConsumerThresholdMeasurementUnit, AddressSettings.DEFAULT_SLOW_CONSUMER_THRESHOLD_MEASUREMENT_UNIT);
    }
 
    public AddressSettings setSlowConsumerThresholdMeasurementUnit(final SlowConsumerThresholdMeasurementUnit slowConsumerThresholdMeasurementUnit) {
@@ -1132,7 +1132,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getSlowConsumerCheckPeriod() {
-      return slowConsumerCheckPeriod != null ? slowConsumerCheckPeriod : AddressSettings.DEFAULT_SLOW_CONSUMER_CHECK_PERIOD;
+      return Objects.requireNonNullElse(slowConsumerCheckPeriod, AddressSettings.DEFAULT_SLOW_CONSUMER_CHECK_PERIOD);
    }
 
    public AddressSettings setSlowConsumerCheckPeriod(final long slowConsumerCheckPeriod) {
@@ -1141,7 +1141,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public SlowConsumerPolicy getSlowConsumerPolicy() {
-      return slowConsumerPolicy != null ? slowConsumerPolicy : AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY;
+      return Objects.requireNonNullElse(slowConsumerPolicy, AddressSettings.DEFAULT_SLOW_CONSUMER_POLICY);
    }
 
    public AddressSettings setSlowConsumerPolicy(final SlowConsumerPolicy slowConsumerPolicy) {
@@ -1150,7 +1150,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getManagementBrowsePageSize() {
-      return managementBrowsePageSize != null ? managementBrowsePageSize : AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE;
+      return Objects.requireNonNullElse(managementBrowsePageSize, AddressSettings.MANAGEMENT_BROWSE_PAGE_SIZE);
    }
 
    public AddressSettings setManagementBrowsePageSize(int managementBrowsePageSize) {
@@ -1160,7 +1160,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
 
    @Deprecated
    public int getQueuePrefetch() {
-      return queuePrefetch != null ? queuePrefetch : AddressSettings.DEFAULT_QUEUE_PREFETCH;
+      return Objects.requireNonNullElse(queuePrefetch, AddressSettings.DEFAULT_QUEUE_PREFETCH);
    }
 
    @Deprecated
@@ -1179,7 +1179,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getDefaultConsumerWindowSize() {
-      return defaultConsumerWindowSize != null ? defaultConsumerWindowSize : ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE;
+      return Objects.requireNonNullElse(defaultConsumerWindowSize, ActiveMQClient.DEFAULT_CONSUMER_WINDOW_SIZE);
    }
 
    public AddressSettings setDefaultConsumerWindowSize(int defaultConsumerWindowSize) {
@@ -1188,7 +1188,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultGroupRebalance() {
-      return defaultGroupRebalance != null ? defaultGroupRebalance : ActiveMQDefaultConfiguration.getDefaultGroupRebalance();
+      return Objects.requireNonNullElse(defaultGroupRebalance, ActiveMQDefaultConfiguration.getDefaultGroupRebalance());
    }
 
    public AddressSettings setDefaultGroupRebalance(boolean defaultGroupRebalance) {
@@ -1197,7 +1197,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isDefaultGroupRebalancePauseDispatch() {
-      return defaultGroupRebalancePauseDispatch != null ? defaultGroupRebalancePauseDispatch : ActiveMQDefaultConfiguration.getDefaultGroupRebalancePauseDispatch();
+      return Objects.requireNonNullElse(defaultGroupRebalancePauseDispatch, ActiveMQDefaultConfiguration.getDefaultGroupRebalancePauseDispatch());
    }
 
    public AddressSettings setDefaultGroupRebalancePauseDispatch(boolean defaultGroupRebalancePauseDispatch) {
@@ -1206,7 +1206,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getDefaultGroupBuckets() {
-      return defaultGroupBuckets != null ? defaultGroupBuckets : ActiveMQDefaultConfiguration.getDefaultGroupBuckets();
+      return Objects.requireNonNullElse(defaultGroupBuckets, ActiveMQDefaultConfiguration.getDefaultGroupBuckets());
    }
 
    public SimpleString getDefaultGroupFirstKey() {
@@ -1224,7 +1224,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getDefaultRingSize() {
-      return defaultRingSize != null ? defaultRingSize : ActiveMQDefaultConfiguration.DEFAULT_RING_SIZE;
+      return Objects.requireNonNullElse(defaultRingSize, ActiveMQDefaultConfiguration.DEFAULT_RING_SIZE);
    }
 
    public AddressSettings setDefaultRingSize(final long defaultRingSize) {
@@ -1233,7 +1233,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public long getRetroactiveMessageCount() {
-      return retroactiveMessageCount != null ? retroactiveMessageCount : ActiveMQDefaultConfiguration.DEFAULT_RETROACTIVE_MESSAGE_COUNT;
+      return Objects.requireNonNullElse(retroactiveMessageCount, ActiveMQDefaultConfiguration.DEFAULT_RETROACTIVE_MESSAGE_COUNT);
    }
 
    public AddressSettings setRetroactiveMessageCount(final long defaultRetroactiveMessageCount) {
@@ -1242,7 +1242,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isEnableMetrics() {
-      return enableMetrics != null ? enableMetrics : AddressSettings.DEFAULT_ENABLE_METRICS;
+      return Objects.requireNonNullElse(enableMetrics, AddressSettings.DEFAULT_ENABLE_METRICS);
    }
 
    public AddressSettings setEnableMetrics(final boolean enableMetrics) {
@@ -1251,7 +1251,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public int getManagementMessageAttributeSizeLimit() {
-      return managementMessageAttributeSizeLimit != null ? managementMessageAttributeSizeLimit : AddressSettings.MANAGEMENT_MESSAGE_ATTRIBUTE_SIZE_LIMIT;
+      return Objects.requireNonNullElse(managementMessageAttributeSizeLimit, AddressSettings.MANAGEMENT_MESSAGE_ATTRIBUTE_SIZE_LIMIT);
    }
 
    public AddressSettings setManagementMessageAttributeSizeLimit(int managementMessageAttributeSizeLimit) {
@@ -1260,7 +1260,7 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    public boolean isEnableIngressTimestamp() {
-      return enableIngressTimestamp != null ? enableIngressTimestamp : AddressSettings.DEFAULT_ENABLE_INGRESS_TIMESTAMP;
+      return Objects.requireNonNullElse(enableIngressTimestamp, AddressSettings.DEFAULT_ENABLE_INGRESS_TIMESTAMP);
    }
 
    public AddressSettings setEnableIngressTimestamp(final boolean enableIngressTimestamp) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/HierarchicalObjectRepository.java
@@ -26,6 +26,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
@@ -119,7 +120,7 @@ public class HierarchicalObjectRepository<T> implements HierarchicalRepository<T
    }
 
    public HierarchicalObjectRepository(final WildcardConfiguration wildcardConfiguration, final MatchModifier matchModifier, final String literalMatchMarkers) {
-      this.wildcardConfiguration = wildcardConfiguration == null ? DEFAULT_WILDCARD_CONFIGURATION : wildcardConfiguration;
+      this.wildcardConfiguration = Objects.requireNonNullElse(wildcardConfiguration, DEFAULT_WILDCARD_CONFIGURATION);
       this.matchComparator = new MatchComparator(this.wildcardConfiguration);
       this.matchModifier = matchModifier;
       if (literalMatchMarkers != null) {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/ResourceLimitSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/ResourceLimitSettings.java
@@ -18,6 +18,7 @@
 package org.apache.activemq.artemis.core.settings.impl;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -62,11 +63,11 @@ public class ResourceLimitSettings implements Serializable, EncodingSupport {
    }
 
    public int getMaxSessions() {
-      return maxSessions != null ? maxSessions : DEFAULT_MAX_SESSIONS;
+      return Objects.requireNonNullElse(maxSessions, DEFAULT_MAX_SESSIONS);
    }
 
    public int getMaxQueues() {
-      return maxQueues != null ? maxQueues : DEFAULT_MAX_QUEUES;
+      return Objects.requireNonNullElse(maxQueues, DEFAULT_MAX_QUEUES);
    }
 
    //   public long getMaxQueueSizeBytes()

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/scram/ScramUtils.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/scram/ScramUtils.java
@@ -59,7 +59,7 @@ public class ScramUtils {
 
       byte[] previous = null;
       for (int i = 1; i < iterationsCount; i++) {
-         mac.update(previous != null ? previous : result);
+         mac.update(Objects.requireNonNullElse(previous, result));
          previous = mac.doFinal();
          for (int x = 0; x < result.length; x++) {
             result[x] ^= previous[x];

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/targets/MockTargetProbe.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/routing/targets/MockTargetProbe.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.server.routing.targets;
 
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
 public class MockTargetProbe extends TargetProbe {
@@ -39,8 +40,7 @@ public class MockTargetProbe extends TargetProbe {
    }
 
    public int getTargetExecutions(Target target) {
-      Integer executions = targetExecutions.get(target);
-      return executions != null ? executions : 0;
+      return Objects.requireNonNullElse(targetExecutions.get(target), 0);
    }
 
    public int setTargetExecutions(Target target, int executions) {

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/ActiveMQXAResourceWrapperImpl.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/ActiveMQXAResourceWrapperImpl.java
@@ -20,6 +20,7 @@ import javax.transaction.xa.XAException;
 import javax.transaction.xa.XAResource;
 import javax.transaction.xa.Xid;
 import java.util.Map;
+import java.util.Objects;
 
 public class ActiveMQXAResourceWrapperImpl implements ActiveMQXAResourceWrapper {
 
@@ -49,7 +50,7 @@ public class ActiveMQXAResourceWrapperImpl implements ActiveMQXAResourceWrapper 
       String jndiName = (String) properties.get(ACTIVEMQ_JNDI_NAME);
       String nodeId = "NodeId:" + properties.get(ACTIVEMQ_NODE_ID);
 
-      this.jndiNameNodeId = jndiName == null ? nodeId : jndiName + " " + nodeId;
+      this.jndiNameNodeId = Objects.requireNonNullElse(jndiName, nodeId) + " " + nodeId;
    }
 
    public XAResource getResource() {

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/XARecoveryConfig.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/XARecoveryConfig.java
@@ -20,6 +20,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ServerLocatorConfig;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
@@ -84,7 +85,7 @@ public class XARecoveryConfig {
       this.username = username;
       this.password = password;
       this.ha = ha;
-      this.properties = properties == null ? new HashMap<>() : properties;
+      this.properties = Objects.requireNonNullElseGet(properties, () -> new HashMap<>());
       this.clientProtocolManager = clientProtocolManager;
       this.locatorConfig = locatorConfig;
    }

--- a/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
+++ b/artemis-web/src/main/java/org/apache/activemq/artemis/component/WebServerComponent.java
@@ -32,6 +32,7 @@ import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import jakarta.servlet.DispatcherType;
@@ -123,7 +124,7 @@ public class WebServerComponent implements ExternalComponent, WebServerComponent
          scanPeriod = DEFAULT_SCAN_PERIOD_VALUE;
       }
 
-      temporaryWarDir = Paths.get(artemisInstance != null ? artemisInstance : ".").resolve("tmp").resolve("webapps").toAbsolutePath();
+      temporaryWarDir = Paths.get(Objects.requireNonNullElse(artemisInstance, ".")).resolve("tmp").resolve("webapps").toAbsolutePath();
       if (!Files.exists(temporaryWarDir)) {
          Files.createDirectories(temporaryWarDir);
       }
@@ -161,9 +162,9 @@ public class WebServerComponent implements ExternalComponent, WebServerComponent
       connectors = new ServerConnector[bindings.size()];
       String[] virtualHosts = new String[bindings.size()];
 
-      this.artemisHomePath = Paths.get(artemisHome != null ? artemisHome : ".");
+      this.artemisHomePath = Paths.get(Objects.requireNonNullElse(artemisHome, "."));
       Path homeWarDir = artemisHomePath.resolve(this.webServerConfig.path).toAbsolutePath();
-      Path instanceWarDir = Paths.get(artemisInstance != null ? artemisInstance : ".").resolve(this.webServerConfig.path).toAbsolutePath();
+      Path instanceWarDir = Paths.get(Objects.requireNonNullElse(artemisInstance, ".")).resolve(this.webServerConfig.path).toAbsolutePath();
 
       for (int i = 0; i < bindings.size(); i++) {
          BindingDTO binding = bindings.get(i);
@@ -277,12 +278,12 @@ public class WebServerComponent implements ExternalComponent, WebServerComponent
 
       if ("https".equals(scheme)) {
          SslContextFactory.Server sslFactory = new SslContextFactory.Server();
-         sslFactory.setKeyStorePath(binding.keyStorePath == null ? artemisInstance + "/etc/keystore.jks" : binding.keyStorePath);
+         sslFactory.setKeyStorePath(Objects.requireNonNullElse(binding.keyStorePath, artemisInstance + "/etc/keystore.jks"));
          if (binding.keyStoreType != null) {
             sslFactory.setKeyStoreType(binding.keyStoreType);
             checkPemProviderLoaded(binding.keyStoreType);
          }
-         sslFactory.setKeyStorePassword(binding.getKeyStorePassword() == null ? "password" : binding.getKeyStorePassword());
+         sslFactory.setKeyStorePassword(Objects.requireNonNullElse(binding.getKeyStorePassword(), "password"));
 
          if (binding.getIncludedTLSProtocols() != null) {
             sslFactory.setIncludeProtocols(binding.getIncludedTLSProtocols());
@@ -313,8 +314,8 @@ public class WebServerComponent implements ExternalComponent, WebServerComponent
          }
 
          SecureRequestCustomizer secureRequestCustomizer = new SecureRequestCustomizer();
-         secureRequestCustomizer.setSniHostCheck(binding.getSniHostCheck() != null ? binding.getSniHostCheck() : DEFAULT_SNI_HOST_CHECK_VALUE);
-         secureRequestCustomizer.setSniRequired(binding.getSniRequired() != null ? binding.getSniRequired() : DEFAULT_SNI_REQUIRED_VALUE);
+         secureRequestCustomizer.setSniHostCheck(Objects.requireNonNullElse(binding.getSniHostCheck(), DEFAULT_SNI_HOST_CHECK_VALUE));
+         secureRequestCustomizer.setSniRequired(Objects.requireNonNullElse(binding.getSniRequired(), DEFAULT_SNI_REQUIRED_VALUE));
          httpConfiguration.addCustomizer(secureRequestCustomizer);
          httpConfiguration.setSendServerVersion(false);
          HttpConnectionFactory httpFactory = new HttpConnectionFactory(httpConfiguration);

--- a/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
+++ b/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
@@ -40,6 +40,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.UUID;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
@@ -635,7 +636,7 @@ public class WebServerComponentTest extends ArtemisTestCase {
    }
 
    private int testSimpleSecureServer(String webServerHostname, int webServerPort, String requestHostname, String sniHostname, HostnameVerifier hostnameVerifier) throws Exception {
-      HttpGet request = new HttpGet("https://" + (requestHostname != null ? requestHostname : webServerHostname) + ":" + webServerPort + "/WebServerComponentTest.txt");
+      HttpGet request = new HttpGet("https://" + (Objects.requireNonNullElse(requestHostname, webServerHostname)) + ":" + webServerPort + "/WebServerComponentTest.txt");
 
       HttpHost webServerHost = HttpHost.create("https://" + webServerHostname + ":" + webServerPort);
       SSLContext sslContext = new SSLContextBuilder().loadTrustMaterial(null, (certificate, authType) -> true).build();

--- a/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/ActiveMQConnectionFactory.java
+++ b/tests/activemq5-unit-tests/src/main/java/org/apache/activemq/ActiveMQConnectionFactory.java
@@ -37,6 +37,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import java.util.concurrent.RejectedExecutionHandler;
+import java.util.Objects;
 
 import org.apache.activemq.blob.BlobTransferPolicy;
 import org.apache.activemq.broker.region.policy.RedeliveryPolicyMap;
@@ -243,7 +244,7 @@ public class ActiveMQConnectionFactory extends JNDIBaseStorable implements Conne
             if (params == Collections.EMPTY_MAP) {
                params = new HashMap<>();
             }
-            params.put("invmBrokerId", uri.getHost() == null ? "localhost" : uri.getHost());
+            params.put("invmBrokerId", Objects.requireNonNullElse(uri.getHost(), "localhost"));
             defaultTcpUri = URISupport.createRemainingURI(defaultTcpUri, params);
             return defaultTcpUri;
          }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/integration/stomp/util/AbstractStompClientConnection.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/integration/stomp/util/AbstractStompClientConnection.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
@@ -117,7 +118,7 @@ public abstract class AbstractStompClientConnection implements StompClientConnec
    }
 
    private void parseURI(URI uri) {
-      scheme = uri.getScheme() == null ? "tcp" : uri.getScheme();
+      scheme = Objects.requireNonNullElse(uri.getScheme(), "tcp");
       host = uri.getHost();
       port = uri.getPort();
       this.version = StompClientConnectionFactory.getStompVersionFromURI(uri);

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/util/Jmx.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/util/Jmx.java
@@ -105,7 +105,7 @@ public class Jmx {
          final JsonObject nodePair = nodeIDs.getJsonObject(i);
          try {
             final String nodeID = nodePair.getString("nodeID");
-            final String primary = nodePair.getString("primary") == null ? nodePair.getString("live") : nodePair.getString("primary");
+            final String primary = Objects.requireNonNullElse(nodePair.getString("primary"), nodePair.getString("live"));
             final String backup = nodePair.getString("backup", null);
             networkTopology.put(nodeID, new Pair<>(primary, backup));
          } catch (Exception e) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromAddressTest.java
@@ -43,6 +43,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
@@ -2097,9 +2098,9 @@ class AMQPBridgeFromAddressTest extends AmqpClientTestSupport {
          server.start();
          server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.MULTICAST));
 
-         final String expectedSourceAddress = (prefix != null ? prefix : "") +
-                                              (address != null ? address : getTestName()) +
-                                              (suffix != null ? suffix : "");
+         final String expectedSourceAddress = Objects.requireNonNullElse(prefix, "") +
+                                              Objects.requireNonNullElse(address, getTestName()) +
+                                              Objects.requireNonNullElse(suffix, "");
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromQueueTest.java
@@ -46,6 +46,7 @@ import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import javax.jms.Connection;
@@ -2402,9 +2403,9 @@ public class AMQPBridgeFromQueueTest extends AmqpClientTestSupport {
          server.start();
          server.addAddressInfo(new AddressInfo(SimpleString.of(getTestName()), RoutingType.ANYCAST));
 
-         final String expectedSourceAddress = (prefix != null ? prefix : "") +
-                                              (address != null ? address : getTestName()) +
-                                              (suffix != null ? suffix : "");
+         final String expectedSourceAddress = Objects.requireNonNullElse(prefix, "") +
+                                              Objects.requireNonNullElse(address, getTestName()) +
+                                              Objects.requireNonNullElse(suffix, "");
 
          peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
          peer.expectAttach().ofReceiver()

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToAddressTest.java
@@ -41,6 +41,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import javax.jms.Connection;
@@ -518,9 +519,9 @@ public class AMQPBridgeToAddressTest  extends AmqpClientTestSupport {
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
-         final String expectedTargetAddress = (prefix != null ? prefix : "") +
-                                              (address != null ? address : getTestName()) +
-                                              (suffix != null ? suffix : "");
+         final String expectedTargetAddress = Objects.requireNonNullElse(prefix, "") +
+                                              Objects.requireNonNullElse(address, getTestName()) +
+                                              Objects.requireNonNullElse(suffix, "");
 
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeToQueueTest.java
@@ -34,6 +34,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import javax.jms.Connection;
@@ -542,9 +543,9 @@ class AMQPBridgeToQueueTest  extends AmqpClientTestSupport {
          amqpConnection.setReconnectAttempts(0);// No reconnects
          amqpConnection.addElement(element);
 
-         final String expectedTargetAddress = (prefix != null ? prefix : "") +
-                                              (address != null ? address : getTestName()) +
-                                              (suffix != null ? suffix : "");
+         final String expectedTargetAddress = Objects.requireNonNullElse(prefix, "") +
+                                              Objects.requireNonNullElse(address, getTestName()) +
+                                              Objects.requireNonNullElse(suffix, "");
 
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CoreClientTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/CoreClientTest.java
@@ -21,6 +21,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -119,9 +120,7 @@ public class CoreClientTest extends ActiveMQTestBase {
 
       server.start();
 
-      ServerLocator locator = serverLocator == null ? createNonHALocator(netty) : serverLocator;
-
-      ClientSessionFactory sf = createSessionFactory(locator);
+      ClientSessionFactory sf = createSessionFactory(Objects.requireNonNullElseGet(serverLocator, () -> createNonHALocator(netty)));
 
       ClientSession session = sf.createSession(false, true, true);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/routing/RoutingTestBase.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/routing/RoutingTestBase.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.config.Configuration;
@@ -62,7 +63,7 @@ public class RoutingTestBase extends ClusterTestBase {
    protected TransportConfiguration getDefaultServerConnector(final int node) {
       Map<String, TransportConfiguration> connectorConfigurations = getServer(node).getConfiguration().getConnectorConfigurations();
       TransportConfiguration connector = connectorConfigurations.get(DEFAULT_CONNECTOR_NAME);
-      return connector != null ? connector : connectorConfigurations.values().stream().findFirst().get();
+      return Objects.requireNonNullElseGet(connector, () -> connectorConfigurations.values().stream().findFirst().get());
    }
 
    protected TransportConfiguration setupDefaultServerConnector(final int node) {


### PR DESCRIPTION
The code-base is littered with uses of Java's ternary operator to check for null and fallback to a default value. Many of these can be replaced with either `Objects.requireNonNullElse` or `Objects.requireNonNullElseGet`. The latter is used where appropriate to essentially match the short-circuit semantics provided by the ternary operator.