### PR TITLE
ARTEMIS-3163 Support for Netty IO_URING transport

### DIFF
--- a/artemis-core-client-osgi/pom.xml
+++ b/artemis-core-client-osgi/pom.xml
@@ -70,7 +70,7 @@
                   <Import-Package>
                      org.glassfish.json*;resolution:=optional,
                      de.dentrassi.crypto.pem;resolution:=optional,
-                     io.netty.buffer;io.netty.*;version="[4.1,5)",
+                     io.netty.*;version="[4.2,5)",
                      *
                   </Import-Package>
                   <_exportcontents>org.apache.activemq.artemis.*;-noimport:=true</_exportcontents>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -111,10 +111,6 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
-         <artifactId>netty-codec</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
          <artifactId>netty-codec-socks</artifactId>
       </dependency>
       <dependency>

--- a/artemis-core-client/pom.xml
+++ b/artemis-core-client/pom.xml
@@ -91,6 +91,15 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
+         <artifactId>netty-transport-native-io_uring</artifactId>
+         <classifier>${netty-transport-native-io_uring-classifier}</classifier>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
+         <artifactId>netty-transport-classes-io_uring</artifactId>
+      </dependency>
+      <dependency>
+         <groupId>io.netty</groupId>
          <artifactId>netty-codec-http</artifactId>
       </dependency>
       <dependency>

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/ActiveMQClientLogger.java
@@ -349,4 +349,10 @@ public interface ActiveMQClientLogger {
 
    @LogMessage(id = 214036, value = "Connection closure to {} has been detected: {} [code={}]", level = LogMessage.Level.INFO)
    void connectionClosureDetected(String remoteAddress, String message, ActiveMQExceptionType type);
+
+   @LogMessage(id = 214037, value = "Unable to check IoUring availability ", level = LogMessage.Level.WARN)
+   void unableToCheckIoUringAvailability(Throwable e);
+
+   @LogMessage(id = 214038, value = "IoUring is not available, please add to the classpath or configure useIoUring=false to remove this warning", level = LogMessage.Level.WARN)
+   void unableToCheckIoUringAvailabilitynoClass();
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/CheckDependencies.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/CheckDependencies.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.remoting.impl.netty;
 
 import io.netty.channel.epoll.Epoll;
 import io.netty.channel.kqueue.KQueue;
+import io.netty.channel.uring.IoUring;
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
 import org.apache.activemq.artemis.utils.Env;
 
@@ -51,4 +52,17 @@ public class CheckDependencies {
          return false;
       }
    }
+
+   public static final boolean isIoUringAvailable() {
+      try {
+         return Env.isLinuxOs() && IoUring.isAvailable();
+      } catch (NoClassDefFoundError noClassDefFoundError) {
+         ActiveMQClientLogger.LOGGER.unableToCheckIoUringAvailabilitynoClass();
+         return false;
+      } catch (Throwable e)  {
+         ActiveMQClientLogger.LOGGER.unableToCheckIoUringAvailability(e);
+         return false;
+      }
+   }
+
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -68,6 +68,8 @@ public class TransportConstants {
 
    public static final String USE_KQUEUE_PROP_NAME = "useKQueue";
 
+   public static final String USE_IOURING_PROP_NAME = "useIoUring";
+
    /**
     * @deprecated Use USE_GLOBAL_WORKER_POOL_PROP_NAME
     */
@@ -213,6 +215,8 @@ public class TransportConstants {
    public static final boolean DEFAULT_USE_EPOLL = true;
 
    public static final boolean DEFAULT_USE_KQUEUE = true;
+
+   public static final boolean DEFAULT_USE_IOURING = false;
 
    public static final boolean DEFAULT_USE_INVM = false;
 
@@ -422,6 +426,7 @@ public class TransportConstants {
       allowableAcceptorKeys.add(TransportConstants.USE_NIO_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);
+      allowableAcceptorKeys.add(TransportConstants.USE_IOURING_PROP_NAME);
       allowableAcceptorKeys.add(TransportConstants.USE_INVM_PROP_NAME);
       //noinspection deprecation
       allowableAcceptorKeys.add(TransportConstants.PROTOCOL_PROP_NAME);
@@ -497,6 +502,7 @@ public class TransportConstants {
       allowableConnectorKeys.add(TransportConstants.USE_NIO_GLOBAL_WORKER_POOL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_EPOLL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_KQUEUE_PROP_NAME);
+      allowableConnectorKeys.add(TransportConstants.USE_IOURING_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.USE_GLOBAL_WORKER_POOL_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.HOST_PROP_NAME);
       allowableConnectorKeys.add(TransportConstants.PORT_PROP_NAME);

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -33,7 +33,8 @@
 		<bundle>mvn:io.netty/netty-resolver/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-buffer/${netty.version}</bundle>
-		<bundle>mvn:io.netty/netty-codec/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-codec-base/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-codec-compression/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-codec-socks/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-codec-http/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-handler/${netty.version}</bundle>

--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -44,6 +44,8 @@
 		<bundle>mvn:io.netty/netty-transport-native-epoll/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport-classes-kqueue/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport-native-kqueue/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-transport-classes-io_uring/${netty.version}</bundle>
+		<bundle>mvn:io.netty/netty-transport-native-io_uring/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport-native-unix-common/${netty.version}</bundle>
 	</feature>
 

--- a/artemis-jms-client-osgi/pom.xml
+++ b/artemis-jms-client-osgi/pom.xml
@@ -78,7 +78,7 @@
                   <Import-Package>
                      org.glassfish.json*;resolution:=optional,
                      de.dentrassi.crypto.pem;resolution:=optional,
-                     io.netty.buffer;io.netty.*;version="[4.1,5)",
+                     io.netty.*;version="[4.2,5)",
                      *
                   </Import-Package>
                   <_exportcontents>org.apache.activemq.artemis.*;-noimport:=true</_exportcontents>

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -391,12 +391,6 @@
          </dependency>
          <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-codec</artifactId>
-            <version>${netty.version}</version>
-            <!-- License: Apache 2.0 -->
-         </dependency>
-         <dependency>
-            <groupId>io.netty</groupId>
             <artifactId>netty-codec-http</artifactId>
             <version>${netty.version}</version>
             <!-- License: Apache 2.0 -->

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -452,6 +452,19 @@
             <!-- License: Apache 2.0 -->
          </dependency>
          <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-classes-io_uring</artifactId>
+            <version>${netty.version}</version>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-transport-native-io_uring</artifactId>
+            <version>${netty.version}</version>
+            <classifier>${netty-transport-native-io_uring-classifier}</classifier>
+            <!-- License: Apache 2.0 -->
+         </dependency>
+         <dependency>
             <groupId>org.apache.qpid</groupId>
             <artifactId>proton-j</artifactId>
             <version>${proton.version}</version>

--- a/artemis-protocols/artemis-jakarta-openwire-protocol/pom.xml
+++ b/artemis-protocols/artemis-jakarta-openwire-protocol/pom.xml
@@ -91,10 +91,6 @@
          <artifactId>netty-transport</artifactId>
       </dependency>
       <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.osgi</groupId>
          <artifactId>osgi.cmpn</artifactId>
       </dependency>

--- a/artemis-protocols/artemis-mqtt-protocol/pom.xml
+++ b/artemis-protocols/artemis-mqtt-protocol/pom.xml
@@ -71,10 +71,6 @@
       </dependency>
       <dependency>
          <groupId>io.netty</groupId>
-         <artifactId>netty-codec</artifactId>
-      </dependency>
-      <dependency>
-         <groupId>io.netty</groupId>
          <artifactId>netty-common</artifactId>
       </dependency>
       <dependency>

--- a/artemis-protocols/artemis-openwire-protocol/pom.xml
+++ b/artemis-protocols/artemis-openwire-protocol/pom.xml
@@ -97,10 +97,6 @@
          <artifactId>netty-transport</artifactId>
       </dependency>
       <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec</artifactId>
-      </dependency>
-      <dependency>
          <groupId>org.osgi</groupId>
          <artifactId>osgi.cmpn</artifactId>
       </dependency>

--- a/artemis-server-osgi/pom.xml
+++ b/artemis-server-osgi/pom.xml
@@ -128,7 +128,7 @@
                      org.glassfish.json*;resolution:=optional,
                      org.postgresql*;resolution:=optional,
                      de.dentrassi.crypto.pem;resolution:=optional,
-                     io.netty.buffer;io.netty.*;version="[4.1,5)",
+                     io.netty.*;version="[4.2,5)",
                      java.net.http*;resolution:=optional,
                      com.sun.net.httpserver*;resolution:=optional,
                      *

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -133,10 +133,6 @@
          <artifactId>netty-transport-classes-kqueue</artifactId>
       </dependency>
       <dependency>
-         <groupId>io.netty</groupId>
-         <artifactId>netty-codec</artifactId>
-      </dependency>
-      <dependency>
          <groupId>commons-beanutils</groupId>
          <artifactId>commons-beanutils</artifactId>
       </dependency>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -49,18 +49,19 @@ import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.DefaultEventLoopGroup;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.ServerChannel;
 import io.netty.channel.WriteBufferWaterMark;
-import io.netty.channel.epoll.EpollEventLoopGroup;
+import io.netty.channel.epoll.EpollIoHandler;
 import io.netty.channel.epoll.EpollServerSocketChannel;
 import io.netty.channel.group.ChannelGroup;
 import io.netty.channel.group.ChannelGroupFuture;
 import io.netty.channel.group.DefaultChannelGroup;
-import io.netty.channel.kqueue.KQueueEventLoopGroup;
+import io.netty.channel.kqueue.KQueueIoHandler;
 import io.netty.channel.kqueue.KQueueServerSocketChannel;
 import io.netty.channel.local.LocalAddress;
 import io.netty.channel.local.LocalServerChannel;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslHandler;
@@ -436,19 +437,19 @@ public class NettyAcceptor extends AbstractAcceptor {
 
          if (useEpoll && CheckDependencies.isEpollAvailable()) {
             channelClazz = EpollServerSocketChannel.class;
-            eventLoopGroup = new EpollEventLoopGroup(remotingThreads, AccessController.doPrivileged((PrivilegedAction<ActiveMQThreadFactory>) () -> new ActiveMQThreadFactory("activemq-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader())));
+            eventLoopGroup = new MultiThreadIoEventLoopGroup(remotingThreads, AccessController.doPrivileged((PrivilegedAction<ActiveMQThreadFactory>) () -> new ActiveMQThreadFactory("activemq-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader())), EpollIoHandler.newFactory());
             acceptorType = EPOLL_ACCEPTOR_TYPE;
 
             logger.debug("Acceptor using native epoll");
          } else if (useKQueue && CheckDependencies.isKQueueAvailable()) {
             channelClazz = KQueueServerSocketChannel.class;
-            eventLoopGroup = new KQueueEventLoopGroup(remotingThreads, AccessController.doPrivileged((PrivilegedAction<ActiveMQThreadFactory>) () -> new ActiveMQThreadFactory("activemq-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader())));
+            eventLoopGroup = new MultiThreadIoEventLoopGroup(remotingThreads, AccessController.doPrivileged((PrivilegedAction<ActiveMQThreadFactory>) () -> new ActiveMQThreadFactory("activemq-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader())), KQueueIoHandler.newFactory());
             acceptorType = KQUEUE_ACCEPTOR_TYPE;
 
             logger.debug("Acceptor using native kqueue");
          } else {
             channelClazz = NioServerSocketChannel.class;
-            eventLoopGroup = new NioEventLoopGroup(remotingThreads, AccessController.doPrivileged((PrivilegedAction<ActiveMQThreadFactory>) () -> new ActiveMQThreadFactory("activemq-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader())));
+            eventLoopGroup = new MultiThreadIoEventLoopGroup(remotingThreads, AccessController.doPrivileged((PrivilegedAction<ActiveMQThreadFactory>) () -> new ActiveMQThreadFactory("activemq-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader())), NioIoHandler.newFactory());
             acceptorType = NIO_ACCEPTOR_TYPE;
             logger.debug("Acceptor using nio");
          }

--- a/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
+++ b/artemis-web/src/test/java/org/apache/activemq/cli/test/WebServerComponentTest.java
@@ -55,8 +55,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
@@ -1005,7 +1006,7 @@ public class WebServerComponentTest extends ArtemisTestCase {
    }
 
    private Channel getChannel(int port, ClientHandler clientHandler) throws InterruptedException {
-      EventLoopGroup group = new NioEventLoopGroup();
+      EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
       Bootstrap bootstrap = new Bootstrap();
       bootstrap.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer() {
          @Override
@@ -1018,7 +1019,7 @@ public class WebServerComponentTest extends ArtemisTestCase {
    }
 
    private Channel getSslChannel(int port, SslHandler sslHandler, ClientHandler clientHandler) throws InterruptedException {
-      EventLoopGroup group = new NioEventLoopGroup();
+      EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
       Bootstrap bootstrap = new Bootstrap();
       bootstrap.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer() {
          @Override

--- a/docs/user-manual/configuring-transports.adoc
+++ b/docs/user-manual/configuring-transports.adoc
@@ -244,14 +244,14 @@ These Native transports add features specific to a particular platform, generate
 
 Both Clients and Server can benefit from this.
 
-Current Supported Platforms.
+Currently supported platforms:
 
 * Linux running 64bit JVM
 * MacOS running 64bit JVM
 
-Apache ActiveMQ Artemis will by default enable the corresponding native transport if a supported platform is detected.
+Apache ActiveMQ Artemis will enable the corresponding native transport by default if a supported platform is detected.
 
-If running on an unsupported platform or any issues loading native libs, Apache ActiveMQ Artemis will fallback onto Java NIO.
+If running on an unsupported platform, or if any issues occur while loading the native libs, Apache ActiveMQ Artemis will fallback onto Java NIO.
 
 ==== Linux Native Transport
 
@@ -263,6 +263,22 @@ useEpoll::
 enables the use of epoll if a supported linux platform is running a 64bit JVM is detected.
 Setting this to `false` will force the use of Java NIO instead of epoll.
 Default is `true`
+
+Additionally, Apache ActiveMQ Artemis offers support for using IO_URING, @see https://en.wikipedia.org/wiki/Io_uring.
+
+The following properties are specific to this native transport:
+
+useIoUring::
+enables the use of IO_URING if a supported linux platform running a 64bit JVM is detected.
+Setting this to `false` will attempt the use of `epoll`, then finally falling back to using Java NIO.
+Default is `false`
+
+[WARNING]
+====
+[#io_uring-warning]
+IO_URING support is a recent addition to the broker and should be considered `experimental` at this stage.
+Using it _could_ introduce unwanted side effects. As such, thourough testing and verification is advised before use in any production or otherwise critical environment.
+====
 
 ==== MacOS Native Transport
 

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <checkstyle.version>10.25.0</checkstyle.version>
       <mockito.version>5.18.0</mockito.version>
       <jctools.version>4.0.5</jctools.version>
-      <netty.version>4.1.121.Final</netty.version>
+      <netty.version>4.2.2.Final</netty.version>
       <hdrhistogram.version>2.2.2</hdrhistogram.version>
       <curator.version>5.8.0</curator.version>
       <zookeeper.version>3.9.3</zookeeper.version>

--- a/pom.xml
+++ b/pom.xml
@@ -269,6 +269,7 @@
 
       <netty-transport-native-epoll-classifier>linux-x86_64</netty-transport-native-epoll-classifier>
       <netty-transport-native-kqueue-classifier>osx-x86_64</netty-transport-native-kqueue-classifier>
+      <netty-transport-native-io_uring-classifier>linux-x86_64</netty-transport-native-io_uring-classifier>
 
       <fast-tests>false</fast-tests>
 

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/util/TcpProxy.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/tests/util/TcpProxy.java
@@ -36,7 +36,8 @@ import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
 import io.netty.channel.EventLoopGroup;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.logging.LogLevel;
@@ -144,8 +145,8 @@ public final class TcpProxy implements Runnable {
       logger.info("Proxying {} to {}", localPort, remotePort);
 
       // Configure the bootstrap.
-      EventLoopGroup bossGroup = new NioEventLoopGroup(1);
-      EventLoopGroup workerGroup = new NioEventLoopGroup();
+      EventLoopGroup bossGroup = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
+      EventLoopGroup workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
       try {
          ServerBootstrap b = new ServerBootstrap();
          b.group(bossGroup, workerGroup)

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyTcpTransport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/netty/NettyTcpTransport.java
@@ -17,20 +17,13 @@
 package org.apache.activemq.transport.netty;
 
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.net.URI;
 import java.security.Principal;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Function;
-import static java.util.function.Function.identity;
-
-import io.netty.channel.ChannelPromise;
-import io.netty.util.ReferenceCounted;
-import org.apache.activemq.transport.amqp.client.util.IOExceptionSupport;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 import io.netty.bootstrap.Bootstrap;
 import io.netty.buffer.ByteBuf;
@@ -42,15 +35,23 @@ import io.netty.channel.ChannelInboundHandlerAdapter;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelOption;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.ChannelPromise;
 import io.netty.channel.EventLoopGroup;
 import io.netty.channel.FixedRecvByteBufAllocator;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.logging.LoggingHandler;
 import io.netty.handler.ssl.SslHandler;
+import io.netty.util.ReferenceCounted;
 import io.netty.util.concurrent.Future;
 import io.netty.util.concurrent.GenericFutureListener;
+import org.apache.activemq.transport.amqp.client.util.IOExceptionSupport;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static java.util.function.Function.identity;
 
 /**
  * TCP based transport that uses Netty as the underlying IO layer.
@@ -125,7 +126,7 @@ public class NettyTcpTransport implements NettyTransport {
          sslHandler = null;
       }
 
-      group = new NioEventLoopGroup(1);
+      group = new MultiThreadIoEventLoopGroup(1, NioIoHandler.newFactory());
 
       bootstrap = new Bootstrap();
       bootstrap.group(group);

--- a/tests/integration-tests-isolated/src/test/java/org/apache/activemq/artemis/tests/integration/isolated/web/WebServerComponentTest.java
+++ b/tests/integration-tests-isolated/src/test/java/org/apache/activemq/artemis/tests/integration/isolated/web/WebServerComponentTest.java
@@ -16,11 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.isolated.web;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
 import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileReader;
@@ -37,8 +32,9 @@ import io.netty.channel.Channel;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.nio.NioSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpRequest;
 import io.netty.handler.codec.http.HttpClientCodec;
@@ -61,6 +57,11 @@ import org.eclipse.jetty.server.HttpConnectionFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
  * This test leaks a thread named org.eclipse.jetty.util.RolloverFileOutputStream which is why it is isolated now. In
@@ -211,7 +212,7 @@ public class WebServerComponentTest {
    }
 
    private Channel getChannel(int port, ClientHandler clientHandler) throws InterruptedException {
-      EventLoopGroup group = new NioEventLoopGroup();
+      EventLoopGroup group = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
       Bootstrap bootstrap = new Bootstrap();
       bootstrap.group(group).channel(NioSocketChannel.class).handler(new ChannelInitializer() {
          @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/HttpAuthorityTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/HttpAuthorityTest.java
@@ -26,8 +26,9 @@ import io.netty.channel.ChannelFuture;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -51,8 +52,8 @@ public class HttpAuthorityTest extends ActiveMQTestBase {
       int port = 61616;
       CountDownLatch requestTested = new CountDownLatch(1);
       AtomicBoolean failed = new AtomicBoolean(false);
-      EventLoopGroup bossGroup = new NioEventLoopGroup();
-      EventLoopGroup workerGroup = new NioEventLoopGroup();
+      EventLoopGroup bossGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+      EventLoopGroup workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
       try {
          ServerBootstrap bootstrap = new ServerBootstrap();
          bootstrap.group(bossGroup, workerGroup).channel(NioServerSocketChannel.class).childHandler(new ChannelInitializer<SocketChannel>() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/transports/netty/NettyConnectorWithHTTPUpgradeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/transports/netty/NettyConnectorWithHTTPUpgradeTest.java
@@ -27,8 +27,10 @@ import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
 import io.netty.channel.SimpleChannelInboundHandler;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
@@ -107,8 +109,8 @@ public class NettyConnectorWithHTTPUpgradeTest extends ActiveMQTestBase {
    private ServerLocator locator;
    private String acceptorName;
 
-   private NioEventLoopGroup bossGroup;
-   private NioEventLoopGroup workerGroup;
+   private EventLoopGroup bossGroup;
+   private EventLoopGroup workerGroup;
 
    private String SERVER_SIDE_KEYSTORE = "server-keystore.jks";
    private String CLIENT_SIDE_TRUSTSTORE = "server-ca-truststore.jks";
@@ -214,8 +216,8 @@ public class NettyConnectorWithHTTPUpgradeTest extends ActiveMQTestBase {
    }
 
    private void startWebServer(int port) throws Exception {
-      bossGroup = new NioEventLoopGroup();
-      workerGroup = new NioEventLoopGroup();
+      bossGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+      workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
       ServerBootstrap b = new ServerBootstrap();
       final SSLContext context;
       if (useSSL) {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/SocksProxyTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/SocksProxyTest.java
@@ -16,13 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.unit.core.remoting.impl.netty;
 
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assumptions.assumeTrue;
-
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.NetworkInterface;
@@ -38,7 +31,9 @@ import java.util.concurrent.TimeUnit;
 import io.netty.bootstrap.ServerBootstrap;
 import io.netty.channel.ChannelInitializer;
 import io.netty.channel.ChannelPipeline;
-import io.netty.channel.nio.NioEventLoopGroup;
+import io.netty.channel.EventLoopGroup;
+import io.netty.channel.MultiThreadIoEventLoopGroup;
+import io.netty.channel.nio.NioIoHandler;
 import io.netty.channel.socket.SocketChannel;
 import io.netty.channel.socket.nio.NioServerSocketChannel;
 import io.netty.handler.proxy.Socks5ProxyHandler;
@@ -58,6 +53,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
 public class SocksProxyTest extends ActiveMQTestBase {
 
    private static final int SOCKS_PORT = 1080;
@@ -66,8 +68,8 @@ public class SocksProxyTest extends ActiveMQTestBase {
    private ExecutorService threadPool;
    private ScheduledExecutorService scheduledThreadPool;
 
-   private NioEventLoopGroup bossGroup;
-   private NioEventLoopGroup workerGroup;
+   private EventLoopGroup bossGroup;
+   private EventLoopGroup workerGroup;
 
    @Override
    @BeforeEach
@@ -264,8 +266,8 @@ public class SocksProxyTest extends ActiveMQTestBase {
    }
 
    private void startSocksProxy() throws Exception {
-      bossGroup   = new NioEventLoopGroup();
-      workerGroup = new NioEventLoopGroup();
+      bossGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
+      workerGroup = new MultiThreadIoEventLoopGroup(NioIoHandler.newFactory());
 
       ServerBootstrap b = new ServerBootstrap();
       b.group(bossGroup, workerGroup);


### PR DESCRIPTION
This is a continuation of #5296 using a branch from @jbertram that's using Netty 4.2. (Netty support in a separate commit)

Setting this as a separate PR as it'd dependent on having the Netty branch merged first and as far as I can tell there is at least one more issue remaining for Netty 4.2, where some tests under `karaf-client-integration-tests` are currently failing.
I think it's because `artemis-features` cannot build properly as at least one dependency requires a lower version of Netty:
`missing requirement [org.apache.qpid.jms.client/1.13.0] osgi.wiring.package; filter:="(&(osgi.wiring.package=io.netty.bootstrap)(version>=4.1.0)(!(version>=4.2.0)))"`


Regardless, use of the Io_Uring transport is showing a lot of promise. Running tests against a broker with default configuration, only setting useEpoll vs useIoUring and using the following perf client commands:
epoll:
`bin/artemis perf client --warmup 60 --duration 300 --max-pending 100 --persistent --url "tcp://localhost:61616?confirmationWindowSize=20000" --consumer-url "tcp://localhost:61616" --show-latency --consumers 2 --num-destinations 30 --hdr broker-uring_client-uring_30-destinations.hdr queue://EPOLL.EPOLL`

uring:
`bin/artemis perf client --warmup 60 --duration 300 --max-pending 100 --persistent --url "tcp://localhost:61616?confirmationWindowSize=20000&useIoUring=true" --consumer-url "tcp://localhost:61616?useIoUring=true" --show-latency --consumers 2 --num-destinations 30 --hdr broker-epoll_client-epoll_30-destinations_faster.hdr queue://URING.URING`

I can see that IoUring transfers about 12% more messages in the given time and they have the following latency percentiles:
Epoll:
![epoll_latency](https://github.com/user-attachments/assets/9c81786c-7e24-4198-a876-96e898377e9e)

IoUring:
![uring_latency](https://github.com/user-attachments/assets/304ea63a-e014-4327-9306-d6681fc73523)

The tests are run on my work laptop so I'd take those results as a rough indicator and nothing more though.