### PR TITLE
ARTEMIS-5442 use Objects.equals consistently

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/ClusterNodeVerifier.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/check/ClusterNodeVerifier.java
@@ -23,6 +23,7 @@ import java.util.Date;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Consumer;
 
@@ -293,19 +294,17 @@ public class ClusterNodeVerifier implements AutoCloseable {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o)
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
-         if (o == null || getClass() != o.getClass())
+         }
+         if (!(obj instanceof TopologyItem other)) {
             return false;
+         }
 
-         TopologyItem item = (TopologyItem) o;
-
-         if (nodeID != null ? !nodeID.equals(item.nodeID) : item.nodeID != null)
-            return false;
-         if (primary != null ? !primary.equals(item.primary) : item.primary != null)
-            return false;
-         return backup != null ? backup.equals(item.backup) : item.backup == null;
+         return Objects.equals(nodeID, other.nodeID) &&
+                Objects.equals(primary, other.primary) &&
+                Objects.equals(backup, other.backup);
       }
 
       @Override

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ObjLongPair.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/ObjLongPair.java
@@ -56,18 +56,16 @@ public class ObjLongPair<A> implements Serializable {
    }
 
    @Override
-   public boolean equals(final Object other) {
-      if (other == this) {
+   public boolean equals(final Object obj) {
+      if (obj == this) {
          return true;
       }
-
-      if (other instanceof ObjLongPair == false) {
+      if (!(obj instanceof ObjLongPair other)) {
          return false;
       }
 
-      ObjLongPair<A> pother = (ObjLongPair<A>) other;
-
-      return (Objects.equals(pother.a, a)) && (pother.b == b);
+      return Objects.equals(other.a, a) &&
+             other.b == b;
    }
 
    @Override

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/Pair.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/Pair.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.api.core;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * A Pair is a holder for 2 objects.
@@ -53,19 +54,16 @@ public final class Pair<A, B> implements Serializable {
    }
 
    @Override
-   public boolean equals(final Object other) {
-      if (other == this) {
+   public boolean equals(final Object obj) {
+      if (obj == this) {
          return true;
       }
-
-      if (other instanceof Pair == false) {
+      if (!(obj instanceof Pair<?, ?> other)) {
          return false;
       }
 
-      Pair<A, B> pother = (Pair<A, B>) other;
-
-      return (pother.a == null ? a == null : pother.a.equals(a)) && (pother.b == null ? b == null : pother.b.equals(b));
-
+      return Objects.equals(other.a, a) &&
+             Objects.equals(other.b, b);
    }
 
    @Override

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/QueueConfiguration.java
@@ -847,80 +847,46 @@ public class QueueConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof QueueConfiguration other)) {
          return false;
+      }
 
-      QueueConfiguration that = (QueueConfiguration) o;
-
-      if (!Objects.equals(id, that.id))
-         return false;
-      if (!Objects.equals(name, that.name))
-         return false;
-      if (!Objects.equals(address, that.address))
-         return false;
-      if (!Objects.equals(routingType, that.routingType))
-         return false;
-      if (!Objects.equals(filterString, that.filterString))
-         return false;
-      if (!Objects.equals(durable, that.durable))
-         return false;
-      if (!Objects.equals(user, that.user))
-         return false;
-      if (!Objects.equals(maxConsumers, that.maxConsumers))
-         return false;
-      if (!Objects.equals(exclusive, that.exclusive))
-         return false;
-      if (!Objects.equals(groupRebalance, that.groupRebalance))
-         return false;
-      if (!Objects.equals(groupRebalancePauseDispatch, that.groupRebalancePauseDispatch))
-         return false;
-      if (!Objects.equals(groupBuckets, that.groupBuckets))
-         return false;
-      if (!Objects.equals(groupFirstKey, that.groupFirstKey))
-         return false;
-      if (!Objects.equals(lastValue, that.lastValue))
-         return false;
-      if (!Objects.equals(lastValueKey, that.lastValueKey))
-         return false;
-      if (!Objects.equals(nonDestructive, that.nonDestructive))
-         return false;
-      if (!Objects.equals(purgeOnNoConsumers, that.purgeOnNoConsumers))
-         return false;
-      if (!Objects.equals(enabled, that.enabled))
-         return false;
-      if (!Objects.equals(consumersBeforeDispatch, that.consumersBeforeDispatch))
-         return false;
-      if (!Objects.equals(delayBeforeDispatch, that.delayBeforeDispatch))
-         return false;
-      if (!Objects.equals(consumerPriority, that.consumerPriority))
-         return false;
-      if (!Objects.equals(autoDelete, that.autoDelete))
-         return false;
-      if (!Objects.equals(autoDeleteDelay, that.autoDeleteDelay))
-         return false;
-      if (!Objects.equals(autoDeleteMessageCount, that.autoDeleteMessageCount))
-         return false;
-      if (!Objects.equals(ringSize, that.ringSize))
-         return false;
-      if (!Objects.equals(configurationManaged, that.configurationManaged))
-         return false;
-      if (!Objects.equals(temporary, that.temporary))
-         return false;
-      if (!Objects.equals(autoCreateAddress, that.autoCreateAddress))
-         return false;
-      if (!Objects.equals(internal, that.internal))
-         return false;
-      if (!Objects.equals(_transient, that._transient))
-         return false;
-      if (!Objects.equals(autoCreated, that.autoCreated))
-         return false;
-      if (!Objects.equals(fqqn, that.fqqn))
-         return false;
-
-      return true;
+      return Objects.equals(id, other.id) &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(address, other.address) &&
+             Objects.equals(routingType, other.routingType) &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(durable, other.durable) &&
+             Objects.equals(user, other.user) &&
+             Objects.equals(maxConsumers, other.maxConsumers) &&
+             Objects.equals(exclusive, other.exclusive) &&
+             Objects.equals(groupRebalance, other.groupRebalance) &&
+             Objects.equals(groupRebalancePauseDispatch, other.groupRebalancePauseDispatch) &&
+             Objects.equals(groupBuckets, other.groupBuckets) &&
+             Objects.equals(groupFirstKey, other.groupFirstKey) &&
+             Objects.equals(lastValue, other.lastValue) &&
+             Objects.equals(lastValueKey, other.lastValueKey) &&
+             Objects.equals(nonDestructive, other.nonDestructive) &&
+             Objects.equals(purgeOnNoConsumers, other.purgeOnNoConsumers) &&
+             Objects.equals(enabled, other.enabled) &&
+             Objects.equals(consumersBeforeDispatch, other.consumersBeforeDispatch) &&
+             Objects.equals(delayBeforeDispatch, other.delayBeforeDispatch) &&
+             Objects.equals(consumerPriority, other.consumerPriority) &&
+             Objects.equals(autoDelete, other.autoDelete) &&
+             Objects.equals(autoDeleteDelay, other.autoDeleteDelay) &&
+             Objects.equals(autoDeleteMessageCount, other.autoDeleteMessageCount) &&
+             Objects.equals(ringSize, other.ringSize) &&
+             Objects.equals(configurationManaged, other.configurationManaged) &&
+             Objects.equals(temporary, other.temporary) &&
+             Objects.equals(autoCreateAddress, other.autoCreateAddress) &&
+             Objects.equals(internal, other.internal) &&
+             Objects.equals(_transient, other._transient) &&
+             Objects.equals(autoCreated, other.autoCreated) &&
+             Objects.equals(fqqn, other.fqqn);
    }
 
    public boolean isMirrorQueue() {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/api/core/SimpleString.java
@@ -387,16 +387,15 @@ public final class SimpleString implements CharSequence, Serializable, Comparabl
    }
 
    @Override
-   public boolean equals(final Object other) {
-      if (this == other) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (other instanceof SimpleString simpleString) {
-         return ByteUtil.equals(data, simpleString.data);
-      } else {
+      if (!(obj instanceof SimpleString other)) {
          return false;
       }
+
+      return ByteUtil.equals(data, other.data);
    }
 
    /**

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/json/impl/JsonValueImpl.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/json/impl/JsonValueImpl.java
@@ -103,14 +103,18 @@ public class JsonValueImpl implements JsonValue {
 
    @Override
    public boolean equals(Object obj) {
-      if (obj instanceof JsonValueImpl jsonValue) {
-         return rawValue.equals(jsonValue.getRawValue());
+      if (this == obj) {
+         return true;
       }
-      return super.equals(obj);
+      if (!(obj instanceof JsonValueImpl other)) {
+         return false;
+      }
+
+      return Objects.equals(rawValue, other.getRawValue());
    }
 
    @Override
    public int hashCode() {
-      return rawValue.hashCode();
+      return Objects.hashCode(rawValue);
    }
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/UUID.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/UUID.java
@@ -231,11 +231,11 @@ public final class UUID {
     * Checking equality of UUIDs is easy; just compare the 128-bit number.
     */
    @Override
-   public boolean equals(final Object o) {
-      if (!(o instanceof UUID)) {
+   public boolean equals(final Object obj) {
+      if (!(obj instanceof UUID)) {
          return false;
       }
-      byte[] otherId = ((UUID) o).mId;
+      byte[] otherId = ((UUID) obj).mId;
       byte[] thisId = mId;
       for (int i = 0; i < 16; ++i) {
          if (otherId[i] != thisId[i]) {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/LongHashSet.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/LongHashSet.java
@@ -464,17 +464,18 @@ public class LongHashSet extends AbstractSet<Long> implements Serializable {
     * {@inheritDoc}
     */
    @Override
-   public boolean equals(final Object other) {
-      if (other == this) {
+   public boolean equals(final Object obj) {
+      if (obj == this) {
          return true;
       }
 
-      if (other instanceof LongHashSet otherSet) {
-
-         return otherSet.containsMissingValue == containsMissingValue && otherSet.sizeOfArrayValues == sizeOfArrayValues && containsAll(otherSet);
+      if (obj instanceof LongHashSet other) {
+         return other.containsMissingValue == containsMissingValue &&
+                other.sizeOfArrayValues == sizeOfArrayValues &&
+                containsAll(other);
       }
 
-      if (!(other instanceof Set<?> c)) {
+      if (!(obj instanceof Set<?> c)) {
          return false;
       }
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/NoOpMap.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/collections/NoOpMap.java
@@ -89,8 +89,8 @@ public class NoOpMap<K, V> extends AbstractMap<K, V> {
    }
 
    @Override
-   public boolean equals(Object o) {
-      return (o instanceof Map m) && m.isEmpty();
+   public boolean equals(Object obj) {
+      return (obj instanceof Map other) && other.isEmpty();
    }
 
    @Override

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/bean/MetaBeanTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/bean/MetaBeanTest.java
@@ -266,37 +266,26 @@ public class MetaBeanTest {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o)
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
-         if (o == null || getClass() != o.getClass())
+         }
+         if (!(obj instanceof MYClass other)) {
             return false;
+         }
 
-         MYClass myClass = (MYClass) o;
-
-         if (b != myClass.b)
-            return false;
-         if (boolValue != myClass.boolValue)
-            return false;
-         if (!Objects.equals(a, myClass.a))
-            return false;
-         if (!Objects.equals(c, myClass.c))
-            return false;
-         if (!Objects.equals(d, myClass.d))
-            return false;
-         if (!Objects.equals(idCacheSize, myClass.idCacheSize))
-            return false;
-         if (!Objects.equals(simpleString, myClass.simpleString))
-            return false;
-         if (!Objects.equals(gated, myClass.gated))
-            return false;
-         if (!Objects.equals(longValue, myClass.longValue))
-            return false;
-         if (!Objects.equals(doubleValue, myClass.doubleValue))
-            return false;
-         if (!Objects.equals(floatValue, myClass.floatValue))
-            return false;
-         return myEnum == myClass.myEnum;
+         return Objects.equals(a, other.a) &&
+                b == other.b &&
+                boolValue == other.boolValue &&
+                Objects.equals(c, other.c) &&
+                Objects.equals(d, other.d) &&
+                Objects.equals(idCacheSize, other.idCacheSize) &&
+                Objects.equals(simpleString, other.simpleString) &&
+                Objects.equals(gated, other.gated) &&
+                Objects.equals(longValue, other.longValue) &&
+                Objects.equals(doubleValue, other.doubleValue) &&
+                Objects.equals(floatValue, other.floatValue) &&
+                myEnum == other.myEnum;
       }
 
       @Override

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/collections/PriorityCollectionTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/collections/PriorityCollectionTest.java
@@ -242,11 +242,15 @@ public class PriorityCollectionTest {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) return true;
-         if (o == null || getClass() != o.getClass()) return false;
-         TestPriorityAware that = (TestPriorityAware) o;
-         return value == that.value;
+      public boolean equals(Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof TestPriorityAware other)) {
+            return false;
+         }
+
+         return value == other.value;
       }
 
       @Override
@@ -275,12 +279,16 @@ public class PriorityCollectionTest {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) return true;
-         if (o == null || getClass() != o.getClass()) return false;
-         TestPriority that = (TestPriority) o;
-         return priority == that.priority &&
-                 Objects.equals(name, that.name);
+      public boolean equals(Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof TestPriority other)) {
+            return false;
+         }
+
+         return priority == other.priority &&
+                Objects.equals(name, other.name);
       }
 
       @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/BroadcastGroupConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/BroadcastGroupConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.api.core;
 
 import java.io.Serializable;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 
@@ -89,30 +90,15 @@ public final class BroadcastGroupConfiguration implements Serializable {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof BroadcastGroupConfiguration other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      BroadcastGroupConfiguration other = (BroadcastGroupConfiguration) obj;
-      if (broadcastPeriod != other.broadcastPeriod)
-         return false;
-      if (connectorInfos == null) {
-         if (other.connectorInfos != null)
-            return false;
-      } else if (!connectorInfos.equals(other.connectorInfos))
-         return false;
-      if (endpointFactory == null) {
-         if (other.endpointFactory != null)
-            return false;
-      } else if (!endpointFactory.equals(other.endpointFactory))
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      return true;
+      }
+      return broadcastPeriod == other.broadcastPeriod &&
+             Objects.equals(connectorInfos, other.connectorInfos) &&
+             Objects.equals(endpointFactory, other.endpointFactory) &&
+             Objects.equals(name, other.name);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/DiscoveryGroupConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/DiscoveryGroupConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.api.core;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
@@ -96,22 +97,17 @@ public final class DiscoveryGroupConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof DiscoveryGroupConfiguration other)) {
          return false;
+      }
 
-      DiscoveryGroupConfiguration that = (DiscoveryGroupConfiguration) o;
-
-      if (discoveryInitialWaitTimeout != that.discoveryInitialWaitTimeout)
-         return false;
-      if (refreshTimeout != that.refreshTimeout)
-         return false;
-      if (name != null ? !name.equals(that.name) : that.name != null)
-         return false;
-
-      return true;
+      return discoveryInitialWaitTimeout == other.discoveryInitialWaitTimeout &&
+             refreshTimeout == other.refreshTimeout &&
+             Objects.equals(name, other.name);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/TransportConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/TransportConfiguration.java
@@ -206,28 +206,21 @@ public class TransportConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
-         return false;
-
-      TransportConfiguration that = (TransportConfiguration) o;
-
-      if (!isSameParams(that)) {
+      }
+      if (!(obj instanceof TransportConfiguration other)) {
          return false;
       }
 
-      if (!Objects.equals(name, that.name)) {
-         return false;
-      }
-
-      // Empty and null extraProps maps are equivalent so the condition to check if two extraProps maps are not equal is:
-      if ((extraProps != that.extraProps) && (extraProps != null || !that.extraProps.isEmpty()) && (that.extraProps != null || !extraProps.isEmpty()) && (extraProps == null || that.extraProps == null || !extraProps.equals(that.extraProps))) {
-         return false;
-      }
-
-      return true;
+      return isSameParams(other) &&
+             Objects.equals(name, other.name) &&
+             // Empty and null extraProps maps are equivalent so the condition to check if two extraProps maps are not equal is:
+             !((extraProps != other.extraProps) &&
+               (extraProps != null || !other.extraProps.isEmpty()) &&
+               (other.extraProps != null || !extraProps.isEmpty()) &&
+               (extraProps == null || other.extraProps == null || !extraProps.equals(other.extraProps)));
    }
 
    public boolean isSameParams(TransportConfiguration that) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/UDPBroadcastEndpointFactory.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/UDPBroadcastEndpointFactory.java
@@ -24,6 +24,7 @@ import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.net.MulticastSocket;
+import java.util.Objects;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.core.client.ActiveMQClientLogger;
@@ -289,20 +290,14 @@ public final class UDPBroadcastEndpointFactory implements BroadcastEndpointFacto
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof UDPBroadcastEndpointFactory other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      UDPBroadcastEndpointFactory other = (UDPBroadcastEndpointFactory) obj;
-      if (groupAddress == null) {
-         if (other.groupAddress != null)
-            return false;
-      } else if (!groupAddress.equals(other.groupAddress))
-         return false;
-      if (groupPort != other.groupPort)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(groupAddress, other.groupAddress) &&
+             groupPort == other.groupPort;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/TopologyMemberImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/TopologyMemberImpl.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.client.impl;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -157,25 +158,20 @@ public final class TopologyMemberImpl implements TopologyMember {
       return "TopologyMember[id=" + nodeId + ", connector=" + connector + ", backupGroupName=" + backupGroupName + ", scaleDownGroupName=" + scaleDownGroupName + "]";
    }
 
-
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof TopologyMemberImpl other)) {
          return false;
+      }
 
-      TopologyMemberImpl that = (TopologyMemberImpl) o;
-
-      // note the uniqueEventId is not park of the equals and hashmap key
-
-      if (connector != null ? !connector.equals(that.connector) : that.connector != null)
-         return false;
-      if (backupGroupName != null ? !backupGroupName.equals(that.backupGroupName) : that.backupGroupName != null)
-         return false;
-      if (scaleDownGroupName != null ? !scaleDownGroupName.equals(that.scaleDownGroupName) : that.scaleDownGroupName != null)
-         return false;
-      return nodeId != null ? nodeId.equals(that.nodeId) : that.nodeId == null;
+      // note the uniqueEventId is not part of the equals and hashmap key
+      return Objects.equals(connector, other.connector) &&
+             Objects.equals(backupGroupName, other.backupGroupName) &&
+             Objects.equals(scaleDownGroupName, other.scaleDownGroupName) &&
+             Objects.equals(nodeId, other.nodeId);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/FederationConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/FederationConfiguration.java
@@ -164,11 +164,16 @@ public class FederationConfiguration implements Serializable {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) return true;
-         if (!(o instanceof Credentials that)) return false;
-         return Objects.equals(user, that.user) &&
-               Objects.equals(password, that.password);
+      public boolean equals(Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof Credentials other)) {
+            return false;
+         }
+
+         return Objects.equals(user, other.user) &&
+                Objects.equals(password, other.password);
       }
 
       @Override
@@ -188,14 +193,19 @@ public class FederationConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederationConfiguration that)) return false;
-      return Objects.equals(name, that.name) &&
-           Objects.equals(credentials, that.credentials) &&
-           Objects.equals(upstreamConfigurations, that.upstreamConfigurations) &&
-           Objects.equals(federationPolicyMap, that.federationPolicyMap) &&
-           Objects.equals(transformerConfigurationMap, that.transformerConfigurationMap);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederationConfiguration other)) {
+         return false;
+      }
+
+      return Objects.equals(name, other.name) &&
+             Objects.equals(credentials, other.credentials) &&
+             Objects.equals(upstreamConfigurations, other.upstreamConfigurations) &&
+             Objects.equals(federationPolicyMap, other.federationPolicyMap) &&
+             Objects.equals(transformerConfigurationMap, other.transformerConfigurationMap);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/TransformerConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/TransformerConfiguration.java
@@ -26,6 +26,7 @@ import java.io.Serializable;
 import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public final class TransformerConfiguration implements Serializable {
 
@@ -126,24 +127,15 @@ public final class TransformerConfiguration implements Serializable {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof TransformerConfiguration other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      TransformerConfiguration other = (TransformerConfiguration) obj;
-      if (className == null) {
-         if (other.className != null)
-            return false;
-      } else if (!className.equals(other.className))
-         return false;
-      if (properties == null) {
-         if (other.properties != null)
-            return false;
-      } else if (!properties.equals(other.properties))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(className, other.className) &&
+             Objects.equals(properties, other.properties);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationAddressPolicyConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationAddressPolicyConfiguration.java
@@ -196,10 +196,15 @@ public class FederationAddressPolicyConfiguration implements FederationPolicy<Fe
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) return true;
-         if (!(o instanceof Matcher matcher)) return false;
-         return Objects.equals(addressMatch, matcher.addressMatch);
+      public boolean equals(Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof Matcher other)) {
+            return false;
+         }
+
+         return Objects.equals(addressMatch, other.addressMatch);
       }
 
       @Override
@@ -218,17 +223,22 @@ public class FederationAddressPolicyConfiguration implements FederationPolicy<Fe
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederationAddressPolicyConfiguration that)) return false;
-      return maxHops == that.maxHops &&
-            Objects.equals(name, that.name) &&
-            Objects.equals(includes, that.includes) &&
-            Objects.equals(excludes, that.excludes) &&
-            Objects.equals(autoDelete, that.autoDelete) &&
-            Objects.equals(autoDeleteDelay, that.autoDeleteDelay) &&
-            Objects.equals(autoDeleteMessageCount, that.autoDeleteMessageCount) &&
-            Objects.equals(transformerRef, that.transformerRef);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederationAddressPolicyConfiguration other)) {
+         return false;
+      }
+
+      return maxHops == other.maxHops &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(includes, other.includes) &&
+             Objects.equals(excludes, other.excludes) &&
+             Objects.equals(autoDelete, other.autoDelete) &&
+             Objects.equals(autoDeleteDelay, other.autoDeleteDelay) &&
+             Objects.equals(autoDeleteMessageCount, other.autoDeleteMessageCount) &&
+             Objects.equals(transformerRef, other.transformerRef);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationConnectionConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationConnectionConfiguration.java
@@ -201,31 +201,31 @@ public class FederationConnectionConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof FederationConnectionConfiguration other)) {
          return false;
       }
-      FederationConnectionConfiguration that = (FederationConnectionConfiguration) o;
-      return clientFailureCheckPeriod == that.clientFailureCheckPeriod &&
-          connectionTTL == that.connectionTTL &&
-          retryInterval == that.retryInterval &&
-          Double.compare(that.retryIntervalMultiplier, retryIntervalMultiplier) == 0 &&
-          maxRetryInterval == that.maxRetryInterval &&
-          initialConnectAttempts == that.initialConnectAttempts &&
-          reconnectAttempts == that.reconnectAttempts &&
-          callTimeout == that.callTimeout &&
-          callFailoverTimeout == that.callFailoverTimeout &&
-          isHA == that.isHA &&
-          priorityAdjustment == that.priorityAdjustment &&
-          circuitBreakerTimeout == that.circuitBreakerTimeout &&
-          shareConnection == that.shareConnection &&
-          Objects.equals(discoveryGroupName, that.discoveryGroupName) &&
-          Objects.equals(staticConnectors, that.staticConnectors) &&
-          Objects.equals(username, that.username) &&
-          Objects.equals(password, that.password);
+
+      return clientFailureCheckPeriod == other.clientFailureCheckPeriod &&
+             connectionTTL == other.connectionTTL &&
+             retryInterval == other.retryInterval &&
+             Double.compare(other.retryIntervalMultiplier, retryIntervalMultiplier) == 0 &&
+             maxRetryInterval == other.maxRetryInterval &&
+             initialConnectAttempts == other.initialConnectAttempts &&
+             reconnectAttempts == other.reconnectAttempts &&
+             callTimeout == other.callTimeout &&
+             callFailoverTimeout == other.callFailoverTimeout &&
+             isHA == other.isHA &&
+             priorityAdjustment == other.priorityAdjustment &&
+             circuitBreakerTimeout == other.circuitBreakerTimeout &&
+             shareConnection == other.shareConnection &&
+             Objects.equals(discoveryGroupName, other.discoveryGroupName) &&
+             Objects.equals(staticConnectors, other.staticConnectors) &&
+             Objects.equals(username, other.username) &&
+             Objects.equals(password, other.password);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationDownstreamConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationDownstreamConfiguration.java
@@ -83,19 +83,19 @@ public class FederationDownstreamConfiguration extends FederationStreamConfigura
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof FederationDownstreamConfiguration other)) {
          return false;
       }
-      if (!super.equals(o)) {
+      if (!super.equals(obj)) {
          return false;
       }
-      FederationDownstreamConfiguration that = (FederationDownstreamConfiguration) o;
-      return Objects.equals(upstreamConfigurationRef, that.upstreamConfigurationRef) &&
-         Objects.equals(upstreamConfiguration, that.upstreamConfiguration);
+
+      return Objects.equals(upstreamConfigurationRef, other.upstreamConfigurationRef) &&
+             Objects.equals(upstreamConfiguration, other.upstreamConfiguration);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationPolicySet.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationPolicySet.java
@@ -62,11 +62,16 @@ public class FederationPolicySet implements FederationPolicy<FederationPolicySet
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederationPolicySet that)) return false;
-      return Objects.equals(name, that.name) &&
-            Objects.equals(policyRefs, that.policyRefs);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederationPolicySet other)) {
+         return false;
+      }
+
+      return Objects.equals(name, other.name) &&
+             Objects.equals(policyRefs, other.policyRefs);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationQueuePolicyConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationQueuePolicyConfiguration.java
@@ -167,11 +167,16 @@ public class FederationQueuePolicyConfiguration implements FederationPolicy<Fede
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) return true;
-         if (!(o instanceof Matcher matcher)) return false;
-         return Objects.equals(queueMatch, matcher.queueMatch) &&
-               Objects.equals(addressMatch, matcher.addressMatch);
+      public boolean equals(Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof Matcher other)) {
+            return false;
+         }
+
+         return Objects.equals(queueMatch, other.queueMatch) &&
+                Objects.equals(addressMatch, other.addressMatch);
       }
 
       @Override
@@ -191,15 +196,20 @@ public class FederationQueuePolicyConfiguration implements FederationPolicy<Fede
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederationQueuePolicyConfiguration that)) return false;
-      return includeFederated == that.includeFederated &&
-            Objects.equals(name, that.name) &&
-            Objects.equals(includes, that.includes) &&
-            Objects.equals(excludes, that.excludes) &&
-            Objects.equals(priorityAdjustment, that.priorityAdjustment) &&
-            Objects.equals(transformerRef, that.transformerRef);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederationQueuePolicyConfiguration other)) {
+         return false;
+      }
+
+      return includeFederated == other.includeFederated &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(includes, other.includes) &&
+             Objects.equals(excludes, other.excludes) &&
+             Objects.equals(priorityAdjustment, other.priorityAdjustment) &&
+             Objects.equals(transformerRef, other.transformerRef);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationStreamConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationStreamConfiguration.java
@@ -67,12 +67,17 @@ public abstract class FederationStreamConfiguration <T extends FederationStreamC
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (!(o instanceof FederationStreamConfiguration that))
+      }
+      if (!(obj instanceof FederationStreamConfiguration other)) {
          return false;
-      return Objects.equals(name, that.name) && Objects.equals(connectionConfiguration, that.connectionConfiguration) && Objects.equals(policyRefs, that.policyRefs);
+      }
+
+      return Objects.equals(name, other.name) &&
+             Objects.equals(connectionConfiguration, other.connectionConfiguration) &&
+             Objects.equals(policyRefs, other.policyRefs);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationTransformerConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/config/federation/FederationTransformerConfiguration.java
@@ -50,11 +50,16 @@ public class FederationTransformerConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederationTransformerConfiguration that)) return false;
-      return Objects.equals(name, that.name) &&
-            Objects.equals(transformerConfiguration, that.transformerConfiguration);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederationTransformerConfiguration other)) {
+         return false;
+      }
+
+      return Objects.equals(name, other.name) &&
+             Objects.equals(transformerConfiguration, other.transformerConfiguration);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQConsumerContext.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/ActiveMQConsumerContext.java
@@ -32,18 +32,15 @@ public class ActiveMQConsumerContext extends ConsumerContext {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof ActiveMQConsumerContext other)) {
          return false;
+      }
 
-      ActiveMQConsumerContext that = (ActiveMQConsumerContext) o;
-
-      if (id != that.id)
-         return false;
-
-      return true;
+      return id == other.id;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/PacketImpl.java
@@ -466,7 +466,10 @@ public class PacketImpl implements Packet {
       if (!(obj instanceof PacketImpl other)) {
          return false;
       }
-      return (channelID == other.channelID) && (size == other.size) && (type != other.type);
+
+      return channelID == other.channelID &&
+             size == other.size &&
+             type != other.type;
    }
 
    private int stringEncodeSize(final String str) {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ActiveMQExceptionMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ActiveMQExceptionMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ActiveMQExceptionType;
@@ -83,13 +85,6 @@ public class ActiveMQExceptionMessage extends PacketImpl {
       if (!(obj instanceof ActiveMQExceptionMessage other)) {
          return false;
       }
-      if (exception == null) {
-         if (other.exception != null) {
-            return false;
-         }
-      } else if (!exception.equals(other.exception)) {
-         return false;
-      }
-      return true;
+      return Objects.equals(exception, other.exception);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ActiveMQExceptionMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ActiveMQExceptionMessage_V2.java
@@ -83,9 +83,6 @@ public class ActiveMQExceptionMessage_V2 extends ActiveMQExceptionMessage {
       if (!(obj instanceof ActiveMQExceptionMessage_V2 other)) {
          return false;
       }
-      if (correlationID != other.correlationID) {
-         return false;
-      }
-      return true;
+      return correlationID == other.correlationID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -157,26 +159,10 @@ public class ClusterTopologyChangeMessage extends PacketImpl {
       if (!(obj instanceof ClusterTopologyChangeMessage other)) {
          return false;
       }
-      if (exit != other.exit) {
-         return false;
-      }
-      if (last != other.last) {
-         return false;
-      }
-      if (nodeID == null) {
-         if (other.nodeID != null) {
-            return false;
-         }
-      } else if (!nodeID.equals(other.nodeID)) {
-         return false;
-      }
-      if (pair == null) {
-         if (other.pair != null) {
-            return false;
-         }
-      } else if (!pair.equals(other.pair)) {
-         return false;
-      }
-      return true;
+
+      return exit == other.exit &&
+             last == other.last &&
+             Objects.equals(nodeID, other.nodeID) &&
+             Objects.equals(pair, other.pair);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V2.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -156,16 +158,8 @@ public class ClusterTopologyChangeMessage_V2 extends ClusterTopologyChangeMessag
       if (!(obj instanceof ClusterTopologyChangeMessage_V2 other)) {
          return false;
       }
-      if (uniqueEventID != other.uniqueEventID) {
-         return false;
-      }
-      if (backupGroupName == null) {
-         if (other.backupGroupName != null) {
-            return false;
-         }
-      } else if (!backupGroupName.equals(other.backupGroupName)) {
-         return false;
-      }
-      return true;
+
+      return uniqueEventID == other.uniqueEventID &&
+             Objects.equals(backupGroupName, other.backupGroupName);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ClusterTopologyChangeMessage_V3.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
@@ -113,13 +115,7 @@ public class ClusterTopologyChangeMessage_V3 extends ClusterTopologyChangeMessag
       if (!(obj instanceof ClusterTopologyChangeMessage_V3 other)) {
          return false;
       }
-      if (scaleDownGroupName == null) {
-         if (other.scaleDownGroupName != null) {
-            return false;
-         }
-      } else if (!scaleDownGroupName.equals(other.scaleDownGroupName)) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(scaleDownGroupName, other.scaleDownGroupName);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateAddressMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateAddressMessage.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.EnumSet;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -119,26 +120,19 @@ public class CreateAddressMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateAddressMessage other))
+      }
+      if (!(obj instanceof CreateAddressMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (routingTypes == null) {
-         if (other.routingTypes != null)
-            return false;
-      } else if (!routingTypes.equals(other.routingTypes))
-         return false;
-      if (autoCreated != other.autoCreated)
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address) &&
+             Objects.equals(routingTypes, other.routingTypes) &&
+             autoCreated == other.autoCreated &&
+             requiresResponse == other.requiresResponse;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateProducerMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateProducerMessage.java
@@ -68,12 +68,19 @@ public class CreateProducerMessage  extends PacketImpl {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
-      CreateProducerMessage that = (CreateProducerMessage) o;
-      return Objects.equals(id, that.id) && Objects.equals(address, that.address);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof CreateProducerMessage other)) {
+         return false;
+      }
+      if (!super.equals(obj)) {
+         return false;
+      }
+
+      return Objects.equals(id, other.id) &&
+             Objects.equals(address, other.address);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -154,33 +156,21 @@ public class CreateQueueMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateQueueMessage other))
+      }
+      if (!(obj instanceof CreateQueueMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (durable != other.durable)
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      if (temporary != other.temporary)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address) &&
+             durable == other.durable &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(queueName, other.queueName) &&
+             requiresResponse == other.requiresResponse &&
+             temporary == other.temporary;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateQueueMessage_V2.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.QueueAttributes;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -480,98 +482,34 @@ public class CreateQueueMessage_V2 extends CreateQueueMessage {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateQueueMessage_V2 other))
+      }
+      if (!(obj instanceof CreateQueueMessage_V2 other)) {
          return false;
-      if (autoCreated != other.autoCreated)
-         return false;
-      if (maxConsumers != other.maxConsumers)
-         return false;
-      if (purgeOnNoConsumers != other.purgeOnNoConsumers)
-         return false;
-      if (exclusive == null) {
-         if (other.exclusive != null)
-            return false;
-      } else if (!exclusive.equals(other.exclusive))
-         return false;
-      if (groupRebalance == null) {
-         if (other.groupRebalance != null)
-            return false;
-      } else if (!groupRebalance.equals(other.groupRebalance))
-         return false;
-      if (groupRebalancePauseDispatch == null) {
-         if (other.groupRebalancePauseDispatch != null)
-            return false;
-      } else if (!groupRebalancePauseDispatch.equals(other.groupRebalancePauseDispatch))
-         return false;
-      if (groupBuckets == null) {
-         if (other.groupBuckets != null)
-            return false;
-      } else if (!groupBuckets.equals(other.groupBuckets))
-         return false;
-      if (groupFirstKey == null) {
-         if (other.groupFirstKey != null)
-            return false;
-      } else if (!groupFirstKey.equals(other.groupFirstKey))
-         return false;
-      if (lastValue == null) {
-         if (other.lastValue != null)
-            return false;
-      } else if (!lastValue.equals(other.lastValue))
-         return false;
-      if (lastValueKey == null) {
-         if (other.lastValueKey != null)
-            return false;
-      } else if (!lastValueKey.equals(other.lastValueKey))
-         return false;
-      if (nonDestructive == null) {
-         if (other.nonDestructive != null)
-            return false;
-      } else if (!nonDestructive.equals(other.nonDestructive))
-         return false;
-      if (consumersBeforeDispatch == null) {
-         if (other.consumersBeforeDispatch != null)
-            return false;
-      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch))
-         return false;
-      if (delayBeforeDispatch == null) {
-         if (other.delayBeforeDispatch != null)
-            return false;
-      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch))
-         return false;
-      if (autoDelete == null) {
-         if (other.autoDelete != null)
-            return false;
-      } else if (!autoDelete.equals(other.autoDelete))
-         return false;
-      if (autoDeleteDelay == null) {
-         if (other.autoDeleteDelay != null)
-            return false;
-      } else if (!autoDeleteDelay.equals(other.autoDeleteDelay))
-         return false;
-      if (autoDeleteMessageCount == null) {
-         if (other.autoDeleteMessageCount != null)
-            return false;
-      } else if (!autoDeleteMessageCount.equals(other.autoDeleteMessageCount))
-         return false;
-      if (ringSize == null) {
-         if (other.ringSize != null)
-            return false;
-      } else if (!ringSize.equals(other.ringSize))
-         return false;
-      if (enabled == null) {
-         if (other.enabled != null)
-            return false;
-      } else if (!enabled.equals(other.enabled))
-         return false;
-      if (routingType == null) {
-         if (other.routingType != null)
-            return false;
-      } else if (!routingType.equals(other.routingType))
-         return false;
-      return true;
+      }
+
+      return autoCreated == other.autoCreated &&
+             maxConsumers == other.maxConsumers &&
+             purgeOnNoConsumers == other.purgeOnNoConsumers &&
+             Objects.equals(exclusive, other.exclusive) &&
+             Objects.equals(groupRebalance, other.groupRebalance) &&
+             Objects.equals(groupRebalancePauseDispatch, other.groupRebalancePauseDispatch) &&
+             Objects.equals(groupBuckets, other.groupBuckets) &&
+             Objects.equals(groupFirstKey, other.groupFirstKey) &&
+             Objects.equals(lastValue, other.lastValue) &&
+             Objects.equals(lastValueKey, other.lastValueKey) &&
+             Objects.equals(nonDestructive, other.nonDestructive) &&
+             Objects.equals(consumersBeforeDispatch, other.consumersBeforeDispatch) &&
+             Objects.equals(delayBeforeDispatch, other.delayBeforeDispatch) &&
+             Objects.equals(autoDelete, other.autoDelete) &&
+             Objects.equals(autoDeleteDelay, other.autoDeleteDelay) &&
+             Objects.equals(autoDeleteMessageCount, other.autoDeleteMessageCount) &&
+             Objects.equals(ringSize, other.ringSize) &&
+             Objects.equals(enabled, other.enabled) &&
+             Objects.equals(routingType, other.routingType);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
@@ -232,48 +234,27 @@ public class CreateSessionMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateSessionMessage other))
+      }
+      if (!(obj instanceof CreateSessionMessage other)) {
          return false;
-      if (autoCommitAcks != other.autoCommitAcks)
-         return false;
-      if (autoCommitSends != other.autoCommitSends)
-         return false;
-      if (defaultAddress == null) {
-         if (other.defaultAddress != null)
-            return false;
-      } else if (!defaultAddress.equals(other.defaultAddress))
-         return false;
-      if (minLargeMessageSize != other.minLargeMessageSize)
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      if (password == null) {
-         if (other.password != null)
-            return false;
-      } else if (!password.equals(other.password))
-         return false;
-      if (preAcknowledge != other.preAcknowledge)
-         return false;
-      if (sessionChannelID != other.sessionChannelID)
-         return false;
-      if (username == null) {
-         if (other.username != null)
-            return false;
-      } else if (!username.equals(other.username))
-         return false;
-      if (version != other.version)
-         return false;
-      if (windowSize != other.windowSize)
-         return false;
-      if (xa != other.xa)
-         return false;
-      return true;
+      }
+
+      return autoCommitAcks == other.autoCommitAcks &&
+             autoCommitSends == other.autoCommitSends &&
+             Objects.equals(defaultAddress, other.defaultAddress) &&
+             minLargeMessageSize == other.minLargeMessageSize &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(password, other.password) &&
+             preAcknowledge == other.preAcknowledge &&
+             sessionChannelID == other.sessionChannelID &&
+             Objects.equals(username, other.username) &&
+             version == other.version &&
+             windowSize == other.windowSize &&
+             xa == other.xa;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionMessage_V2.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 
 public class CreateSessionMessage_V2 extends CreateSessionMessage {
@@ -89,11 +91,7 @@ public class CreateSessionMessage_V2 extends CreateSessionMessage {
       if (!(obj instanceof CreateSessionMessage_V2 other)) {
          return false;
       }
-      if (clientID == null) {
-         if (other.clientID != null)
-            return false;
-      } else if (!clientID.equals(other.clientID))
-         return false;
-      return true;
+
+      return Objects.equals(clientID, other.clientID);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSessionResponseMessage.java
@@ -67,15 +67,17 @@ public class CreateSessionResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateSessionResponseMessage other))
+      }
+      if (!(obj instanceof CreateSessionResponseMessage other)) {
          return false;
-      if (serverVersion != other.serverVersion)
-         return false;
-      return true;
+      }
+
+      return serverVersion == other.serverVersion;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSharedQueueMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSharedQueueMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -130,31 +132,20 @@ public class CreateSharedQueueMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateSharedQueueMessage other))
+      }
+      if (!(obj instanceof CreateSharedQueueMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      if (durable != other.durable)
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return durable == other.durable &&
+             requiresResponse == other.requiresResponse &&
+             Objects.equals(address, other.address) &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(queueName, other.queueName);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSharedQueueMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/CreateSharedQueueMessage_V2.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -421,118 +423,38 @@ public class CreateSharedQueueMessage_V2 extends CreateSharedQueueMessage {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof CreateSharedQueueMessage_V2 other))
+      }
+      if (!(obj instanceof CreateSharedQueueMessage_V2 other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      if (durable != other.durable)
-         return false;
-      if (routingType != other.routingType)
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      if (maxConsumers == null) {
-         if (other.maxConsumers != null)
-            return false;
-      } else if (!maxConsumers.equals(other.maxConsumers))
-         return false;
-      if (purgeOnNoConsumers == null) {
-         if (other.purgeOnNoConsumers != null)
-            return false;
-      } else if (!purgeOnNoConsumers.equals(other.purgeOnNoConsumers))
-         return false;
-      if (exclusive == null) {
-         if (other.exclusive != null)
-            return false;
-      } else if (!exclusive.equals(other.exclusive))
-         return false;
-      if (groupRebalance == null) {
-         if (other.groupRebalance != null)
-            return false;
-      } else if (!groupRebalance.equals(other.groupRebalance))
-         return false;
-      if (groupRebalancePauseDispatch == null) {
-         if (other.groupRebalancePauseDispatch != null)
-            return false;
-      } else if (!groupRebalancePauseDispatch.equals(other.groupRebalancePauseDispatch))
-         return false;
-      if (groupBuckets == null) {
-         if (other.groupBuckets != null)
-            return false;
-      } else if (!groupBuckets.equals(other.groupBuckets))
-         return false;
-      if (groupFirstKey == null) {
-         if (other.groupFirstKey != null)
-            return false;
-      } else if (!groupFirstKey.equals(other.groupFirstKey))
-         return false;
-      if (lastValue == null) {
-         if (other.lastValue != null)
-            return false;
-      } else if (!lastValue.equals(other.lastValue))
-         return false;
-      if (lastValueKey == null) {
-         if (other.lastValueKey != null)
-            return false;
-      } else if (!lastValueKey.equals(other.lastValueKey))
-         return false;
-      if (nonDestructive == null) {
-         if (other.nonDestructive != null)
-            return false;
-      } else if (!nonDestructive.equals(other.nonDestructive))
-         return false;
-      if (consumersBeforeDispatch == null) {
-         if (other.consumersBeforeDispatch != null)
-            return false;
-      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch))
-         return false;
-      if (delayBeforeDispatch == null) {
-         if (other.delayBeforeDispatch != null)
-            return false;
-      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch))
-         return false;
-      if (autoDelete == null) {
-         if (other.autoDelete != null)
-            return false;
-      } else if (!autoDelete.equals(other.autoDelete))
-         return false;
-      if (autoDeleteDelay == null) {
-         if (other.autoDeleteDelay != null)
-            return false;
-      } else if (!autoDeleteDelay.equals(other.autoDeleteDelay))
-         return false;
-      if (autoDeleteMessageCount == null) {
-         if (other.autoDeleteMessageCount != null)
-            return false;
-      } else if (!autoDeleteMessageCount.equals(other.autoDeleteMessageCount))
-         return false;
-      if (ringSize == null) {
-         if (other.ringSize != null)
-            return false;
-      } else if (!ringSize.equals(other.ringSize))
-         return false;
-      if (enabled == null) {
-         if (other.enabled != null)
-            return false;
-      } else if (!enabled.equals(other.enabled))
-         return false;
-      return true;
+      }
+
+      return durable == other.durable &&
+             requiresResponse == other.requiresResponse &&
+             routingType == other.routingType &&
+             Objects.equals(address, other.address) &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(queueName, other.queueName) &&
+             Objects.equals(maxConsumers, other.maxConsumers) &&
+             Objects.equals(purgeOnNoConsumers, other.purgeOnNoConsumers) &&
+             Objects.equals(exclusive, other.exclusive) &&
+             Objects.equals(groupRebalance, other.groupRebalance) &&
+             Objects.equals(groupRebalancePauseDispatch, other.groupRebalancePauseDispatch) &&
+             Objects.equals(groupBuckets, other.groupBuckets) &&
+             Objects.equals(groupFirstKey, other.groupFirstKey) &&
+             Objects.equals(lastValue, other.lastValue) &&
+             Objects.equals(lastValueKey, other.lastValueKey) &&
+             Objects.equals(nonDestructive, other.nonDestructive) &&
+             Objects.equals(consumersBeforeDispatch, other.consumersBeforeDispatch) &&
+             Objects.equals(delayBeforeDispatch, other.delayBeforeDispatch) &&
+             Objects.equals(autoDelete, other.autoDelete) &&
+             Objects.equals(autoDeleteDelay, other.autoDeleteDelay) &&
+             Objects.equals(autoDeleteMessageCount, other.autoDeleteMessageCount) &&
+             Objects.equals(ringSize, other.ringSize) &&
+             Objects.equals(enabled, other.enabled);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -85,13 +87,7 @@ public class DisconnectMessage extends PacketImpl {
       if (!(obj instanceof DisconnectMessage other)) {
          return false;
       }
-      if (nodeID == null) {
-         if (other.nodeID != null) {
-            return false;
-         }
-      } else if (!nodeID.equals(other.nodeID)) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(nodeID, other.nodeID);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage_V2.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 
@@ -78,13 +80,7 @@ public class DisconnectMessage_V2 extends DisconnectMessage {
       if (!(obj instanceof DisconnectMessage_V2 other)) {
          return false;
       }
-      if (scaleDownNodeID == null) {
-         if (other.scaleDownNodeID != null) {
-            return false;
-         }
-      } else if (!scaleDownNodeID.equals(other.scaleDownNodeID)) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(scaleDownNodeID, other.scaleDownNodeID);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/DisconnectMessage_V3.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.DisconnectReason;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -116,18 +118,8 @@ public class DisconnectMessage_V3 extends DisconnectMessage {
       if (!(obj instanceof DisconnectMessage_V3 other)) {
          return false;
       }
-      if (reason == null) {
-         if (other.reason != null)
-            return false;
-      } else if (!reason.equals(other.reason))
-         return false;
-      if (targetNodeID == null) {
-         if (other.targetNodeID != null) {
-            return false;
-         }
-      } else if (!targetNodeID.equals(other.targetNodeID)) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(reason, other.reason) &&
+             Objects.equals(targetNodeID, other.targetNodeID);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/NullResponseMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/NullResponseMessage_V2.java
@@ -92,10 +92,8 @@ public class NullResponseMessage_V2 extends NullResponseMessage {
       if (!(obj instanceof NullResponseMessage_V2 other)) {
          return false;
       }
-      if (correlationID != other.correlationID) {
-         return false;
-      }
-      return true;
+
+      return correlationID == other.correlationID;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/PacketsConfirmedMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/PacketsConfirmedMessage.java
@@ -76,9 +76,7 @@ public class PacketsConfirmedMessage extends PacketImpl {
       if (!(obj instanceof PacketsConfirmedMessage other)) {
          return false;
       }
-      if (commandID != other.commandID) {
-         return false;
-      }
-      return true;
+
+      return commandID == other.commandID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/Ping.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/Ping.java
@@ -88,9 +88,7 @@ public final class Ping extends PacketImpl {
       if (!(obj instanceof Ping other)) {
          return false;
       }
-      if (connectionTTL != other.connectionTTL) {
-         return false;
-      }
-      return true;
+
+      return connectionTTL == other.connectionTTL;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReattachSessionMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReattachSessionMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
@@ -81,19 +83,17 @@ public class ReattachSessionMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReattachSessionMessage other))
+      }
+      if (!(obj instanceof ReattachSessionMessage other)) {
          return false;
-      if (lastConfirmedCommandID != other.lastConfirmedCommandID)
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      return true;
+      }
+
+      return lastConfirmedCommandID == other.lastConfirmedCommandID &&
+             Objects.equals(name, other.name);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReattachSessionResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReattachSessionResponseMessage.java
@@ -86,16 +86,17 @@ public class ReattachSessionResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReattachSessionResponseMessage other))
+      }
+      if (!(obj instanceof ReattachSessionResponseMessage other)) {
          return false;
-      if (lastConfirmedCommandID != other.lastConfirmedCommandID)
-         return false;
-      if (reattached != other.reattached)
-         return false;
-      return true;
+      }
+
+      return lastConfirmedCommandID == other.lastConfirmedCommandID &&
+             reattached == other.reattached;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/RemoveProducerMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/RemoveProducerMessage.java
@@ -53,12 +53,18 @@ public class RemoveProducerMessage extends PacketImpl {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
-      RemoveProducerMessage that = (RemoveProducerMessage) o;
-      return Objects.equals(id, that.id);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!super.equals(obj)) {
+         return false;
+      }
+      if (!(obj instanceof RemoveProducerMessage other)) {
+         return false;
+      }
+
+      return Objects.equals(id, other.id);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/RollbackMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/RollbackMessage.java
@@ -68,14 +68,16 @@ public class RollbackMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof RollbackMessage other))
+      }
+      if (!(obj instanceof RollbackMessage other)) {
          return false;
-      if (considerLastMessageAsDelivered != other.considerLastMessageAsDelivered)
-         return false;
-      return true;
+      }
+
+      return considerLastMessageAsDelivered == other.considerLastMessageAsDelivered;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionAcknowledgeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionAcknowledgeMessage.java
@@ -93,18 +93,18 @@ public class SessionAcknowledgeMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionAcknowledgeMessage other))
+      }
+      if (!(obj instanceof SessionAcknowledgeMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (messageID != other.messageID)
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return consumerID == other.consumerID &&
+             messageID == other.messageID &&
+             requiresResponse == other.requiresResponse;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionAddMetaDataMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionAddMetaDataMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
@@ -83,23 +85,17 @@ public class SessionAddMetaDataMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionAddMetaDataMessage other))
+      }
+      if (!(obj instanceof SessionAddMetaDataMessage other)) {
          return false;
-      if (data == null) {
-         if (other.data != null)
-            return false;
-      } else if (!data.equals(other.data))
-         return false;
-      if (key == null) {
-         if (other.key != null)
-            return false;
-      } else if (!key.equals(other.key))
-         return false;
-      return true;
-   }
+      }
 
+      return Objects.equals(data, other.data) &&
+             Objects.equals(key, other.key);
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionAddMetaDataMessageV2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionAddMetaDataMessageV2.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
@@ -109,25 +111,19 @@ public class SessionAddMetaDataMessageV2 extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionAddMetaDataMessageV2 other))
+      }
+      if (!(obj instanceof SessionAddMetaDataMessageV2 other)) {
          return false;
-      if (data == null) {
-         if (other.data != null)
-            return false;
-      } else if (!data.equals(other.data))
-         return false;
-      if (key == null) {
-         if (other.key != null)
-            return false;
-      } else if (!key.equals(other.key))
-         return false;
-      if (requiresConfirmation != other.requiresConfirmation)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(data, other.data) &&
+             Objects.equals(key, other.key) &&
+             requiresConfirmation == other.requiresConfirmation;
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 
@@ -59,17 +61,16 @@ public class SessionBindingQueryMessage extends QueueAbstractPacket {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionBindingQueryMessage other))
+      }
+      if (!(obj instanceof SessionBindingQueryMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -96,19 +97,16 @@ public class SessionBindingQueryResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionBindingQueryResponseMessage other))
+      }
+      if (!(obj instanceof SessionBindingQueryResponseMessage other)) {
          return false;
-      if (exists != other.exists)
-         return false;
-      if (queueNames == null) {
-         if (other.queueNames != null)
-            return false;
-      } else if (!queueNames.equals(other.queueNames))
-         return false;
-      return true;
+      }
+      return exists == other.exists &&
+             Objects.equals(queueNames, other.queueNames);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V2.java
@@ -78,14 +78,16 @@ public class SessionBindingQueryResponseMessage_V2 extends SessionBindingQueryRe
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionBindingQueryResponseMessage_V2 other))
+      }
+      if (!(obj instanceof SessionBindingQueryResponseMessage_V2 other)) {
          return false;
-      if (autoCreateQueues != other.autoCreateQueues)
-         return false;
-      return true;
+      }
+
+      return autoCreateQueues == other.autoCreateQueues;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V3.java
@@ -81,14 +81,16 @@ public class SessionBindingQueryResponseMessage_V3 extends SessionBindingQueryRe
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionBindingQueryResponseMessage_V3 other))
+      }
+      if (!(obj instanceof SessionBindingQueryResponseMessage_V3 other)) {
          return false;
-      if (autoCreateAddresses != other.autoCreateAddresses)
-         return false;
-      return true;
+      }
+
+      return autoCreateAddresses == other.autoCreateAddresses;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V4.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V4.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -180,46 +181,22 @@ public class SessionBindingQueryResponseMessage_V4 extends SessionBindingQueryRe
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionBindingQueryResponseMessage_V4 other))
+      }
+      if (!(obj instanceof SessionBindingQueryResponseMessage_V4 other)) {
          return false;
-      if (defaultPurgeOnNoConsumers != other.defaultPurgeOnNoConsumers)
-         return false;
-      if (defaultMaxConsumers != other.defaultMaxConsumers)
-         return false;
-      if (defaultExclusive == null) {
-         if (other.defaultExclusive != null)
-            return false;
-      } else if (!defaultExclusive.equals(other.defaultExclusive))
-         return false;
-      if (defaultLastValue == null) {
-         if (other.defaultLastValue != null)
-            return false;
-      } else if (!defaultLastValue.equals(other.defaultLastValue))
-         return false;
-      if (defaultLastValueKey == null) {
-         if (other.defaultLastValueKey != null)
-            return false;
-      } else if (!defaultLastValueKey.equals(other.defaultLastValueKey))
-         return false;
-      if (defaultNonDestructive == null) {
-         if (other.defaultNonDestructive != null)
-            return false;
-      } else if (!defaultNonDestructive.equals(other.defaultNonDestructive))
-         return false;
-      if (defaultConsumersBeforeDispatch == null) {
-         if (other.defaultConsumersBeforeDispatch != null)
-            return false;
-      } else if (!defaultConsumersBeforeDispatch.equals(other.defaultConsumersBeforeDispatch))
-         return false;
-      if (defaultDelayBeforeDispatch == null) {
-         if (other.defaultDelayBeforeDispatch != null)
-            return false;
-      } else if (!defaultDelayBeforeDispatch.equals(other.defaultDelayBeforeDispatch))
-         return false;
-      return true;
+      }
+      return defaultPurgeOnNoConsumers == other.defaultPurgeOnNoConsumers &&
+             defaultMaxConsumers == other.defaultMaxConsumers &&
+             Objects.equals(defaultExclusive, other.defaultExclusive) &&
+             Objects.equals(defaultLastValue, other.defaultLastValue) &&
+             Objects.equals(defaultLastValueKey, other.defaultLastValueKey) &&
+             Objects.equals(defaultNonDestructive, other.defaultNonDestructive) &&
+             Objects.equals(defaultConsumersBeforeDispatch, other.defaultConsumersBeforeDispatch) &&
+             Objects.equals(defaultDelayBeforeDispatch, other.defaultDelayBeforeDispatch);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V5.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionBindingQueryResponseMessage_V5.java
@@ -128,12 +128,8 @@ public class SessionBindingQueryResponseMessage_V5 extends SessionBindingQueryRe
       if (!(obj instanceof SessionBindingQueryResponseMessage_V5 other)) {
          return false;
       }
-      if (supportsMulticast != other.supportsMulticast) {
-         return false;
-      }
-      if (supportsAnycast != other.supportsAnycast) {
-         return false;
-      }
-      return true;
+
+      return supportsMulticast == other.supportsMulticast &&
+             supportsAnycast == other.supportsAnycast;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionCloseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionCloseMessage.java
@@ -25,12 +25,15 @@ public class SessionCloseMessage extends PacketImpl {
    }
 
    @Override
-   public boolean equals(final Object other) {
-      if (other instanceof SessionCloseMessage == false) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof SessionCloseMessage)) {
          return false;
       }
 
-      return super.equals(other);
+      return super.equals(obj);
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionCommitMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionCommitMessage_V2.java
@@ -78,9 +78,7 @@ public class SessionCommitMessage_V2 extends SessionCommitMessage {
       if (!(obj instanceof SessionCommitMessage_V2 other)) {
          return false;
       }
-      if (correlationID != other.correlationID) {
-         return false;
-      }
-      return true;
+
+      return correlationID == other.correlationID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionConsumerCloseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionConsumerCloseMessage.java
@@ -62,14 +62,16 @@ public class SessionConsumerCloseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionConsumerCloseMessage other))
+      }
+      if (!(obj instanceof SessionConsumerCloseMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      return true;
+      }
+
+      return consumerID == other.consumerID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionConsumerFlowCreditMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionConsumerFlowCreditMessage.java
@@ -70,16 +70,17 @@ public class SessionConsumerFlowCreditMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionConsumerFlowCreditMessage other))
+      }
+      if (!(obj instanceof SessionConsumerFlowCreditMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (credits != other.credits)
-         return false;
-      return true;
+      }
+
+      return consumerID == other.consumerID &&
+             credits == other.credits;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionContinuationMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionContinuationMessage.java
@@ -100,17 +100,17 @@ public abstract class SessionContinuationMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionContinuationMessage other))
+      }
+      if (!(obj instanceof SessionContinuationMessage other)) {
          return false;
-      if (!Arrays.equals(body, other.body))
-         return false;
-      if (continues != other.continues)
-         return false;
-      return true;
-   }
+      }
 
+      return Arrays.equals(body, other.body) &&
+             continues == other.continues;
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionCreateConsumerMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionCreateConsumerMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -145,30 +147,21 @@ public class SessionCreateConsumerMessage extends QueueAbstractPacket {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionCreateConsumerMessage other))
+      }
+      if (!(obj instanceof SessionCreateConsumerMessage other)) {
          return false;
-      if (browseOnly != other.browseOnly)
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (priority != other.priority)
-         return false;
-      if (id != other.id)
-         return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return browseOnly == other.browseOnly &&
+             Objects.equals(filterString, other.filterString) &&
+             priority == other.priority &&
+             id == other.id &&
+             Objects.equals(queueName, other.queueName) &&
+             requiresResponse == other.requiresResponse;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionDeleteQueueMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionDeleteQueueMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -65,17 +67,16 @@ public class SessionDeleteQueueMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionDeleteQueueMessage other))
+      }
+      if (!(obj instanceof SessionDeleteQueueMessage other)) {
          return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(queueName, other.queueName);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionExpireMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionExpireMessage.java
@@ -80,16 +80,17 @@ public class SessionExpireMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionExpireMessage other))
+      }
+      if (!(obj instanceof SessionExpireMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (messageID != other.messageID)
-         return false;
-      return true;
+      }
+
+      return consumerID == other.consumerID &&
+             messageID == other.messageID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionForceConsumerDelivery.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionForceConsumerDelivery.java
@@ -74,17 +74,18 @@ public class SessionForceConsumerDelivery extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionForceConsumerDelivery other))
+      }
+      if (!(obj instanceof SessionForceConsumerDelivery other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (sequence != other.sequence)
-         return false;
-      return true;
+      }
+
+      return consumerID == other.consumerID &&
+             sequence == other.sequence;
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionIndividualAcknowledgeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionIndividualAcknowledgeMessage.java
@@ -97,18 +97,18 @@ public class SessionIndividualAcknowledgeMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionIndividualAcknowledgeMessage other))
+      }
+      if (!(obj instanceof SessionIndividualAcknowledgeMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (messageID != other.messageID)
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return consumerID == other.consumerID &&
+             messageID == other.messageID &&
+             requiresResponse == other.requiresResponse;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionProducerCreditsFailMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionProducerCreditsFailMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -77,19 +79,17 @@ public class SessionProducerCreditsFailMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionProducerCreditsFailMessage other))
+      }
+      if (!(obj instanceof SessionProducerCreditsFailMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (credits != other.credits)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address) &&
+             credits == other.credits;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionProducerCreditsMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionProducerCreditsMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -77,19 +79,17 @@ public class SessionProducerCreditsMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionProducerCreditsMessage other))
+      }
+      if (!(obj instanceof SessionProducerCreditsMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (credits != other.credits)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address) &&
+             credits == other.credits;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 
@@ -58,17 +60,16 @@ public class SessionQueueQueryMessage extends QueueAbstractPacket {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionQueueQueryMessage other))
+      }
+      if (!(obj instanceof SessionQueueQueryMessage other)) {
          return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(queueName, other.queueName);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -176,38 +178,24 @@ public class SessionQueueQueryResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionQueueQueryResponseMessage other))
+      }
+      if (!(obj instanceof SessionQueueQueryResponseMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (consumerCount != other.consumerCount)
-         return false;
-      if (durable != other.durable)
-         return false;
-      if (exists != other.exists)
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (messageCount != other.messageCount)
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      if (temporary != other.temporary)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address) &&
+             consumerCount == other.consumerCount &&
+             durable == other.durable &&
+             exists == other.exists &&
+             Objects.equals(filterString, other.filterString) &&
+             messageCount == other.messageCount &&
+             Objects.equals(name, other.name) &&
+             temporary == other.temporary;
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V2.java
@@ -105,14 +105,16 @@ public class SessionQueueQueryResponseMessage_V2 extends SessionQueueQueryRespon
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionQueueQueryResponseMessage_V2 other))
+      }
+      if (!(obj instanceof SessionQueueQueryResponseMessage_V2 other)) {
          return false;
-      if (autoCreateQueues != other.autoCreateQueues)
-         return false;
-      return true;
+      }
+
+      return autoCreateQueues == other.autoCreateQueues;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V3.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionQueueQueryResponseMessage_V3.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
@@ -456,108 +458,36 @@ public class SessionQueueQueryResponseMessage_V3 extends SessionQueueQueryRespon
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionQueueQueryResponseMessage_V3 other))
+      }
+      if (!(obj instanceof SessionQueueQueryResponseMessage_V3 other)) {
          return false;
-      if (autoCreated != other.autoCreated)
-         return false;
-      if (purgeOnNoConsumers != other.purgeOnNoConsumers)
-         return false;
-      if (exclusive == null) {
-         if (other.exclusive != null)
-            return false;
-      } else if (!exclusive.equals(other.exclusive))
-         return false;
-      if (groupRebalance == null) {
-         if (other.groupRebalance != null)
-            return false;
-      } else if (!groupRebalance.equals(other.groupRebalance))
-         return false;
-      if (groupRebalancePauseDispatch == null) {
-         if (other.groupRebalancePauseDispatch != null)
-            return false;
-      } else if (!groupRebalancePauseDispatch.equals(other.groupRebalancePauseDispatch))
-         return false;
-      if (groupBuckets == null) {
-         if (other.groupBuckets != null)
-            return false;
-      } else if (!groupBuckets.equals(other.groupBuckets))
-         return false;
-      if (groupFirstKey == null) {
-         if (other.groupFirstKey != null)
-            return false;
-      } else if (!groupFirstKey.equals(other.groupFirstKey))
-         return false;
-      if (lastValue == null) {
-         if (other.lastValue != null)
-            return false;
-      } else if (!lastValue.equals(other.lastValue))
-         return false;
-      if (lastValueKey == null) {
-         if (other.lastValueKey != null)
-            return false;
-      } else if (!lastValueKey.equals(other.lastValueKey))
-         return false;
-      if (nonDestructive == null) {
-         if (other.nonDestructive != null)
-            return false;
-      } else if (!nonDestructive.equals(other.nonDestructive))
-         return false;
-      if (consumersBeforeDispatch == null) {
-         if (other.consumersBeforeDispatch != null)
-            return false;
-      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch))
-         return false;
-      if (delayBeforeDispatch == null) {
-         if (other.delayBeforeDispatch != null)
-            return false;
-      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch))
-         return false;
-      if (autoDelete == null) {
-         if (other.autoDelete != null)
-            return false;
-      } else if (!autoDelete.equals(other.autoDelete))
-         return false;
-      if (autoDeleteDelay == null) {
-         if (other.autoDeleteDelay != null)
-            return false;
-      } else if (!autoDeleteDelay.equals(other.autoDeleteDelay))
-         return false;
-      if (autoDeleteMessageCount == null) {
-         if (other.autoDeleteMessageCount != null)
-            return false;
-      } else if (!autoDeleteMessageCount.equals(other.autoDeleteMessageCount))
-         return false;
-      if (ringSize == null) {
-         if (other.ringSize != null)
-            return false;
-      } else if (!ringSize.equals(other.ringSize))
-         return false;
-      if (enabled == null) {
-         if (other.enabled != null)
-            return false;
-      } else if (!enabled.equals(other.enabled))
-         return false;
-      if (defaultConsumerWindowSize == null) {
-         if (other.defaultConsumerWindowSize != null)
-            return false;
-      } else if (!defaultConsumerWindowSize.equals(other.defaultConsumerWindowSize))
-         return false;
-      if (routingType == null) {
-         if (other.routingType != null)
-            return false;
-      } else if (!routingType.equals(other.routingType))
-         return false;
-      if (maxConsumers != other.maxConsumers)
-         return false;
-      if (configurationManaged == null) {
-         if (other.configurationManaged != null)
-            return false;
-      } else if (!configurationManaged.equals(other.configurationManaged))
-         return false;
-      return true;
+      }
+
+      return autoCreated == other.autoCreated &&
+             purgeOnNoConsumers == other.purgeOnNoConsumers &&
+             maxConsumers == other.maxConsumers &&
+             Objects.equals(exclusive, other.exclusive) &&
+             Objects.equals(groupRebalance, other.groupRebalance) &&
+             Objects.equals(groupRebalancePauseDispatch, other.groupRebalancePauseDispatch) &&
+             Objects.equals(groupBuckets, other.groupBuckets) &&
+             Objects.equals(groupFirstKey, other.groupFirstKey) &&
+             Objects.equals(lastValue, other.lastValue) &&
+             Objects.equals(lastValueKey, other.lastValueKey) &&
+             Objects.equals(nonDestructive, other.nonDestructive) &&
+             Objects.equals(consumersBeforeDispatch, other.consumersBeforeDispatch) &&
+             Objects.equals(delayBeforeDispatch, other.delayBeforeDispatch) &&
+             Objects.equals(autoDelete, other.autoDelete) &&
+             Objects.equals(autoDeleteDelay, other.autoDeleteDelay) &&
+             Objects.equals(autoDeleteMessageCount, other.autoDeleteMessageCount) &&
+             Objects.equals(ringSize, other.ringSize) &&
+             Objects.equals(enabled, other.enabled) &&
+             Objects.equals(defaultConsumerWindowSize, other.defaultConsumerWindowSize) &&
+             Objects.equals(routingType, other.routingType) &&
+             Objects.equals(configurationManaged, other.configurationManaged);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionReceiveContinuationMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionReceiveContinuationMessage.java
@@ -97,15 +97,16 @@ public class SessionReceiveContinuationMessage extends SessionContinuationMessag
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionReceiveContinuationMessage other))
+      }
+      if (!(obj instanceof SessionReceiveContinuationMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      return true;
-   }
+      }
 
+      return consumerID == other.consumerID;
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionReceiveLargeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionReceiveLargeMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
@@ -123,24 +125,19 @@ public class SessionReceiveLargeMessage extends PacketImpl implements MessagePac
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionReceiveLargeMessage other))
+      }
+      if (!(obj instanceof SessionReceiveLargeMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (deliveryCount != other.deliveryCount)
-         return false;
-      if (largeMessageSize != other.largeMessageSize)
-         return false;
-      if (message == null) {
-         if (other.message != null)
-            return false;
-      } else if (!message.equals(other.message))
-         return false;
-      return true;
-   }
+      }
 
+      return consumerID == other.consumerID &&
+             deliveryCount == other.deliveryCount &&
+             largeMessageSize == other.largeMessageSize &&
+             Objects.equals(message, other.message);
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionReceiveMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionReceiveMessage.java
@@ -96,17 +96,17 @@ public class SessionReceiveMessage extends MessagePacket {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionReceiveMessage other))
+      }
+      if (!(obj instanceof SessionReceiveMessage other)) {
          return false;
-      if (consumerID != other.consumerID)
-         return false;
-      if (deliveryCount != other.deliveryCount)
-         return false;
-      return true;
-   }
+      }
 
+      return consumerID == other.consumerID &&
+             deliveryCount == other.deliveryCount;
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionRequestProducerCreditsMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionRequestProducerCreditsMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -82,20 +84,17 @@ public class SessionRequestProducerCreditsMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionRequestProducerCreditsMessage other))
+      }
+      if (!(obj instanceof SessionRequestProducerCreditsMessage other)) {
          return false;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (credits != other.credits)
-         return false;
-      return true;
-   }
+      }
 
+      return Objects.equals(address, other.address) &&
+             credits == other.credits;
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendContinuationMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendContinuationMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler;
@@ -141,22 +143,19 @@ public class SessionSendContinuationMessage extends SessionContinuationMessage {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionSendContinuationMessage other))
+      }
+      if (!(obj instanceof SessionSendContinuationMessage other)) {
          return false;
-      if (message == null) {
-         if (other.message != null)
-            return false;
-      } else if (!message.equals(other.message))
-         return false;
-      if (messageBodySize != other.messageBodySize)
-         return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(message, other.message) &&
+             messageBodySize == other.messageBodySize &&
+             requiresResponse == other.requiresResponse;
    }
 
    public SendAcknowledgementHandler getHandler() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendContinuationMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendContinuationMessage_V2.java
@@ -98,14 +98,16 @@ public class SessionSendContinuationMessage_V2 extends SessionSendContinuationMe
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionSendContinuationMessage_V2 other))
+      }
+      if (!(obj instanceof SessionSendContinuationMessage_V2 other)) {
          return false;
-      if (correlationID != other.correlationID)
-         return false;
-      return true;
+      }
+
+      return correlationID == other.correlationID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendLargeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendLargeMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
@@ -77,18 +79,16 @@ public class SessionSendLargeMessage extends PacketImpl implements MessagePacket
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionSendLargeMessage other))
+      }
+      if (!(obj instanceof SessionSendLargeMessage other)) {
          return false;
-      if (largeMessage == null) {
-         if (other.largeMessage != null)
-            return false;
-      } else if (!largeMessage.equals(other.largeMessage))
-         return false;
-      return true;
-   }
+      }
 
+      return Objects.equals(largeMessage, other.largeMessage);
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendMessage.java
@@ -130,15 +130,17 @@ public class SessionSendMessage extends MessagePacket {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionSendMessage other))
+      }
+      if (!(obj instanceof SessionSendMessage other)) {
          return false;
-      if (requiresResponse != other.requiresResponse)
-         return false;
-      return true;
+      }
+
+      return requiresResponse == other.requiresResponse;
    }
 
    public int getSenderID() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionSendMessage_V2.java
@@ -90,15 +90,16 @@ public class SessionSendMessage_V2 extends SessionSendMessage {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionSendMessage_V2 other))
+      }
+      if (!(obj instanceof SessionSendMessage_V2 other)) {
          return false;
-      if (correlationID != other.correlationID)
-         return false;
-      return true;
-   }
+      }
 
+      return correlationID == other.correlationID;
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAAfterFailedMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAAfterFailedMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -72,18 +74,16 @@ public class SessionXAAfterFailedMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAAfterFailedMessage other))
+      }
+      if (!(obj instanceof SessionXAAfterFailedMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
-   }
+      }
 
+      return Objects.equals(xid, other.xid);
+   }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXACommitMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXACommitMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -75,19 +77,17 @@ public class SessionXACommitMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXACommitMessage other))
+      }
+      if (!(obj instanceof SessionXACommitMessage other)) {
          return false;
-      if (onePhase != other.onePhase)
-         return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return onePhase == other.onePhase &&
+             Objects.equals(xid, other.xid);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAEndMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAEndMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -76,19 +78,17 @@ public class SessionXAEndMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAEndMessage other))
+      }
+      if (!(obj instanceof SessionXAEndMessage other)) {
          return false;
-      if (failed != other.failed)
-         return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return failed == other.failed &&
+             Objects.equals(xid, other.xid);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAForgetMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAForgetMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -67,18 +69,17 @@ public class SessionXAForgetMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAForgetMessage other))
+      }
+      if (!(obj instanceof SessionXAForgetMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xid, other.xid);
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAGetInDoubtXidsResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAGetInDoubtXidsResponseMessage.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 import javax.transaction.xa.Xid;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -85,17 +86,16 @@ public class SessionXAGetInDoubtXidsResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAGetInDoubtXidsResponseMessage other))
+      }
+      if (!(obj instanceof SessionXAGetInDoubtXidsResponseMessage other)) {
          return false;
-      if (xids == null) {
-         if (other.xids != null)
-            return false;
-      } else if (!xids.equals(other.xids))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xids, other.xids);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAGetTimeoutResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAGetTimeoutResponseMessage.java
@@ -69,14 +69,16 @@ public class SessionXAGetTimeoutResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAGetTimeoutResponseMessage other))
+      }
+      if (!(obj instanceof SessionXAGetTimeoutResponseMessage other)) {
          return false;
-      if (timeoutSeconds != other.timeoutSeconds)
-         return false;
-      return true;
+      }
+
+      return timeoutSeconds == other.timeoutSeconds;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAJoinMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAJoinMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -67,17 +69,16 @@ public class SessionXAJoinMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAJoinMessage other))
+      }
+      if (!(obj instanceof SessionXAJoinMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xid, other.xid);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAPrepareMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAPrepareMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -67,17 +69,16 @@ public class SessionXAPrepareMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAPrepareMessage other))
+      }
+      if (!(obj instanceof SessionXAPrepareMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xid, other.xid);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAResponseMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 
@@ -94,21 +96,18 @@ public class SessionXAResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAResponseMessage other))
+      }
+      if (!(obj instanceof SessionXAResponseMessage other)) {
          return false;
-      if (error != other.error)
-         return false;
-      if (message == null) {
-         if (other.message != null)
-            return false;
-      } else if (!message.equals(other.message))
-         return false;
-      if (responseCode != other.responseCode)
-         return false;
-      return true;
+      }
+
+      return error == other.error &&
+             Objects.equals(message, other.message) &&
+             responseCode == other.responseCode;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAResponseMessage_V2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAResponseMessage_V2.java
@@ -92,9 +92,7 @@ public class SessionXAResponseMessage_V2 extends SessionXAResponseMessage {
       if (!(obj instanceof SessionXAResponseMessage_V2 other)) {
          return false;
       }
-      if (correlationID != other.correlationID) {
-         return false;
-      }
-      return true;
+
+      return correlationID == other.correlationID;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAResumeMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAResumeMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -67,17 +69,16 @@ public class SessionXAResumeMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAResumeMessage other))
+      }
+      if (!(obj instanceof SessionXAResumeMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xid, other.xid);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXARollbackMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXARollbackMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -67,17 +69,16 @@ public class SessionXARollbackMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXARollbackMessage other))
+      }
+      if (!(obj instanceof SessionXARollbackMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xid, other.xid);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXASetTimeoutMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXASetTimeoutMessage.java
@@ -64,14 +64,16 @@ public class SessionXASetTimeoutMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXASetTimeoutMessage other))
+      }
+      if (!(obj instanceof SessionXASetTimeoutMessage other)) {
          return false;
-      if (timeoutSeconds != other.timeoutSeconds)
-         return false;
-      return true;
+      }
+
+      return timeoutSeconds == other.timeoutSeconds;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXASetTimeoutResponseMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXASetTimeoutResponseMessage.java
@@ -69,14 +69,16 @@ public class SessionXASetTimeoutResponseMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXASetTimeoutResponseMessage other))
+      }
+      if (!(obj instanceof SessionXASetTimeoutResponseMessage other)) {
          return false;
-      if (ok != other.ok)
-         return false;
-      return true;
+      }
+
+      return ok == other.ok;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAStartMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SessionXAStartMessage.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import javax.transaction.xa.Xid;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
 import org.apache.activemq.artemis.utils.XidCodecSupport;
@@ -69,18 +71,17 @@ public class SessionXAStartMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SessionXAStartMessage other))
+      }
+      if (!(obj instanceof SessionXAStartMessage other)) {
          return false;
-      if (xid == null) {
-         if (other.xid != null)
-            return false;
-      } else if (!xid.equals(other.xid))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(xid, other.xid);
    }
 
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SubscribeClusterTopologyUpdatesMessage.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SubscribeClusterTopologyUpdatesMessage.java
@@ -74,14 +74,16 @@ public class SubscribeClusterTopologyUpdatesMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SubscribeClusterTopologyUpdatesMessage other))
+      }
+      if (!(obj instanceof SubscribeClusterTopologyUpdatesMessage other)) {
          return false;
-      if (clusterConnection != other.clusterConnection)
-         return false;
-      return true;
+      }
+
+      return clusterConnection == other.clusterConnection;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SubscribeClusterTopologyUpdatesMessageV2.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/SubscribeClusterTopologyUpdatesMessageV2.java
@@ -65,14 +65,16 @@ public class SubscribeClusterTopologyUpdatesMessageV2 extends SubscribeClusterTo
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof SubscribeClusterTopologyUpdatesMessageV2 other))
+      }
+      if (!(obj instanceof SubscribeClusterTopologyUpdatesMessageV2 other)) {
          return false;
-      if (clientVersion != other.clientVersion)
-         return false;
-      return true;
+      }
+
+      return clientVersion == other.clientVersion;
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/security/Role.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/security/Role.java
@@ -273,57 +273,27 @@ public class Role implements Serializable {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof Role other)) {
          return false;
       }
 
-      Role role = (Role) o;
-
-      if (consume != role.consume) {
-         return false;
-      }
-      if (createAddress != role.createAddress) {
-         return false;
-      }
-      if (deleteAddress != role.deleteAddress) {
-         return false;
-      }
-      if (createDurableQueue != role.createDurableQueue) {
-         return false;
-      }
-      if (createNonDurableQueue != role.createNonDurableQueue) {
-         return false;
-      }
-      if (deleteDurableQueue != role.deleteDurableQueue) {
-         return false;
-      }
-      if (deleteNonDurableQueue != role.deleteNonDurableQueue) {
-         return false;
-      }
-      if (send != role.send) {
-         return false;
-      }
-      if (manage != role.manage) {
-         return false;
-      }
-      if (browse != role.browse) {
-         return false;
-      }
-      if (!name.equals(role.name)) {
-         return false;
-      }
-      if (view != role.view) {
-         return false;
-      }
-      if (edit != role.edit) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(name, other.name) &&
+             send == other.send &&
+             consume == other.consume &&
+             createAddress == other.createAddress &&
+             deleteAddress == other.deleteAddress &&
+             createDurableQueue == other.createDurableQueue &&
+             createNonDurableQueue == other.createNonDurableQueue &&
+             deleteDurableQueue == other.deleteDurableQueue &&
+             deleteNonDurableQueue == other.deleteNonDurableQueue &&
+             manage == other.manage &&
+             browse == other.browse &&
+             view == other.view &&
+             edit == other.edit;
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/transaction/impl/XidImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/transaction/impl/XidImpl.java
@@ -105,35 +105,17 @@ public class XidImpl implements Xid, Serializable {
    }
 
    @Override
-   public boolean equals(final Object other) {
+   public boolean equals(Object other) {
       if (this == other) {
          return true;
       }
       if (!(other instanceof Xid xother)) {
          return false;
       }
-      if (xother.getFormatId() != formatId) {
-         return false;
-      }
-      if (xother.getBranchQualifier().length != branchQualifier.length) {
-         return false;
-      }
-      if (xother.getGlobalTransactionId().length != globalTransactionId.length) {
-         return false;
-      }
-      for (int i = 0; i < branchQualifier.length; i++) {
-         byte[] otherBQ = xother.getBranchQualifier();
-         if (branchQualifier[i] != otherBQ[i]) {
-            return false;
-         }
-      }
-      for (int i = 0; i < globalTransactionId.length; i++) {
-         byte[] otherGtx = xother.getGlobalTransactionId();
-         if (globalTransactionId[i] != otherGtx[i]) {
-            return false;
-         }
-      }
-      return true;
+
+      return formatId == xother.getFormatId() &&
+             Arrays.equals(branchQualifier, xother.getBranchQualifier()) &&
+             Arrays.equals(globalTransactionId, xother.getGlobalTransactionId());
    }
 
    @Override

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/version/impl/VersionImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/version/impl/VersionImpl.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.version.impl;
 
 import java.io.Serializable;
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.core.version.Version;
 
@@ -118,34 +119,15 @@ public class VersionImpl implements Version, Serializable {
       if (this == obj) {
          return true;
       }
-      if (obj == null) {
-         return false;
-      }
       if (!(obj instanceof VersionImpl other)) {
          return false;
       }
-      if (!Arrays.equals(compatibleVersionList, other.compatibleVersionList)) {
-         return false;
-      }
-      if (incrementingVersion != other.incrementingVersion) {
-         return false;
-      }
-      if (majorVersion != other.majorVersion) {
-         return false;
-      }
-      if (microVersion != other.microVersion) {
-         return false;
-      }
-      if (minorVersion != other.minorVersion) {
-         return false;
-      }
-      if (versionName == null) {
-         if (other.versionName != null) {
-            return false;
-         }
-      } else if (!versionName.equals(other.versionName)) {
-         return false;
-      }
-      return true;
+
+      return Arrays.equals(compatibleVersionList, other.compatibleVersionList) &&
+             incrementingVersion == other.incrementingVersion &&
+             majorVersion == other.majorVersion &&
+             microVersion == other.microVersion &&
+             minorVersion == other.minorVersion &&
+             Objects.equals(versionName, other.versionName);
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextConfig.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/spi/core/remoting/ssl/SSLContextConfig.java
@@ -183,21 +183,23 @@ public final class SSLContextConfig {
 
    @Override
    public boolean equals(final Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null || getClass() != obj.getClass())
+      }
+      if (!(obj instanceof SSLContextConfig other)) {
          return false;
-      final SSLContextConfig other = (SSLContextConfig) obj;
-      return Objects.equals(keystorePath, other.keystorePath)
-         && Objects.equals(keystoreType, other.keystoreType)
-         && Objects.equals(keystoreProvider, other.keystoreProvider)
-         && Objects.equals(truststorePath, other.truststorePath)
-         && Objects.equals(truststoreType, other.truststoreType)
-         && Objects.equals(truststoreProvider, other.truststoreProvider)
-         && Objects.equals(crlPath, other.crlPath)
-         && Objects.equals(trustManagerFactoryPlugin, other.trustManagerFactoryPlugin)
-         && trustAll == other.trustAll
-         && Objects.equals(keystoreAlias, other.keystoreAlias);
+      }
+
+      return Objects.equals(keystorePath, other.keystorePath) &&
+             Objects.equals(keystoreType, other.keystoreType) &&
+             Objects.equals(keystoreProvider, other.keystoreProvider) &&
+             Objects.equals(truststorePath, other.truststorePath) &&
+             Objects.equals(truststoreType, other.truststoreType) &&
+             Objects.equals(truststoreProvider, other.truststoreProvider) &&
+             Objects.equals(crlPath, other.crlPath) &&
+             Objects.equals(trustManagerFactoryPlugin, other.trustManagerFactoryPlugin) &&
+             trustAll == other.trustAll &&
+             Objects.equals(keystoreAlias, other.keystoreAlias);
    }
 
    public String getCrlPath() {

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQDestination.java
@@ -488,16 +488,15 @@ public class ActiveMQDestination extends JNDIStorable implements Destination, Se
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (!(o instanceof ActiveMQDestination that)) {
+      if (!(obj instanceof ActiveMQDestination other)) {
          return false;
       }
 
-      return simpleAddress.equals(that.simpleAddress);
+      return Objects.equals(simpleAddress, other.simpleAddress);
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQQueue.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQQueue.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.jms.client;
 
 import javax.jms.Queue;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.SimpleString;
 
 /**
@@ -70,16 +72,15 @@ public class ActiveMQQueue extends ActiveMQDestination implements Queue {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (!(o instanceof ActiveMQQueue that)) {
+      if (!(obj instanceof ActiveMQQueue other)) {
          return false;
       }
 
-      return super.getAddress().equals(that.getAddress());
+      return Objects.equals(super.getAddress(), other.getAddress());
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryQueue.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryQueue.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.jms.client;
 
 import javax.jms.TemporaryQueue;
+import java.util.Objects;
 
 /**
  * ActiveMQ Artemis implementation of a JMS TemporaryQueue.
@@ -45,16 +46,15 @@ public class ActiveMQTemporaryQueue extends ActiveMQQueue implements TemporaryQu
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (!(o instanceof ActiveMQTemporaryQueue that)) {
+      if (!(obj instanceof ActiveMQTemporaryQueue other)) {
          return false;
       }
 
-      return super.getAddress().equals(that.getAddress());
+      return Objects.equals(super.getAddress(), other.getAddress());
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryTopic.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTemporaryTopic.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.jms.client;
 
 import javax.jms.TemporaryTopic;
+import java.util.Objects;
 
 public class ActiveMQTemporaryTopic extends ActiveMQTopic implements TemporaryTopic {
 
@@ -32,18 +33,16 @@ public class ActiveMQTemporaryTopic extends ActiveMQTopic implements TemporaryTo
       super(address, true, session);
    }
 
-
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (!(o instanceof ActiveMQTemporaryTopic that)) {
+      if (!(obj instanceof ActiveMQTemporaryTopic other)) {
          return false;
       }
 
-      return super.getAddress().equals(that.getAddress());
+      return Objects.equals(super.getAddress(), other.getAddress());
    }
 
    @Override

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTopic.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQTopic.java
@@ -18,6 +18,8 @@ package org.apache.activemq.artemis.jms.client;
 
 import javax.jms.Topic;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.SimpleString;
 
 /**
@@ -69,16 +71,15 @@ public class ActiveMQTopic extends ActiveMQDestination implements Topic {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (!(o instanceof ActiveMQTopic that)) {
+      if (!(obj instanceof ActiveMQTopic other)) {
          return false;
       }
 
-      return super.getAddress().equals(that.getAddress());
+      return Objects.equals(super.getAddress(), other.getAddress());
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/JournalLoadInformation.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/JournalLoadInformation.java
@@ -65,20 +65,12 @@ public class JournalLoadInformation {
       if (this == obj) {
          return true;
       }
-      if (obj == null) {
+      if (!(obj instanceof JournalLoadInformation other)) {
          return false;
       }
-      if (getClass() != obj.getClass()) {
-         return false;
-      }
-      JournalLoadInformation other = (JournalLoadInformation) obj;
-      if (maxID != other.maxID) {
-         return false;
-      }
-      if (numberOfRecords != other.numberOfRecords) {
-         return false;
-      }
-      return true;
+
+      return maxID == other.maxID &&
+             numberOfRecords == other.numberOfRecords;
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/RecordInfo.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/RecordInfo.java
@@ -71,12 +71,15 @@ public class RecordInfo {
    }
 
    @Override
-   public boolean equals(final Object other) {
-      if (!(other instanceof RecordInfo r)) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof RecordInfo other)) {
          return false;
       }
 
-      return r.id == id;
+      return other.id == id;
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/collections/JournalHashMap.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/collections/JournalHashMap.java
@@ -82,21 +82,18 @@ public class JournalHashMap<K, V, C> implements Map<K, V> {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o)
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
-         if (o == null || getClass() != o.getClass())
+         }
+         if (!(obj instanceof MapRecord<?, ?> other)) {
             return false;
+         }
 
-         MapRecord<?, ?> mapRecord = (MapRecord<?, ?>) o;
-
-         if (collectionID != mapRecord.collectionID)
-            return false;
-         if (id != mapRecord.id)
-            return false;
-         if (!Objects.equals(key, mapRecord.key))
-            return false;
-         return Objects.equals(value, mapRecord.value);
+         return collectionID == other.collectionID &&
+                id == other.id &&
+                Objects.equals(key, other.key) &&
+                Objects.equals(value, other.value);
       }
 
       @Override

--- a/artemis-lockmanager/artemis-lockmanager-ri/src/main/java/org/apache/activemq/artemis/lockmanager/zookeeper/CuratorDistributedLockManager.java
+++ b/artemis-lockmanager/artemis-lockmanager-ri/src/main/java/org/apache/activemq/artemis/lockmanager/zookeeper/CuratorDistributedLockManager.java
@@ -79,17 +79,16 @@ public class CuratorDistributedLockManager implements DistributedLockManager, Co
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o)
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
-         if (o == null || getClass() != o.getClass())
+         }
+         if (!(obj instanceof PrimitiveId other)) {
             return false;
+         }
 
-         PrimitiveId that = (PrimitiveId) o;
-
-         if (!Objects.equals(id, that.id))
-            return false;
-         return type == that.type;
+         return Objects.equals(id, other.id) &&
+                type == other.type;
       }
 
       @Override

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverInfo.java
@@ -141,11 +141,9 @@ public class AMQPBridgeReceiverInfo {
       if (this == obj) {
          return true;
       }
-      if (!(obj instanceof AMQPBridgeReceiverInfo)) {
+      if (!(obj instanceof AMQPBridgeReceiverInfo other)) {
          return false;
       }
-
-      final AMQPBridgeReceiverInfo other = (AMQPBridgeReceiverInfo) obj;
 
       return Objects.equals(filterString, other.filterString) &&
              Objects.equals(localAddress, other.localAddress) &&

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeSenderInfo.java
@@ -123,11 +123,9 @@ public class AMQPBridgeSenderInfo {
       if (this == obj) {
          return true;
       }
-      if (!(obj instanceof AMQPBridgeSenderInfo)) {
+      if (!(obj instanceof AMQPBridgeSenderInfo other)) {
          return false;
       }
-
-      final AMQPBridgeSenderInfo other = (AMQPBridgeSenderInfo) obj;
 
       return Objects.equals(localAddress, other.localAddress) &&
              Objects.equals(localFqqn, other.localFqqn) &&

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationGenericConsumerInfo.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationGenericConsumerInfo.java
@@ -120,22 +120,21 @@ public class AMQPFederationGenericConsumerInfo implements FederationConsumerInfo
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (!(o instanceof AMQPFederationGenericConsumerInfo that)) {
+      if (!(obj instanceof AMQPFederationGenericConsumerInfo other)) {
          return false;
       }
 
-      return role == that.role &&
-             priority == that.priority &&
-             Objects.equals(address, that.address) &&
-             Objects.equals(queueName, that.queueName) &&
-             routingType == that.routingType &&
-             Objects.equals(filterString, that.filterString) &&
-             Objects.equals(fqqn, that.fqqn);
+      return role == other.role &&
+             priority == other.priority &&
+             Objects.equals(address, other.address) &&
+             Objects.equals(queueName, other.queueName) &&
+             routingType == other.routingType &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(fqqn, other.fqqn);
    }
 
    @Override

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionRequestInfo.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAConnectionRequestInfo.java
@@ -22,6 +22,7 @@ import javax.resource.spi.ConnectionRequestInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 /**
  * {@inheritDoc}
@@ -141,20 +142,19 @@ public class ActiveMQRAConnectionRequestInfo implements ConnectionRequestInfo {
    @Override
    public boolean equals(final Object obj) {
       logger.trace("equals({})", obj);
-
-      if (obj == null) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof ActiveMQRAConnectionRequestInfo requestInfo)) {
          return false;
       }
 
-      if (obj instanceof ActiveMQRAConnectionRequestInfo requestInfo) {
-         return ActiveMQRaUtils.compare(userName, requestInfo.getUserName()) && ActiveMQRaUtils.compare(password, requestInfo.getPassword()) &&
-            ActiveMQRaUtils.compare(clientID, requestInfo.getClientID()) &&
-            type == requestInfo.getType() &&
-            transacted == requestInfo.isTransacted() &&
-            acknowledgeMode == requestInfo.getAcknowledgeMode();
-      } else {
-         return false;
-      }
+      return Objects.equals(userName, requestInfo.getUserName()) &&
+             Objects.equals(password, requestInfo.getPassword()) &&
+             Objects.equals(clientID, requestInfo.getClientID()) &&
+             type == requestInfo.getType() &&
+             transacted == requestInfo.isTransacted() &&
+             acknowledgeMode == requestInfo.getAcknowledgeMode();
    }
 
    @Override

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAManagedConnectionFactory.java
@@ -28,6 +28,7 @@ import javax.security.auth.Subject;
 import java.io.PrintWriter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
@@ -212,17 +213,16 @@ public final class ActiveMQRAManagedConnectionFactory implements ManagedConnecti
    @Override
    public boolean equals(final Object obj) {
       logger.trace("equals({})", obj);
+      if (this == obj) {
+         return true;
+      }
 
-      if (obj == null) {
+      if (!(obj instanceof ActiveMQRAManagedConnectionFactory other)) {
          return false;
       }
 
-      if (obj instanceof ActiveMQRAManagedConnectionFactory other) {
-
-         return mcfProperties.equals(other.getProperties()) && ra.equals(other.getResourceAdapter());
-      } else {
-         return false;
-      }
+      return Objects.equals(mcfProperties, other.getProperties()) &&
+             Objects.equals(ra, other.getResourceAdapter());
    }
 
    @Override

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAMessage.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQRAMessage.java
@@ -577,12 +577,14 @@ public class ActiveMQRAMessage implements Message {
    @Override
    public boolean equals(final Object object) {
       logger.trace("equals({})", object);
-
-      if (object != null && object instanceof ActiveMQRAMessage activeMQRAMessage) {
-         return message.equals(activeMQRAMessage.message);
-      } else {
-         return message.equals(object);
+      if (this == object) {
+         return true;
       }
+      if (!(object instanceof ActiveMQRAMessage activeMQRAMessage)) {
+         return false;
+      }
+
+      return Objects.equals(message, activeMQRAMessage.message);
    }
 
    @Override

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -36,6 +36,7 @@ import java.util.Hashtable;
 import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.regex.Matcher;
@@ -987,11 +988,11 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
       if (obj == null) {
          return false;
       }
-
-      if (obj instanceof ActiveMQResourceAdapter adapter) {
-         return raProperties.equals(adapter.getProperties());
+      if (!(obj instanceof ActiveMQResourceAdapter adapter)) {
+         return false;
       }
-      return false;
+
+      return Objects.equals(raProperties, adapter.getProperties());
    }
 
    @Override

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ConnectionFactoryProperties.java
@@ -737,249 +737,59 @@ public class ConnectionFactoryProperties implements ConnectionFactoryOptions {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof ConnectionFactoryProperties other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      ConnectionFactoryProperties other = (ConnectionFactoryProperties) obj;
-      if (this.autoGroup == null) {
-         if (other.autoGroup != null)
-            return false;
-      } else if (!this.autoGroup.equals(other.autoGroup))
-         return false;
-      if (this.blockOnAcknowledge == null) {
-         if (other.blockOnAcknowledge != null)
-            return false;
-      } else if (!this.blockOnAcknowledge.equals(other.blockOnAcknowledge))
-         return false;
-      if (this.blockOnDurableSend == null) {
-         if (other.blockOnDurableSend != null)
-            return false;
-      } else if (!this.blockOnDurableSend.equals(other.blockOnDurableSend))
-         return false;
-      if (this.blockOnNonDurableSend == null) {
-         if (other.blockOnNonDurableSend != null)
-            return false;
-      } else if (!this.blockOnNonDurableSend.equals(other.blockOnNonDurableSend))
-         return false;
-      if (this.cacheLargeMessagesClient == null) {
-         if (other.cacheLargeMessagesClient != null)
-            return false;
-      } else if (!this.cacheLargeMessagesClient.equals(other.cacheLargeMessagesClient))
-         return false;
-      if (this.compressLargeMessage == null) {
-         if (other.compressLargeMessage != null)
-            return false;
-      } else if (!this.compressLargeMessage.equals(other.compressLargeMessage))
-         return false;
-      if (this.ha == null) {
-         if (other.ha != null)
-            return false;
-      } else if (!this.ha.equals(other.ha))
-         return false;
-      if (this.preAcknowledge == null) {
-         if (other.preAcknowledge != null)
-            return false;
-      } else if (!this.preAcknowledge.equals(other.preAcknowledge))
-         return false;
-      if (this.callFailoverTimeout == null) {
-         if (other.callFailoverTimeout != null)
-            return false;
-      } else if (!this.callFailoverTimeout.equals(other.callFailoverTimeout))
-         return false;
-      if (this.callTimeout == null) {
-         if (other.callTimeout != null)
-            return false;
-      } else if (!this.callTimeout.equals(other.callTimeout))
-         return false;
-      if (this.clientFailureCheckPeriod == null) {
-         if (other.clientFailureCheckPeriod != null)
-            return false;
-      } else if (!this.clientFailureCheckPeriod.equals(other.clientFailureCheckPeriod))
-         return false;
-      if (this.clientID == null) {
-         if (other.clientID != null)
-            return false;
-      } else if (!this.clientID.equals(other.clientID))
-         return false;
-      if (this.confirmationWindowSize == null) {
-         if (other.confirmationWindowSize != null)
-            return false;
-      } else if (!this.confirmationWindowSize.equals(other.confirmationWindowSize))
-         return false;
-      if (this.connectionLoadBalancingPolicyClassName == null) {
-         if (other.connectionLoadBalancingPolicyClassName != null)
-            return false;
-      } else if (!this.connectionLoadBalancingPolicyClassName.equals(other.connectionLoadBalancingPolicyClassName))
-         return false;
-      if (this.connectionTTL == null) {
-         if (other.connectionTTL != null)
-            return false;
-      } else if (!this.connectionTTL.equals(other.connectionTTL))
-         return false;
-      if (this.consumerMaxRate == null) {
-         if (other.consumerMaxRate != null)
-            return false;
-      } else if (!this.consumerMaxRate.equals(other.consumerMaxRate))
-         return false;
-      if (this.consumerWindowSize == null) {
-         if (other.consumerWindowSize != null)
-            return false;
-      } else if (!this.consumerWindowSize.equals(other.consumerWindowSize))
-         return false;
-      if (this.discoveryAddress == null) {
-         if (other.discoveryAddress != null)
-            return false;
-      } else if (!this.discoveryAddress.equals(other.discoveryAddress))
-         return false;
-      if (this.discoveryInitialWaitTimeout == null) {
-         if (other.discoveryInitialWaitTimeout != null)
-            return false;
-      } else if (!this.discoveryInitialWaitTimeout.equals(other.discoveryInitialWaitTimeout))
-         return false;
-      if (this.discoveryLocalBindAddress == null) {
-         if (other.discoveryLocalBindAddress != null)
-            return false;
-      } else if (!this.discoveryLocalBindAddress.equals(other.discoveryLocalBindAddress))
-         return false;
-      if (this.discoveryPort == null) {
-         if (other.discoveryPort != null)
-            return false;
-      } else if (!this.discoveryPort.equals(other.discoveryPort))
-         return false;
-      if (this.discoveryRefreshTimeout == null) {
-         if (other.discoveryRefreshTimeout != null)
-            return false;
-      } else if (!this.discoveryRefreshTimeout.equals(other.discoveryRefreshTimeout))
-         return false;
-      if (this.dupsOKBatchSize == null) {
-         if (other.dupsOKBatchSize != null)
-            return false;
-      } else if (!this.dupsOKBatchSize.equals(other.dupsOKBatchSize))
-         return false;
-      if (this.groupID == null) {
-         if (other.groupID != null)
-            return false;
-      } else if (!this.groupID.equals(other.groupID))
-         return false;
-      if (this.initialConnectAttempts == null) {
-         if (other.initialConnectAttempts != null)
-            return false;
-      } else if (!this.initialConnectAttempts.equals(other.initialConnectAttempts))
-         return false;
-      if (this.initialMessagePacketSize == null) {
-         if (other.initialMessagePacketSize != null)
-            return false;
-      } else if (!this.initialMessagePacketSize.equals(other.initialMessagePacketSize))
-         return false;
-      if (this.jgroupsChannelName == null) {
-         if (other.jgroupsChannelName != null)
-            return false;
-      } else if (!this.jgroupsChannelName.equals(other.jgroupsChannelName))
-         return false;
-      if (this.jgroupsFile == null) {
-         if (other.jgroupsFile != null)
-            return false;
-      } else if (!this.jgroupsFile.equals(other.jgroupsFile))
-         return false;
-      if (this.maxRetryInterval == null) {
-         if (other.maxRetryInterval != null)
-            return false;
-      } else if (!this.maxRetryInterval.equals(other.maxRetryInterval))
-         return false;
-      if (this.minLargeMessageSize == null) {
-         if (other.minLargeMessageSize != null)
-            return false;
-      } else if (!this.minLargeMessageSize.equals(other.minLargeMessageSize))
-         return false;
-      if (this.producerMaxRate == null) {
-         if (other.producerMaxRate != null)
-            return false;
-      } else if (!this.producerMaxRate.equals(other.producerMaxRate))
-         return false;
-      if (this.producerWindowSize == null) {
-         if (other.producerWindowSize != null)
-            return false;
-      } else if (!this.producerWindowSize.equals(other.producerWindowSize))
-         return false;
-      if (this.protocolManagerFactoryStr == null) {
-         if (other.protocolManagerFactoryStr != null)
-            return false;
-      } else if (!protocolManagerFactoryStr.equals(other.protocolManagerFactoryStr))
-         return false;
-      if (this.reconnectAttempts == null) {
-         if (other.reconnectAttempts != null)
-            return false;
-      } else if (!this.reconnectAttempts.equals(other.reconnectAttempts))
-         return false;
-      if (this.retryInterval == null) {
-         if (other.retryInterval != null)
-            return false;
-      } else if (!this.retryInterval.equals(other.retryInterval))
-         return false;
-      if (this.retryIntervalMultiplier == null) {
-         if (other.retryIntervalMultiplier != null)
-            return false;
-      } else if (!this.retryIntervalMultiplier.equals(other.retryIntervalMultiplier))
-         return false;
-      if (this.scheduledThreadPoolMaxSize == null) {
-         if (other.scheduledThreadPoolMaxSize != null)
-            return false;
-      } else if (!this.scheduledThreadPoolMaxSize.equals(other.scheduledThreadPoolMaxSize))
-         return false;
-      if (this.threadPoolMaxSize == null) {
-         if (other.threadPoolMaxSize != null)
-            return false;
-      } else if (!this.threadPoolMaxSize.equals(other.threadPoolMaxSize))
-         return false;
-      if (this.transactionBatchSize == null) {
-         if (other.transactionBatchSize != null)
-            return false;
-      } else if (!this.transactionBatchSize.equals(other.transactionBatchSize))
-         return false;
-      if (this.useGlobalPools == null) {
-         if (other.useGlobalPools != null)
-            return false;
-      } else if (!this.useGlobalPools.equals(other.useGlobalPools))
-         return false;
-      if (connectorClassName == null) {
-         if (other.connectorClassName != null)
-            return false;
-      } else if (!connectorClassName.equals(other.connectorClassName))
-         return false;
-      if (this.connectionParameters == null) {
-         if (other.connectionParameters != null)
-            return false;
-      } else if (!connectionParameters.equals(other.connectionParameters))
-         return false;
+      }
 
-      if (deserializationDenyList == null) {
-         if (other.deserializationDenyList != null)
-            return false;
-      } else if (!deserializationDenyList.equals(other.deserializationDenyList))
-         return false;
-
-      if (deserializationAllowList == null) {
-         if (other.deserializationAllowList != null)
-            return false;
-      } else if (!deserializationAllowList.equals(other.deserializationAllowList))
-         return false;
-
-      if (this.enable1xPrefixes == null) {
-         if (other.enable1xPrefixes != null)
-            return false;
-      } else if (!this.enable1xPrefixes.equals(other.enable1xPrefixes))
-         return false;
-
-      if (enableSharedClientID == null) {
-         if (other.enableSharedClientID != null)
-            return false;
-      } else if (!this.enableSharedClientID.equals(other.enableSharedClientID))
-         return false;
-
-      return true;
+      return Objects.equals(autoGroup, other.autoGroup) &&
+             Objects.equals(blockOnAcknowledge, other.blockOnAcknowledge) &&
+             Objects.equals(blockOnDurableSend, other.blockOnDurableSend) &&
+             Objects.equals(blockOnNonDurableSend, other.blockOnNonDurableSend) &&
+             Objects.equals(cacheLargeMessagesClient, other.cacheLargeMessagesClient) &&
+             Objects.equals(compressLargeMessage, other.compressLargeMessage) &&
+             Objects.equals(ha, other.ha) &&
+             Objects.equals(preAcknowledge, other.preAcknowledge) &&
+             Objects.equals(callFailoverTimeout, other.callFailoverTimeout) &&
+             Objects.equals(callTimeout, other.callTimeout) &&
+             Objects.equals(clientFailureCheckPeriod, other.clientFailureCheckPeriod) &&
+             Objects.equals(clientID, other.clientID) &&
+             Objects.equals(confirmationWindowSize, other.confirmationWindowSize) &&
+             Objects.equals(connectionLoadBalancingPolicyClassName, other.connectionLoadBalancingPolicyClassName) &&
+             Objects.equals(connectionTTL, other.connectionTTL) &&
+             Objects.equals(consumerMaxRate, other.consumerMaxRate) &&
+             Objects.equals(consumerWindowSize, other.consumerWindowSize) &&
+             Objects.equals(discoveryAddress, other.discoveryAddress) &&
+             Objects.equals(discoveryInitialWaitTimeout, other.discoveryInitialWaitTimeout) &&
+             Objects.equals(discoveryLocalBindAddress, other.discoveryLocalBindAddress) &&
+             Objects.equals(discoveryPort, other.discoveryPort) &&
+             Objects.equals(discoveryRefreshTimeout, other.discoveryRefreshTimeout) &&
+             Objects.equals(dupsOKBatchSize, other.dupsOKBatchSize) &&
+             Objects.equals(groupID, other.groupID) &&
+             Objects.equals(initialConnectAttempts, other.initialConnectAttempts) &&
+             Objects.equals(initialMessagePacketSize, other.initialMessagePacketSize) &&
+             Objects.equals(jgroupsChannelName, other.jgroupsChannelName) &&
+             Objects.equals(jgroupsFile, other.jgroupsFile) &&
+             Objects.equals(maxRetryInterval, other.maxRetryInterval) &&
+             Objects.equals(minLargeMessageSize, other.minLargeMessageSize) &&
+             Objects.equals(producerMaxRate, other.producerMaxRate) &&
+             Objects.equals(producerWindowSize, other.producerWindowSize) &&
+             Objects.equals(protocolManagerFactoryStr, other.protocolManagerFactoryStr) &&
+             Objects.equals(reconnectAttempts, other.reconnectAttempts) &&
+             Objects.equals(retryInterval, other.retryInterval) &&
+             Objects.equals(retryIntervalMultiplier, other.retryIntervalMultiplier) &&
+             Objects.equals(scheduledThreadPoolMaxSize, other.scheduledThreadPoolMaxSize) &&
+             Objects.equals(threadPoolMaxSize, other.threadPoolMaxSize) &&
+             Objects.equals(transactionBatchSize, other.transactionBatchSize) &&
+             Objects.equals(useGlobalPools, other.useGlobalPools) &&
+             Objects.equals(connectorClassName, other.connectorClassName) &&
+             Objects.equals(connectionParameters, other.connectionParameters) &&
+             Objects.equals(deserializationDenyList, other.deserializationDenyList) &&
+             Objects.equals(deserializationAllowList, other.deserializationAllowList) &&
+             Objects.equals(enable1xPrefixes, other.enable1xPrefixes) &&
+             Objects.equals(enableSharedClientID, other.enableSharedClientID);
    }
 
    @Override

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java
@@ -24,6 +24,7 @@ import javax.resource.spi.ResourceAdapter;
 import java.io.Serializable;
 import java.lang.invoke.MethodHandles;
 import java.util.Hashtable;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.ra.ActiveMQRALogger;
 import org.apache.activemq.artemis.ra.ActiveMQRaUtils;
@@ -592,66 +593,42 @@ public class ActiveMQActivationSpec extends ConnectionFactoryProperties implemen
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof ActiveMQActivationSpec that)) {
          return false;
-      if (!super.equals(o))
+      }
+      if (!super.equals(obj)) {
          return false;
+      }
 
-      ActiveMQActivationSpec that = (ActiveMQActivationSpec) o;
-
-      if (acknowledgeMode != null ? !acknowledgeMode.equals(that.acknowledgeMode) : that.acknowledgeMode != null)
-         return false;
-      if (subscriptionDurability != null ? !subscriptionDurability.equals(that.subscriptionDurability) : that.subscriptionDurability != null)
-         return false;
-      if (shareSubscriptions != null ? !shareSubscriptions.equals(that.shareSubscriptions) : that.shareSubscriptions != null)
-         return false;
-      if (strConnectorClassName != null ? !strConnectorClassName.equals(that.strConnectorClassName) : that.strConnectorClassName != null)
-         return false;
-      if (strConnectionParameters != null ? !strConnectionParameters.equals(that.strConnectionParameters) : that.strConnectionParameters != null)
-         return false;
-      if (ra != null ? !ra.equals(that.ra) : that.ra != null)
-         return false;
-      if (connectionFactoryLookup != null ? !connectionFactoryLookup.equals(that.connectionFactoryLookup) : that.connectionFactoryLookup != null)
-         return false;
-      if (destination != null ? !destination.equals(that.destination) : that.destination != null)
-         return false;
-      if (destinationType != null ? !destinationType.equals(that.destinationType) : that.destinationType != null)
-         return false;
-      if (messageSelector != null ? !messageSelector.equals(that.messageSelector) : that.messageSelector != null)
-         return false;
-      if (subscriptionName != null ? !subscriptionName.equals(that.subscriptionName) : that.subscriptionName != null)
-         return false;
-      if (user != null ? !user.equals(that.user) : that.user != null)
-         return false;
-      if (password != null ? !password.equals(that.password) : that.password != null)
-         return false;
-      if (maxSession != null ? !maxSession.equals(that.maxSession) : that.maxSession != null)
-         return false;
-      if (useJNDI != null ? !useJNDI.equals(that.useJNDI) : that.useJNDI != null)
-         return false;
-      if (transactionTimeout != null ? !transactionTimeout.equals(that.transactionTimeout) : that.transactionTimeout != null)
-         return false;
-      if (singleConnection != null ? !singleConnection.equals(that.singleConnection) : that.singleConnection != null)
-         return false;
-      if (jndiParams != null ? !jndiParams.equals(that.jndiParams) : that.jndiParams != null)
-         return false;
-      if (parsedJndiParams != null ? !parsedJndiParams.equals(that.parsedJndiParams) : that.parsedJndiParams != null)
-         return false;
-      if (localTx != null ? !localTx.equals(that.localTx) : that.localTx != null)
-         return false;
-      if (rebalanceConnections != null ? !rebalanceConnections.equals(that.rebalanceConnections) : that.rebalanceConnections != null)
-         return false;
-      if (setupAttempts != null ? !setupAttempts.equals(that.setupAttempts) : that.setupAttempts != null)
-         return false;
-      if (queuePrefix != null ? !queuePrefix.equals(that.queuePrefix) : that.queuePrefix != null)
-         return false;
-      if (topicPrefix != null ? !topicPrefix.equals(that.topicPrefix) : that.topicPrefix != null)
-         return false;
-      return !(setupInterval != null ? !setupInterval.equals(that.setupInterval) : that.setupInterval != null);
-
+      return Objects.equals(acknowledgeMode, that.acknowledgeMode) &&
+             Objects.equals(subscriptionDurability, that.subscriptionDurability) &&
+             Objects.equals(shareSubscriptions, that.shareSubscriptions) &&
+             Objects.equals(strConnectorClassName, that.strConnectorClassName) &&
+             Objects.equals(strConnectionParameters, that.strConnectionParameters) &&
+             Objects.equals(ra, that.ra) &&
+             Objects.equals(connectionFactoryLookup, that.connectionFactoryLookup) &&
+             Objects.equals(destination, that.destination) &&
+             Objects.equals(destinationType, that.destinationType) &&
+             Objects.equals(messageSelector, that.messageSelector) &&
+             Objects.equals(subscriptionName, that.subscriptionName) &&
+             Objects.equals(user, that.user) &&
+             Objects.equals(password, that.password) &&
+             Objects.equals(maxSession, that.maxSession) &&
+             Objects.equals(useJNDI, that.useJNDI) &&
+             Objects.equals(transactionTimeout, that.transactionTimeout) &&
+             Objects.equals(singleConnection, that.singleConnection) &&
+             Objects.equals(jndiParams, that.jndiParams) &&
+             Objects.equals(parsedJndiParams, that.parsedJndiParams) &&
+             Objects.equals(localTx, that.localTx) &&
+             Objects.equals(rebalanceConnections, that.rebalanceConnections) &&
+             Objects.equals(setupAttempts, that.setupAttempts) &&
+             Objects.equals(queuePrefix, that.queuePrefix) &&
+             Objects.equals(topicPrefix, that.topicPrefix) &&
+             Objects.equals(setupInterval, that.setupInterval);
    }
 
    @Override

--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/BinaryExpression.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/BinaryExpression.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.selector.filter;
 
+import java.util.Objects;
+
 /**
  * An expression which performs an operation on two expression values.
  */
@@ -51,30 +53,17 @@ public abstract class BinaryExpression implements Expression {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof BinaryExpression other)) {
          return false;
       }
 
-      final BinaryExpression that = (BinaryExpression) o;
-
-      if (!this.getExpressionSymbol().equals(that.getExpressionSymbol())) {
-         return false;
-      }
-
-      if (left != null && !left.equals(that.left)) {
-         return false;
-      }
-
-      if (right != null && !right.equals(that.right)) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(this.getExpressionSymbol(), other.getExpressionSymbol()) &&
+             Objects.equals(left, other.left) &&
+             Objects.equals(right, other.right);
    }
 
    /**

--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/ConstantExpression.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/ConstantExpression.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.selector.filter;
 
 import java.math.BigDecimal;
+import java.util.Objects;
 
 /**
  * Represents a constant expression
@@ -120,18 +121,15 @@ public class ConstantExpression implements Expression {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof ConstantExpression other)) {
          return false;
       }
-      final ConstantExpression that = (ConstantExpression) o;
-      if (value != null && !value.equals(that.value)) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(value, other.value);
    }
 
    /**

--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/PropertyExpression.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/PropertyExpression.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.selector.filter;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.SimpleString;
 
 /**
@@ -53,12 +55,15 @@ public class PropertyExpression implements Expression {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (o == null || !this.getClass().equals(o.getClass())) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof PropertyExpression other)) {
          return false;
       }
-      return name.equals(((PropertyExpression) o).name);
 
+      return Objects.equals(name, other.name);
    }
 
 }

--- a/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/UnaryExpression.java
+++ b/artemis-selector/src/main/java/org/apache/activemq/artemis/selector/filter/UnaryExpression.java
@@ -20,6 +20,7 @@ import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * An expression which performs an operation on two expression values
@@ -239,26 +240,16 @@ public abstract class UnaryExpression implements Expression {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof UnaryExpression other)) {
          return false;
       }
 
-      final UnaryExpression that = (UnaryExpression) o;
-
-      if (!this.getExpressionSymbol().equals(that.getExpressionSymbol())) {
-         return false;
-      }
-
-      if (right != null && !right.equals(that.right)) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(this.getExpressionSymbol(), other.getExpressionSymbol()) &&
+             Objects.equals(this.right, other.right);
    }
 
    /**

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/BridgeConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/BridgeConfiguration.java
@@ -28,6 +28,7 @@ import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
@@ -704,96 +705,39 @@ public final class BridgeConfiguration implements Serializable {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof BridgeConfiguration other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      BridgeConfiguration other = (BridgeConfiguration) obj;
-      if (callTimeout != other.callTimeout)
-         return false;
-      if (clientFailureCheckPeriod != other.clientFailureCheckPeriod)
-         return false;
-      if (confirmationWindowSize != other.confirmationWindowSize)
-         return false;
-      if (producerWindowSize != other.producerWindowSize)
-         return false;
-      if (connectionTTL != other.connectionTTL)
-         return false;
-      if (discoveryGroupName == null) {
-         if (other.discoveryGroupName != null)
-            return false;
-      } else if (!discoveryGroupName.equals(other.discoveryGroupName))
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (forwardingAddress == null) {
-         if (other.forwardingAddress != null)
-            return false;
-      } else if (!forwardingAddress.equals(other.forwardingAddress))
-         return false;
-      if (ha != other.ha)
-         return false;
-      if (maxRetryInterval != other.maxRetryInterval)
-         return false;
-      if (minLargeMessageSize != other.minLargeMessageSize)
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!parentName.equals(other.parentName))
-         return false;
-      if (password == null) {
-         if (other.password != null)
-            return false;
-      } else if (!password.equals(other.password))
-         return false;
-      if (queueName == null) {
-         if (other.queueName != null)
-            return false;
-      } else if (!queueName.equals(other.queueName))
-         return false;
-      if (initialConnectAttempts != other.initialConnectAttempts)
-         return false;
-      if (reconnectAttempts != other.reconnectAttempts)
-         return false;
-      if (retryInterval != other.retryInterval)
-         return false;
-      if (Double.doubleToLongBits(retryIntervalMultiplier) != Double.doubleToLongBits(other.retryIntervalMultiplier))
-         return false;
-      if (staticConnectors == null) {
-         if (other.staticConnectors != null)
-            return false;
-      } else if (!staticConnectors.equals(other.staticConnectors))
-         return false;
-      if (transformerConfiguration == null) {
-         if (other.transformerConfiguration != null)
-            return false;
-      } else if (!transformerConfiguration.equals(other.transformerConfiguration))
-         return false;
-      if (useDuplicateDetection != other.useDuplicateDetection)
-         return false;
-      if (user == null) {
-         if (other.user != null)
-            return false;
-      } else if (!user.equals(other.user))
-         return false;
-      if (concurrency != other.concurrency)
-         return false;
-      if (pendingAckTimeout != other.pendingAckTimeout)
-         return false;
-      if (configurationManaged != other.configurationManaged)
-         return false;
-      if (clientId == null) {
-         if (other.clientId != null)
-            return false;
-      } else if (!clientId.equals(other.clientId))
-         return false;
-      return true;
+      }
+      return callTimeout == other.callTimeout &&
+             clientFailureCheckPeriod == other.clientFailureCheckPeriod &&
+             confirmationWindowSize == other.confirmationWindowSize &&
+             producerWindowSize == other.producerWindowSize &&
+             connectionTTL == other.connectionTTL &&
+             ha == other.ha &&
+             maxRetryInterval == other.maxRetryInterval &&
+             minLargeMessageSize == other.minLargeMessageSize &&
+             initialConnectAttempts == other.initialConnectAttempts &&
+             reconnectAttempts == other.reconnectAttempts &&
+             retryInterval == other.retryInterval &&
+             Double.doubleToLongBits(retryIntervalMultiplier) == Double.doubleToLongBits(other.retryIntervalMultiplier) &&
+             useDuplicateDetection == other.useDuplicateDetection &&
+             concurrency == other.concurrency &&
+             pendingAckTimeout == other.pendingAckTimeout &&
+             configurationManaged == other.configurationManaged &&
+             Objects.equals(discoveryGroupName, other.discoveryGroupName) &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(forwardingAddress, other.forwardingAddress) &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(parentName, other.parentName) &&
+             Objects.equals(password, other.password) &&
+             Objects.equals(queueName, other.queueName) &&
+             Objects.equals(staticConnectors, other.staticConnectors) &&
+             Objects.equals(transformerConfiguration, other.transformerConfiguration) &&
+             Objects.equals(user, other.user) &&
+             Objects.equals(clientId, other.clientId);
    }
 
    public int getEncodeSize() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ClusterConnectionConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ClusterConnectionConfiguration.java
@@ -21,6 +21,7 @@ import java.net.URI;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.DiscoveryGroupConfiguration;
@@ -422,110 +423,33 @@ public final class ClusterConnectionConfiguration implements Serializable {
       if (this == obj) {
          return true;
       }
-      if (obj == null) {
+      if (!(obj instanceof ClusterConnectionConfiguration other)) {
          return false;
       }
-      if (getClass() != obj.getClass()) {
-         return false;
-      }
-      ClusterConnectionConfiguration other = (ClusterConnectionConfiguration) obj;
-      if (address == null) {
-         if (other.address != null) {
-            return false;
-         }
-      } else if (!address.equals(other.address)) {
-         return false;
-      }
-      if (allowDirectConnectionsOnly != other.allowDirectConnectionsOnly) {
-         return false;
-      }
-      if (callFailoverTimeout != other.callFailoverTimeout) {
-         return false;
-      }
-      if (callTimeout != other.callTimeout) {
-         return false;
-      }
-      if (clientFailureCheckPeriod != other.clientFailureCheckPeriod) {
-         return false;
-      }
-      if (clusterNotificationAttempts != other.clusterNotificationAttempts) {
-         return false;
-      }
-      if (clusterNotificationInterval != other.clusterNotificationInterval) {
-         return false;
-      }
-      if (confirmationWindowSize != other.confirmationWindowSize) {
-         return false;
-      }
-      if (connectionTTL != other.connectionTTL) {
-         return false;
-      }
-      if (connectorName == null) {
-         if (other.connectorName != null) {
-            return false;
-         }
-      } else if (!connectorName.equals(other.connectorName)) {
-         return false;
-      }
-      if (discoveryGroupName == null) {
-         if (other.discoveryGroupName != null) {
-            return false;
-         }
-      } else if (!discoveryGroupName.equals(other.discoveryGroupName)) {
-         return false;
-      }
-      if (duplicateDetection != other.duplicateDetection) {
-         return false;
-      }
-      if (messageLoadBalancingType != other.messageLoadBalancingType) {
-         return false;
-      }
-      if (maxHops != other.maxHops) {
-         return false;
-      }
-      if (maxRetryInterval != other.maxRetryInterval) {
-         return false;
-      }
-      if (minLargeMessageSize != other.minLargeMessageSize) {
-         return false;
-      }
-      if (name == null) {
-         if (other.name != null) {
-            return false;
-         }
-      } else if (!name.equals(other.name)) {
-         return false;
-      }
-      if (initialConnectAttempts != other.initialConnectAttempts) {
-         return false;
-      }
-      if (reconnectAttempts != other.reconnectAttempts) {
-         return false;
-      }
-      if (retryInterval != other.retryInterval) {
-         return false;
-      }
-      if (Double.doubleToLongBits(retryIntervalMultiplier) != Double.doubleToLongBits(other.retryIntervalMultiplier)) {
-         return false;
-      }
-      if (staticConnectors == null) {
-         if (other.staticConnectors != null) {
-            return false;
-         }
-      } else if (!staticConnectors.equals(other.staticConnectors)) {
-         return false;
-      }
-      if (clientId == null) {
-         if (other.clientId != null) {
-            return false;
-         }
-      } else if (!clientId.equals(other.clientId)) {
-         return false;
-      }
-      if (topologyScannerAttempts != other.topologyScannerAttempts) {
-         return false;
-      }
-      return true;
+      return Objects.equals(address, other.address) &&
+             allowDirectConnectionsOnly == other.allowDirectConnectionsOnly &&
+             callFailoverTimeout == other.callFailoverTimeout &&
+             callTimeout == other.callTimeout &&
+             clientFailureCheckPeriod == other.clientFailureCheckPeriod &&
+             clusterNotificationAttempts == other.clusterNotificationAttempts &&
+             clusterNotificationInterval == other.clusterNotificationInterval &&
+             confirmationWindowSize == other.confirmationWindowSize &&
+             connectionTTL == other.connectionTTL &&
+             Objects.equals(connectorName, other.connectorName) &&
+             Objects.equals(discoveryGroupName, other.discoveryGroupName) &&
+             duplicateDetection == other.duplicateDetection &&
+             messageLoadBalancingType == other.messageLoadBalancingType &&
+             maxHops == other.maxHops &&
+             maxRetryInterval == other.maxRetryInterval &&
+             minLargeMessageSize == other.minLargeMessageSize &&
+             Objects.equals(name, other.name) &&
+             initialConnectAttempts == other.initialConnectAttempts &&
+             reconnectAttempts == other.reconnectAttempts &&
+             retryInterval == other.retryInterval &&
+             Double.doubleToLongBits(retryIntervalMultiplier) == Double.doubleToLongBits(other.retryIntervalMultiplier) &&
+             Objects.equals(staticConnectors, other.staticConnectors) &&
+             Objects.equals(clientId, other.clientId) &&
+             topologyScannerAttempts == other.topologyScannerAttempts;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ConnectorServiceConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/ConnectorServiceConfiguration.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.config;
 
 import java.io.Serializable;
 import java.util.Map;
+import java.util.Objects;
 
 public class ConnectorServiceConfiguration implements Serializable {
 
@@ -64,22 +65,17 @@ public class ConnectorServiceConfiguration implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof ConnectorServiceConfiguration other)) {
          return false;
+      }
 
-      ConnectorServiceConfiguration that = (ConnectorServiceConfiguration) o;
-
-      if (getFactoryClassName() != null ? !getFactoryClassName().equals(that.getFactoryClassName()) : that.getFactoryClassName() != null)
-         return false;
-      if (getConnectorName() != null ? !getConnectorName().equals(that.getConnectorName()) : that.getConnectorName() != null)
-         return false;
-      if (getParams() != null ? !getParams().equals(that.getParams()) : that.getParams() != null)
-         return false;
-
-      return true;
+      return Objects.equals(getFactoryClassName(), other.getFactoryClassName()) &&
+             Objects.equals(getConnectorName(), other.getConnectorName()) &&
+             Objects.equals(getParams(), other.getParams());
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/CoreQueueConfiguration.java
@@ -312,118 +312,31 @@ public class CoreQueueConfiguration implements Serializable {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
-         return false;
-      if (getClass() != obj.getClass())
-         return false;
-      CoreQueueConfiguration other = (CoreQueueConfiguration) obj;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (durable != other.durable)
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      if (maxConsumers == null) {
-         if (other.maxConsumers != null)
-            return false;
-      } else if (!maxConsumers.equals(other.maxConsumers))
-         return false;
-      if (purgeOnNoConsumers == null) {
-         if (other.purgeOnNoConsumers != null)
-            return false;
-      } else if (!purgeOnNoConsumers.equals(other.purgeOnNoConsumers)) {
-         return false;
       }
-      if (ringSize == null) {
-         if (other.ringSize != null)
-            return false;
-      } else if (!ringSize.equals(other.ringSize)) {
-         return false;
-      }
-      if (enabled == null) {
-         if (other.enabled != null)
-            return false;
-      } else if (!enabled.equals(other.enabled)) {
-         return false;
-      }
-      if (exclusive == null) {
-         if (other.exclusive != null)
-            return false;
-      } else if (!exclusive.equals(other.exclusive)) {
+      if (!(obj instanceof CoreQueueConfiguration other)) {
          return false;
       }
 
-      if (groupRebalance == null) {
-         if (other.groupRebalance != null)
-            return false;
-      } else if (!groupRebalance.equals(other.groupRebalance)) {
-         return false;
-      }
-
-      if (groupBuckets == null) {
-         if (other.groupBuckets != null)
-            return false;
-      } else if (!groupBuckets.equals(other.groupBuckets)) {
-         return false;
-      }
-
-      if (groupFirstKey == null) {
-         if (other.groupFirstKey != null)
-            return false;
-      } else if (!groupFirstKey.equals(other.groupFirstKey)) {
-         return false;
-      }
-
-      if (lastValue == null) {
-         if (other.lastValue != null)
-            return false;
-      } else if (!lastValue.equals(other.lastValue)) {
-         return false;
-      }
-      if (lastValueKey == null) {
-         if (other.lastValueKey != null)
-            return false;
-      } else if (!lastValueKey.equals(other.lastValueKey)) {
-         return false;
-      }
-      if (nonDestructive == null) {
-         if (other.nonDestructive != null)
-            return false;
-      } else if (!nonDestructive.equals(other.nonDestructive)) {
-         return false;
-      }
-      if (consumersBeforeDispatch == null) {
-         if (other.consumersBeforeDispatch != null)
-            return false;
-      } else if (!consumersBeforeDispatch.equals(other.consumersBeforeDispatch)) {
-         return false;
-      }
-      if (delayBeforeDispatch == null) {
-         if (other.delayBeforeDispatch != null)
-            return false;
-      } else if (!delayBeforeDispatch.equals(other.delayBeforeDispatch)) {
-         return false;
-      }
-      if (routingType == null) {
-         if (other.routingType != null)
-            return false;
-      } else if (!routingType.equals(other.routingType)) {
-         return false;
-      }
-      return true;
+      return Objects.equals(address, other.address) &&
+             durable == other.durable &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(maxConsumers, other.maxConsumers) &&
+             Objects.equals(purgeOnNoConsumers, other.purgeOnNoConsumers) &&
+             Objects.equals(ringSize, other.ringSize) &&
+             Objects.equals(enabled, other.enabled) &&
+             Objects.equals(exclusive, other.exclusive) &&
+             Objects.equals(groupRebalance, other.groupRebalance) &&
+             Objects.equals(groupBuckets, other.groupBuckets) &&
+             Objects.equals(groupFirstKey, other.groupFirstKey) &&
+             Objects.equals(lastValue, other.lastValue) &&
+             Objects.equals(lastValueKey, other.lastValueKey) &&
+             Objects.equals(nonDestructive, other.nonDestructive) &&
+             Objects.equals(consumersBeforeDispatch, other.consumersBeforeDispatch) &&
+             Objects.equals(delayBeforeDispatch, other.delayBeforeDispatch) &&
+             Objects.equals(routingType, other.routingType);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.config;
 import java.io.Serializable;
 import java.io.StringReader;
 import java.util.Map;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
@@ -275,53 +276,22 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof DivertConfiguration other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      DivertConfiguration other = (DivertConfiguration) obj;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (exclusive != other.exclusive)
-         return false;
-      if (filterString == null) {
-         if (other.filterString != null)
-            return false;
-      } else if (!filterString.equals(other.filterString))
-         return false;
-      if (forwardingAddress == null) {
-         if (other.forwardingAddress != null)
-            return false;
-      } else if (!forwardingAddress.equals(other.forwardingAddress))
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      if (routingName == null) {
-         if (other.routingName != null)
-            return false;
-      } else if (!routingName.equals(other.routingName))
-         return false;
-      if (transformerConfiguration == null) {
-         if (other.transformerConfiguration != null)
-            return false;
-      } else if (!transformerConfiguration.equals(other.transformerConfiguration))
-         return false;
-      if (routingType == null) {
-         if (other.routingType != null)
-            return false;
-      } else if (!routingType.equals(other.routingType))
-         return false;
-      return true;
-   }
+      }
 
+      return Objects.equals(address, other.address) &&
+             exclusive == other.exclusive &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(forwardingAddress, other.forwardingAddress) &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(routingName, other.routingName) &&
+             Objects.equals(transformerConfiguration, other.transformerConfiguration) &&
+             Objects.equals(routingType, other.routingType);
+   }
 
    @Override
    public int getEncodeSize() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/WildcardConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/WildcardConfiguration.java
@@ -48,29 +48,19 @@ public class WildcardConfiguration implements Serializable {
 
    String escapeString = String.valueOf(ESCAPE);
 
-
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (!(o instanceof WildcardConfiguration that)) {
+      if (!(obj instanceof WildcardConfiguration other)) {
          return false;
       }
 
-      if (routingEnabled != that.routingEnabled) {
-         return false;
-      }
-      if (singleWord != that.singleWord) {
-         return false;
-      }
-      if (anyWords != that.anyWords) {
-         return false;
-      }
-      if (delimiter != that.delimiter) {
-         return false;
-      }
-      return true;
+      return routingEnabled == other.routingEnabled &&
+             singleWord == other.singleWord &&
+             anyWords == other.anyWords &&
+             delimiter == other.delimiter;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeAddressPolicyElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeAddressPolicyElement.java
@@ -209,27 +209,25 @@ public final class AMQPBridgeAddressPolicyElement implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (!(o instanceof AMQPBridgeAddressPolicyElement)) {
+      if (!(obj instanceof AMQPBridgeAddressPolicyElement other)) {
          return false;
       }
 
-      final AMQPBridgeAddressPolicyElement that = (AMQPBridgeAddressPolicyElement) o;
-
-      return Objects.equals(name, that.name) &&
-             Objects.equals(includes, that.includes) &&
-             Objects.equals(excludes, that.excludes) &&
-             Objects.equals(priority, that.priority) &&
-             Objects.equals(includeDivertBindings, that.includeDivertBindings) &&
-             Objects.equals(useDurableSubscriptions, that.useDurableSubscriptions) &&
-             Objects.equals(filter, that.filter) &&
-             Objects.equals(remoteAddress, that.remoteAddress) &&
-             Objects.equals(remoteAddressPrefix, that.remoteAddressPrefix) &&
-             Objects.equals(remoteAddressSuffix, that.remoteAddressSuffix) &&
-             Arrays.equals(remoteTerminusCapabilities, that.remoteTerminusCapabilities);
+      return Objects.equals(name, other.name) &&
+             Objects.equals(includes, other.includes) &&
+             Objects.equals(excludes, other.excludes) &&
+             Objects.equals(priority, other.priority) &&
+             Objects.equals(includeDivertBindings, other.includeDivertBindings) &&
+             Objects.equals(useDurableSubscriptions, other.useDurableSubscriptions) &&
+             Objects.equals(filter, other.filter) &&
+             Objects.equals(remoteAddress, other.remoteAddress) &&
+             Objects.equals(remoteAddressPrefix, other.remoteAddressPrefix) &&
+             Objects.equals(remoteAddressSuffix, other.remoteAddressSuffix) &&
+             Arrays.equals(remoteTerminusCapabilities, other.remoteTerminusCapabilities);
    }
 
    @Override
@@ -270,18 +268,15 @@ public final class AMQPBridgeAddressPolicyElement implements Serializable {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) {
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
          }
-
-         if (!(o instanceof AddressMatch)) {
+         if (!(obj instanceof AddressMatch other)) {
             return false;
          }
 
-         final AddressMatch matcher = (AddressMatch) o;
-
-         return Objects.equals(addressMatch, matcher.addressMatch);
+         return Objects.equals(addressMatch, other.addressMatch);
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeBrokerConnectionElement.java
@@ -178,16 +178,12 @@ public class AMQPBridgeBrokerConnectionElement extends AMQPBrokerConnectionEleme
       if (this == obj) {
          return true;
       }
-
       if (!super.equals(obj)) {
          return false;
       }
-
-      if (getClass() != obj.getClass()) {
+      if (!(obj instanceof AMQPBridgeBrokerConnectionElement other)) {
          return false;
       }
-
-      final AMQPBridgeBrokerConnectionElement other = (AMQPBridgeBrokerConnectionElement) obj;
 
       return Objects.equals(bridgeFromAddressPolicies, other.bridgeFromAddressPolicies) &&
              Objects.equals(bridgeFromQueuePolicies, other.bridgeFromQueuePolicies) &&

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeQueuePolicyElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBridgeQueuePolicyElement.java
@@ -199,25 +199,23 @@ public final class AMQPBridgeQueuePolicyElement implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (!(o instanceof AMQPBridgeQueuePolicyElement)) {
+      if (!(obj instanceof AMQPBridgeQueuePolicyElement other)) {
          return false;
       }
 
-      final AMQPBridgeQueuePolicyElement that = (AMQPBridgeQueuePolicyElement) o;
-
-      return Objects.equals(name, that.name) &&
-             Objects.equals(includes, that.includes) &&
-             Objects.equals(excludes, that.excludes) &&
-             Objects.equals(priority, that.priority) &&
-             Objects.equals(priorityAdjustment, that.priorityAdjustment) &&
-             Objects.equals(filter, that.filter) &&
-             Objects.equals(remoteAddress, that.remoteAddress) &&
-             Objects.equals(remoteAddressPrefix, that.remoteAddressPrefix) &&
-             Arrays.equals(remoteTerminusCapabilities, that.remoteTerminusCapabilities);
+      return Objects.equals(name, other.name) &&
+             Objects.equals(includes, other.includes) &&
+             Objects.equals(excludes, other.excludes) &&
+             Objects.equals(priority, other.priority) &&
+             Objects.equals(priorityAdjustment, other.priorityAdjustment) &&
+             Objects.equals(filter, other.filter) &&
+             Objects.equals(remoteAddress, other.remoteAddress) &&
+             Objects.equals(remoteAddressPrefix, other.remoteAddressPrefix) &&
+             Arrays.equals(remoteTerminusCapabilities, other.remoteTerminusCapabilities);
    }
 
    @Override
@@ -268,19 +266,16 @@ public final class AMQPBridgeQueuePolicyElement implements Serializable {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) {
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
          }
-
-         if (!(o instanceof QueueMatch)) {
+         if (!(obj instanceof QueueMatch other)) {
             return false;
          }
 
-         final QueueMatch matcher = (QueueMatch) o;
-
-         return Objects.equals(queueMatch, matcher.queueMatch) &&
-                Objects.equals(addressMatch, matcher.addressMatch);
+         return Objects.equals(queueMatch, other.queueMatch) &&
+                Objects.equals(addressMatch, other.addressMatch);
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectConfiguration.java
@@ -189,16 +189,12 @@ public class AMQPBrokerConnectConfiguration extends BrokerConnectConfiguration {
       if (this == obj) {
          return true;
       }
-
       if (!super.equals(obj)) {
          return false;
       }
-
-      if (getClass() != obj.getClass()) {
+      if (!(obj instanceof AMQPBrokerConnectConfiguration other)) {
          return false;
       }
-
-      final AMQPBrokerConnectConfiguration other = (AMQPBrokerConnectConfiguration) obj;
 
       return Objects.equals(connectionElements, other.connectionElements) &&
              Objects.equals(transportConfigurations, other.transportConfigurations);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPBrokerConnectionElement.java
@@ -109,18 +109,11 @@ public class AMQPBrokerConnectionElement implements Serializable {
       if (this == obj) {
          return true;
       }
-
-      if (obj == null) {
+      if (!(obj instanceof AMQPBrokerConnectionElement other)) {
          return false;
       }
 
-      if (getClass() != obj.getClass()) {
-         return false;
-      }
-
-      final AMQPBrokerConnectionElement other = (AMQPBrokerConnectionElement) obj;
-
-      return type == other.type &&
+      return Objects.equals(type, other.type) &&
              Objects.equals(name, other.name) &&
              Objects.equals(matchAddress, other.matchAddress) &&
              Objects.equals(queueName, other.queueName);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPFederatedBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPFederatedBrokerConnectionElement.java
@@ -165,16 +165,12 @@ public class AMQPFederatedBrokerConnectionElement extends AMQPBrokerConnectionEl
       if (this == obj) {
          return true;
       }
-
       if (!super.equals(obj)) {
          return false;
       }
-
-      if (getClass() != obj.getClass()) {
+      if (!(obj instanceof AMQPFederatedBrokerConnectionElement other)) {
          return false;
       }
-
-      final AMQPFederatedBrokerConnectionElement other = (AMQPFederatedBrokerConnectionElement) obj;
 
       return Objects.equals(localAddressPolicies, other.localAddressPolicies) &&
              Objects.equals(localQueuePolicies, other.localQueuePolicies) &&

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPFederationAddressPolicyElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPFederationAddressPolicyElement.java
@@ -174,21 +174,21 @@ public final class AMQPFederationAddressPolicyElement implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (!(o instanceof AMQPFederationAddressPolicyElement that)) {
+      if (!(obj instanceof AMQPFederationAddressPolicyElement other)) {
          return false;
       }
 
-      return maxHops == that.maxHops &&
-             Objects.equals(name, that.name) &&
-             Objects.equals(includes, that.includes) &&
-             Objects.equals(excludes, that.excludes) &&
-             Objects.equals(autoDelete, that.autoDelete) &&
-             Objects.equals(autoDeleteDelay, that.autoDeleteDelay) &&
-             Objects.equals(autoDeleteMessageCount, that.autoDeleteMessageCount);
+      return Objects.equals(name, other.name) &&
+             Objects.equals(includes, other.includes) &&
+             Objects.equals(excludes, other.excludes) &&
+             Objects.equals(autoDelete, other.autoDelete) &&
+             Objects.equals(autoDeleteDelay, other.autoDeleteDelay) &&
+             Objects.equals(autoDeleteMessageCount, other.autoDeleteMessageCount) &&
+             maxHops == other.maxHops;
    }
 
    @Override
@@ -231,16 +231,15 @@ public final class AMQPFederationAddressPolicyElement implements Serializable {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) {
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
          }
-
-         if (!(o instanceof AddressMatch matcher)) {
+         if (!(obj instanceof AddressMatch other)) {
             return false;
          }
 
-         return Objects.equals(addressMatch, matcher.addressMatch);
+         return Objects.equals(addressMatch, other.addressMatch);
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPFederationQueuePolicyElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPFederationQueuePolicyElement.java
@@ -144,19 +144,19 @@ public final class AMQPFederationQueuePolicyElement implements Serializable {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (!(o instanceof AMQPFederationQueuePolicyElement that)) {
+      if (!(obj instanceof AMQPFederationQueuePolicyElement other)) {
          return false;
       }
 
-      return includeFederated == that.includeFederated &&
-             Objects.equals(name, that.name) &&
-             Objects.equals(includes, that.includes) &&
-             Objects.equals(excludes, that.excludes) &&
-             Objects.equals(priorityAdjustment, that.priorityAdjustment);
+      return includeFederated == other.includeFederated &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(includes, other.includes) &&
+             Objects.equals(excludes, other.excludes) &&
+             Objects.equals(priorityAdjustment, other.priorityAdjustment);
    }
 
    @Override
@@ -209,17 +209,16 @@ public final class AMQPFederationQueuePolicyElement implements Serializable {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) {
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
          }
-
-         if (!(o instanceof QueueMatch matcher)) {
+         if (!(obj instanceof QueueMatch other)) {
             return false;
          }
 
-         return Objects.equals(queueMatch, matcher.queueMatch) &&
-                Objects.equals(addressMatch, matcher.addressMatch);
+         return Objects.equals(queueMatch, other.queueMatch) &&
+                Objects.equals(addressMatch, other.addressMatch);
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPMirrorBrokerConnectionElement.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/amqpBrokerConnectivity/AMQPMirrorBrokerConnectionElement.java
@@ -165,23 +165,19 @@ public class AMQPMirrorBrokerConnectionElement extends AMQPBrokerConnectionEleme
       if (this == obj) {
          return true;
       }
-
       if (!super.equals(obj)) {
          return false;
       }
-
-      if (getClass() != obj.getClass()) {
+      if (!(obj instanceof AMQPMirrorBrokerConnectionElement other)) {
          return false;
       }
 
-      final AMQPMirrorBrokerConnectionElement other = (AMQPMirrorBrokerConnectionElement) obj;
-
       return Objects.equals(addressFilter, other.addressFilter) &&
-             durable == other.durable &&
-             messageAcknowledgements == other.messageAcknowledgements &&
+             Objects.equals(durable, other.durable) &&
+             Objects.equals(messageAcknowledgements, other.messageAcknowledgements) &&
              Objects.equals(mirrorSNF, other.mirrorSNF) &&
-             queueCreation == other.queueCreation &&
-             queueRemoval == other.queueRemoval &&
-             sync == other.sync;
+             Objects.equals(queueCreation, other.queueCreation) &&
+             Objects.equals(queueRemoval, other.queueRemoval) &&
+             Objects.equals(sync, other.sync);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/brokerConnectivity/BrokerConnectConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/brokerConnectivity/BrokerConnectConfiguration.java
@@ -117,22 +117,15 @@ public abstract class BrokerConnectConfiguration implements Serializable {
       if (this == obj) {
          return true;
       }
-
-      if (obj == null) {
+      if (!(obj instanceof BrokerConnectConfiguration other)) {
          return false;
       }
-
-      if (getClass() != obj.getClass()) {
-         return false;
-      }
-
-      final BrokerConnectConfiguration other = (BrokerConnectConfiguration) obj;
 
       return Objects.equals(name, other.name) &&
-             autostart == other.autostart &&
+             Objects.equals(autostart, other.autostart) &&
              Objects.equals(password, other.password) &&
-             reconnectAttempts == other.reconnectAttempts &&
-             retryInterval == other.retryInterval &&
+             Objects.equals(reconnectAttempts, other.reconnectAttempts) &&
+             Objects.equals(retryInterval, other.retryInterval) &&
              Objects.equals(uri, other.uri) &&
              Objects.equals(user, other.user);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -2957,255 +2957,88 @@ public class ConfigurationImpl implements Configuration, Serializable {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
-         return false;
-      if (!(obj instanceof ConfigurationImpl other))
-         return false;
-      if (acceptorConfigs == null) {
-         if (other.acceptorConfigs != null)
-            return false;
-      } else if (!acceptorConfigs.equals(other.acceptorConfigs))
-         return false;
-      if (addressSettings == null) {
-         if (other.addressSettings != null)
-            return false;
-      } else if (!addressSettings.equals(other.addressSettings))
-         return false;
-      if (asyncConnectionExecutionEnabled != other.asyncConnectionExecutionEnabled)
-         return false;
-      if (bindingsDirectory == null) {
-         if (other.bindingsDirectory != null)
-            return false;
-      } else if (!bindingsDirectory.equals(other.bindingsDirectory))
-         return false;
-      if (bridgeConfigurations == null) {
-         if (other.bridgeConfigurations != null)
-            return false;
-      } else if (!bridgeConfigurations.equals(other.bridgeConfigurations))
-         return false;
-      if (broadcastGroupConfigurations == null) {
-         if (other.broadcastGroupConfigurations != null)
-            return false;
-      } else if (!broadcastGroupConfigurations.equals(other.broadcastGroupConfigurations))
-         return false;
-
-      if (clusterConfigurations == null) {
-         if (other.clusterConfigurations != null)
-            return false;
-      } else if (!clusterConfigurations.equals(other.clusterConfigurations))
-         return false;
-
-      if (clusterPassword == null) {
-         if (other.clusterPassword != null)
-            return false;
-      } else if (!clusterPassword.equals(other.clusterPassword))
-         return false;
-      if (clusterUser == null) {
-         if (other.clusterUser != null)
-            return false;
-      } else if (!clusterUser.equals(other.clusterUser))
-         return false;
-      if (connectionTTLOverride != other.connectionTTLOverride)
-         return false;
-      if (connectorConfigs == null) {
-         if (other.connectorConfigs != null)
-            return false;
-      } else if (!connectorConfigs.equals(other.connectorConfigs))
-         return false;
-      if (connectorServiceConfigurations == null) {
-         if (other.connectorServiceConfigurations != null)
-            return false;
-      } else if (!connectorServiceConfigurations.equals(other.connectorServiceConfigurations))
-         return false;
-      if (createBindingsDir != other.createBindingsDir)
-         return false;
-      if (createJournalDir != other.createJournalDir)
-         return false;
-
-      if (discoveryGroupConfigurations == null) {
-         if (other.discoveryGroupConfigurations != null)
-            return false;
-      } else if (!discoveryGroupConfigurations.equals(other.discoveryGroupConfigurations))
-         return false;
-      if (divertConfigurations == null) {
-         if (other.divertConfigurations != null)
-            return false;
-      } else if (!divertConfigurations.equals(other.divertConfigurations))
-         return false;
-      if (failoverOnServerShutdown != other.failoverOnServerShutdown)
-         return false;
-      if (fileDeploymentScanPeriod != other.fileDeploymentScanPeriod)
-         return false;
-      if (groupingHandlerConfiguration == null) {
-         if (other.groupingHandlerConfiguration != null)
-            return false;
-      } else if (!groupingHandlerConfiguration.equals(other.groupingHandlerConfiguration))
-         return false;
-      if (idCacheSize != other.idCacheSize)
-         return false;
-      if (incomingInterceptorClassNames == null) {
-         if (other.incomingInterceptorClassNames != null)
-            return false;
-      } else if (!incomingInterceptorClassNames.equals(other.incomingInterceptorClassNames))
-         return false;
-      if (jmxDomain == null) {
-         if (other.jmxDomain != null)
-            return false;
-      } else if (!jmxDomain.equals(other.jmxDomain))
-         return false;
-      if (jmxManagementEnabled != other.jmxManagementEnabled)
-         return false;
-      if (journalBufferSize_AIO != other.journalBufferSize_AIO)
-         return false;
-      if (journalBufferSize_NIO != other.journalBufferSize_NIO)
-         return false;
-      if (journalBufferTimeout_AIO != other.journalBufferTimeout_AIO)
-         return false;
-      if (journalBufferTimeout_NIO != other.journalBufferTimeout_NIO)
-         return false;
-      if (journalCompactMinFiles != other.journalCompactMinFiles)
-         return false;
-      if (journalCompactPercentage != other.journalCompactPercentage)
-         return false;
-      if (journalDirectory == null) {
-         if (other.journalDirectory != null)
-            return false;
-      } else if (!journalDirectory.equals(other.journalDirectory))
-         return false;
-      if (journalFileSize != other.journalFileSize)
-         return false;
-      if (journalMaxIO_AIO != other.journalMaxIO_AIO)
-         return false;
-      if (journalMaxIO_NIO != other.journalMaxIO_NIO)
-         return false;
-      if (journalMinFiles != other.journalMinFiles)
-         return false;
-      if (journalSyncNonTransactional != other.journalSyncNonTransactional)
-         return false;
-      if (journalSyncTransactional != other.journalSyncTransactional)
-         return false;
-      if (journalType != other.journalType)
-         return false;
-      if (largeMessagesDirectory == null) {
-         if (other.largeMessagesDirectory != null)
-            return false;
-      } else if (!largeMessagesDirectory.equals(other.largeMessagesDirectory))
-         return false;
-      if (logJournalWriteRate != other.logJournalWriteRate)
-         return false;
-      if (managementAddress == null) {
-         if (other.managementAddress != null)
-            return false;
-      } else if (!managementAddress.equals(other.managementAddress))
-         return false;
-      if (managementNotificationAddress == null) {
-         if (other.managementNotificationAddress != null)
-            return false;
-      } else if (!managementNotificationAddress.equals(other.managementNotificationAddress))
-         return false;
-
-      if (this.maskPassword == null) {
-         if (other.maskPassword != null)
-            return false;
-      } else {
-         if (!this.maskPassword.equals(other.maskPassword))
-            return false;
       }
-
-      if (maxConcurrentPageIO != other.maxConcurrentPageIO)
-         return false;
-      if (memoryMeasureInterval != other.memoryMeasureInterval)
-         return false;
-      if (memoryWarningThreshold != other.memoryWarningThreshold)
-         return false;
-      if (messageCounterEnabled != other.messageCounterEnabled)
-         return false;
-      if (messageCounterMaxDayHistory != other.messageCounterMaxDayHistory)
-         return false;
-      if (messageCounterSamplePeriod != other.messageCounterSamplePeriod)
-         return false;
-      if (messageExpiryScanPeriod != other.messageExpiryScanPeriod)
-         return false;
-      if (messageExpiryThreadPriority != other.messageExpiryThreadPriority)
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      if (outgoingInterceptorClassNames == null) {
-         if (other.outgoingInterceptorClassNames != null)
-            return false;
-      } else if (!outgoingInterceptorClassNames.equals(other.outgoingInterceptorClassNames))
-         return false;
-      if (pagingDirectory == null) {
-         if (other.pagingDirectory != null)
-            return false;
-      } else if (!pagingDirectory.equals(other.pagingDirectory))
-         return false;
-      if (persistDeliveryCountBeforeDelivery != other.persistDeliveryCountBeforeDelivery)
-         return false;
-      if (persistIDCache != other.persistIDCache)
-         return false;
-      if (persistenceEnabled != other.persistenceEnabled)
-         return false;
-//      if (queueConfigurations == null) {
-//         if (other.queueConfigurations != null)
-//            return false;
-//      } else if (!queueConfigurations.equals(other.queueConfigurations))
-//         return false;
-      if (scheduledThreadPoolMaxSize != other.scheduledThreadPoolMaxSize)
-         return false;
-      if (securityEnabled != other.securityEnabled)
-         return false;
-      if (populateValidatedUser != other.populateValidatedUser)
-         return false;
-      if (securityInvalidationInterval != other.securityInvalidationInterval)
-         return false;
-      if (securitySettings == null) {
-         if (other.securitySettings != null)
-            return false;
-      } else if (!securitySettings.equals(other.securitySettings))
-         return false;
-      if (serverDumpInterval != other.serverDumpInterval)
-         return false;
-      if (threadPoolMaxSize != other.threadPoolMaxSize)
-         return false;
-      if (transactionTimeout != other.transactionTimeout)
-         return false;
-      if (transactionTimeoutScanPeriod != other.transactionTimeoutScanPeriod)
-         return false;
-      if (wildcardConfiguration == null) {
-         if (other.wildcardConfiguration != null)
-            return false;
-      } else if (!wildcardConfiguration.equals(other.wildcardConfiguration))
-         return false;
-      if (resolveProtocols != other.resolveProtocols)
-         return false;
-      if (journalLockAcquisitionTimeout != other.journalLockAcquisitionTimeout)
-         return false;
-      if (connectionTtlCheckInterval != other.connectionTtlCheckInterval)
-         return false;
-      if (journalDatasync != other.journalDatasync) {
+      if (!(obj instanceof ConfigurationImpl other)) {
          return false;
       }
 
-      if (globalMaxSize != null && !globalMaxSize.equals(other.globalMaxSize)) {
-         return false;
-      }
-      if (maxDiskUsage != other.maxDiskUsage) {
-         return false;
-      }
-      if (minDiskFree != other.minDiskFree) {
-         return false;
-      }
-      if (diskScanPeriod != other.diskScanPeriod) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(acceptorConfigs, other.acceptorConfigs) &&
+             Objects.equals(addressSettings, other.addressSettings) &&
+             asyncConnectionExecutionEnabled == other.asyncConnectionExecutionEnabled &&
+             Objects.equals(bindingsDirectory, other.bindingsDirectory) &&
+             Objects.equals(bridgeConfigurations, other.bridgeConfigurations) &&
+             Objects.equals(broadcastGroupConfigurations, other.broadcastGroupConfigurations) &&
+             Objects.equals(clusterConfigurations, other.clusterConfigurations) &&
+             Objects.equals(clusterPassword, other.clusterPassword) &&
+             Objects.equals(clusterUser, other.clusterUser) &&
+             connectionTTLOverride == other.connectionTTLOverride &&
+             Objects.equals(connectorConfigs, other.connectorConfigs) &&
+             Objects.equals(connectorServiceConfigurations, other.connectorServiceConfigurations) &&
+             createBindingsDir == other.createBindingsDir &&
+             createJournalDir == other.createJournalDir &&
+             Objects.equals(discoveryGroupConfigurations, other.discoveryGroupConfigurations) &&
+             Objects.equals(divertConfigurations, other.divertConfigurations) &&
+             failoverOnServerShutdown == other.failoverOnServerShutdown &&
+             fileDeploymentScanPeriod == other.fileDeploymentScanPeriod &&
+             Objects.equals(groupingHandlerConfiguration, other.groupingHandlerConfiguration) &&
+             idCacheSize == other.idCacheSize &&
+             Objects.equals(incomingInterceptorClassNames, other.incomingInterceptorClassNames) &&
+             Objects.equals(jmxDomain, other.jmxDomain) &&
+             jmxManagementEnabled == other.jmxManagementEnabled &&
+             journalBufferSize_AIO == other.journalBufferSize_AIO &&
+             journalBufferSize_NIO == other.journalBufferSize_NIO &&
+             journalBufferTimeout_AIO == other.journalBufferTimeout_AIO &&
+             journalBufferTimeout_NIO == other.journalBufferTimeout_NIO &&
+             journalCompactMinFiles == other.journalCompactMinFiles &&
+             journalCompactPercentage == other.journalCompactPercentage &&
+             Objects.equals(journalDirectory, other.journalDirectory) &&
+             journalFileSize == other.journalFileSize &&
+             journalMaxIO_AIO == other.journalMaxIO_AIO &&
+             journalMaxIO_NIO == other.journalMaxIO_NIO &&
+             journalMinFiles == other.journalMinFiles &&
+             journalSyncNonTransactional == other.journalSyncNonTransactional &&
+             journalSyncTransactional == other.journalSyncTransactional &&
+             journalType == other.journalType &&
+             Objects.equals(largeMessagesDirectory, other.largeMessagesDirectory) &&
+             logJournalWriteRate == other.logJournalWriteRate &&
+             Objects.equals(managementAddress, other.managementAddress) &&
+             Objects.equals(managementNotificationAddress, other.managementNotificationAddress) &&
+             Objects.equals(maskPassword, other.maskPassword) &&
+             maxConcurrentPageIO == other.maxConcurrentPageIO &&
+             memoryMeasureInterval == other.memoryMeasureInterval &&
+             memoryWarningThreshold == other.memoryWarningThreshold &&
+             messageCounterEnabled == other.messageCounterEnabled &&
+             messageCounterMaxDayHistory == other.messageCounterMaxDayHistory &&
+             messageCounterSamplePeriod == other.messageCounterSamplePeriod &&
+             messageExpiryScanPeriod == other.messageExpiryScanPeriod &&
+             messageExpiryThreadPriority == other.messageExpiryThreadPriority &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(outgoingInterceptorClassNames, other.outgoingInterceptorClassNames) &&
+             Objects.equals(pagingDirectory, other.pagingDirectory) &&
+             persistDeliveryCountBeforeDelivery ==
+             other.persistDeliveryCountBeforeDelivery &&
+             persistIDCache == other.persistIDCache &&
+             persistenceEnabled == other.persistenceEnabled &&
+             scheduledThreadPoolMaxSize == other.scheduledThreadPoolMaxSize &&
+             securityEnabled == other.securityEnabled &&
+             populateValidatedUser == other.populateValidatedUser &&
+             securityInvalidationInterval == other.securityInvalidationInterval &&
+             Objects.equals(securitySettings, other.securitySettings) &&
+             serverDumpInterval == other.serverDumpInterval &&
+             threadPoolMaxSize == other.threadPoolMaxSize &&
+             transactionTimeout == other.transactionTimeout &&
+             transactionTimeoutScanPeriod == other.transactionTimeoutScanPeriod &&
+             Objects.equals(wildcardConfiguration, other.wildcardConfiguration) &&
+             resolveProtocols == other.resolveProtocols &&
+             journalLockAcquisitionTimeout == other.journalLockAcquisitionTimeout &&
+             connectionTtlCheckInterval == other.connectionTtlCheckInterval &&
+             journalDatasync == other.journalDatasync &&
+             Objects.equals(globalMaxSize, other.globalMaxSize) &&
+             maxDiskUsage == other.maxDiskUsage &&
+             minDiskFree == other.minDiskFree &&
+             diskScanPeriod == other.diskScanPeriod;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/filter/impl/FilterImpl.java
@@ -34,6 +34,7 @@ import org.apache.activemq.artemis.utils.ByteUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
 
 import static org.apache.activemq.artemis.api.core.FilterConstants.NATIVE_MESSAGE_ID;
 
@@ -134,19 +135,14 @@ public class FilterImpl implements Filter {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof FilterImpl other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      FilterImpl other = (FilterImpl) obj;
-      if (sfilterString == null) {
-         if (other.sfilterString != null)
-            return false;
-      } else if (!sfilterString.equals(other.sfilterString))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(sfilterString, other.sfilterString);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PagePositionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/cursor/impl/PagePositionImpl.java
@@ -95,18 +95,15 @@ public class PagePositionImpl implements PagePosition {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof PagePositionImpl other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      PagePositionImpl other = (PagePositionImpl) obj;
-      if (messageNr != other.messageNr)
-         return false;
-      if (pageNr != other.pageNr)
-         return false;
-      return true;
+      }
+
+      return messageNr == other.messageNr &&
+             pageNr == other.pageNr;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/paging/impl/Page.java
@@ -351,15 +351,15 @@ public final class Page  {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof Page other)) {
          return false;
+      }
 
-      Page page = (Page) o;
-
-      return pageId == page.pageId;
+      return pageId == other.pageId;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedSecuritySetting.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedSecuritySetting.java
@@ -231,81 +231,27 @@ public class PersistedSecuritySetting implements EncodingSupport {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof PersistedSecuritySetting other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      PersistedSecuritySetting other = (PersistedSecuritySetting) obj;
-      if (addressMatch == null) {
-         if (other.addressMatch != null)
-            return false;
-      } else if (!addressMatch.equals(other.addressMatch))
-         return false;
-      if (consumeRoles == null) {
-         if (other.consumeRoles != null)
-            return false;
-      } else if (!consumeRoles.equals(other.consumeRoles))
-         return false;
-      if (createDurableQueueRoles == null) {
-         if (other.createDurableQueueRoles != null)
-            return false;
-      } else if (!createDurableQueueRoles.equals(other.createDurableQueueRoles))
-         return false;
-      if (createNonDurableQueueRoles == null) {
-         if (other.createNonDurableQueueRoles != null)
-            return false;
-      } else if (!createNonDurableQueueRoles.equals(other.createNonDurableQueueRoles))
-         return false;
-      if (deleteDurableQueueRoles == null) {
-         if (other.deleteDurableQueueRoles != null)
-            return false;
-      } else if (!deleteDurableQueueRoles.equals(other.deleteDurableQueueRoles))
-         return false;
-      if (deleteNonDurableQueueRoles == null) {
-         if (other.deleteNonDurableQueueRoles != null)
-            return false;
-      } else if (!deleteNonDurableQueueRoles.equals(other.deleteNonDurableQueueRoles))
-         return false;
-      if (manageRoles == null) {
-         if (other.manageRoles != null)
-            return false;
-      } else if (!manageRoles.equals(other.manageRoles))
-         return false;
-      if (browseRoles == null) {
-         if (other.browseRoles != null)
-            return false;
-      } else if (!browseRoles.equals(other.browseRoles))
-         return false;
-      if (createAddressRoles == null) {
-         if (other.createAddressRoles != null)
-            return false;
-      } else if (!createAddressRoles.equals(other.createAddressRoles))
-         return false;
-      if (deleteAddressRoles == null) {
-         if (other.deleteAddressRoles != null)
-            return false;
-      } else if (!deleteAddressRoles.equals(other.deleteAddressRoles))
-         return false;
-      if (sendRoles == null) {
-         if (other.sendRoles != null)
-            return false;
-      } else if (!sendRoles.equals(other.sendRoles))
-         return false;
-      if (viewRoles == null) {
-         if (other.viewRoles != null)
-            return false;
-      } else if (!viewRoles.equals(other.viewRoles))
-         return false;
-      if (editRoles == null) {
-         if (other.editRoles != null)
-            return false;
-      } else if (!editRoles.equals(other.editRoles))
-         return false;
-      if (storeId != other.storeId)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(addressMatch, other.addressMatch) &&
+             Objects.equals(consumeRoles, other.consumeRoles) &&
+             Objects.equals(createDurableQueueRoles, other.createDurableQueueRoles) &&
+             Objects.equals(createNonDurableQueueRoles, other.createNonDurableQueueRoles) &&
+             Objects.equals(deleteDurableQueueRoles, other.deleteDurableQueueRoles) &&
+             Objects.equals(deleteNonDurableQueueRoles, other.deleteNonDurableQueueRoles) &&
+             Objects.equals(manageRoles, other.manageRoles) &&
+             Objects.equals(browseRoles, other.browseRoles) &&
+             Objects.equals(createAddressRoles, other.createAddressRoles) &&
+             Objects.equals(deleteAddressRoles, other.deleteAddressRoles) &&
+             Objects.equals(sendRoles, other.sendRoles) &&
+             Objects.equals(viewRoles, other.viewRoles) &&
+             Objects.equals(editRoles, other.editRoles) &&
+             storeId == other.storeId;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
@@ -70,6 +70,8 @@ import org.apache.activemq.artemis.utils.XidCodecSupport;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import java.lang.invoke.MethodHandles;
+import java.util.Objects;
+
 import org.w3c.dom.Element;
 import org.w3c.dom.Node;
 import org.w3c.dom.NodeList;
@@ -364,13 +366,15 @@ public final class DescribeJournal {
          }
 
          @Override
-         public boolean equals(Object o) {
-            if (this == o)
+         public boolean equals(Object obj) {
+            if (this == obj) {
                return true;
-            if (o == null || getClass() != o.getClass())
+            }
+            if (!(obj instanceof Count other)) {
                return false;
-            Count count = (Count) o;
-            return value == count.value;
+            }
+
+            return value == other.value;
          }
 
          @Override
@@ -821,18 +825,17 @@ public final class DescribeJournal {
 
       @Override
       public boolean equals(Object obj) {
-         if (this == obj)
+         if (this == obj) {
             return true;
-         if (obj == null)
+         }
+         if (obj == null) {
             return false;
-         if (!(obj instanceof ReferenceDescribe other))
+         }
+         if (!(obj instanceof ReferenceDescribe other)) {
             return false;
-         if (refEncoding == null) {
-            if (other.refEncoding != null)
-               return false;
-         } else if (!refEncoding.equals(other.refEncoding))
-            return false;
-         return true;
+         }
+
+         return Objects.equals(refEncoding, other.refEncoding);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/AckRetry.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/codec/AckRetry.java
@@ -105,17 +105,16 @@ public final class AckRetry {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof AckRetry other)) {
          return false;
+      }
 
-      AckRetry retry = (AckRetry) o;
-
-      if (messageID != retry.messageID)
-         return false;
-      return Objects.equals(nodeID, retry.nodeID);
+      return messageID == other.messageID &&
+             Objects.equals(nodeID, other.nodeID);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/AddressImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/AddressImpl.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.postoffice.impl;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
 import org.apache.activemq.artemis.core.postoffice.Address;
@@ -157,17 +159,15 @@ public class AddressImpl implements Address {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o)
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
-
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof AddressImpl other)) {
          return false;
+      }
 
-      if (address.equals(((AddressImpl) o).address))
-         return true;
-
-      return false;
+      return Objects.equals(address, other.address);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/ByteArray.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/ByteArray.java
@@ -31,7 +31,6 @@ final class ByteArray {
    @Override
    public boolean equals(final Object other) {
       if (other instanceof ByteArray byteArray) {
-
          return ByteUtil.equals(bytes, byteArray.bytes);
       } else {
          return false;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/BackupRegistrationMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/BackupRegistrationMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -96,29 +98,18 @@ public final class BackupRegistrationMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof BackupRegistrationMessage other))
+      }
+      if (!(obj instanceof BackupRegistrationMessage other)) {
          return false;
-      if (backupWantsFailBack != other.backupWantsFailBack)
-         return false;
-      if (clusterPassword == null) {
-         if (other.clusterPassword != null)
-            return false;
-      } else if (!clusterPassword.equals(other.clusterPassword))
-         return false;
-      if (clusterUser == null) {
-         if (other.clusterUser != null)
-            return false;
-      } else if (!clusterUser.equals(other.clusterUser))
-         return false;
-      if (connector == null) {
-         if (other.connector != null)
-            return false;
-      } else if (!connector.equals(other.connector))
-         return false;
-      return true;
+      }
+      return backupWantsFailBack == other.backupWantsFailBack &&
+             Objects.equals(clusterPassword, other.clusterPassword) &&
+             Objects.equals(clusterUser, other.clusterUser) &&
+             Objects.equals(connector, other.connector);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/BackupReplicationStartFailedMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/BackupReplicationStartFailedMessage.java
@@ -80,20 +80,18 @@ public final class BackupReplicationStartFailedMessage extends PacketImpl {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!super.equals(o))
+      }
+      if (!(obj instanceof BackupReplicationStartFailedMessage other)) {
          return false;
+      }
 
-      BackupReplicationStartFailedMessage that = (BackupReplicationStartFailedMessage) o;
-
-      if (problem != that.problem)
-         return false;
-
-      return true;
+      return Objects.equals(problem, other.problem);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/NodeAnnounceMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/NodeAnnounceMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -172,35 +174,12 @@ public class NodeAnnounceMessage extends PacketImpl {
       if (!(obj instanceof NodeAnnounceMessage other)) {
          return false;
       }
-      if (backup != other.backup) {
-         return false;
-      }
-      if (backupConnector == null) {
-         if (other.backupConnector != null) {
-            return false;
-         }
-      } else if (!backupConnector.equals(other.backupConnector)) {
-         return false;
-      }
-      if (connector == null) {
-         if (other.connector != null) {
-            return false;
-         }
-      } else if (!connector.equals(other.connector)) {
-         return false;
-      }
-      if (currentEventID != other.currentEventID) {
-         return false;
-      }
-      if (nodeID == null) {
-         if (other.nodeID != null) {
-            return false;
-         }
-      } else if (!nodeID.equals(other.nodeID)) {
-         return false;
-      } else if (!scaleDownGroupName.equals(other.scaleDownGroupName)) {
-         return false;
-      }
-      return true;
+
+      return backup == other.backup &&
+             Objects.equals(backupConnector, other.backupConnector) &&
+             Objects.equals(connector, other.connector) &&
+             currentEventID == other.currentEventID &&
+             Objects.equals(nodeID, other.nodeID) &&
+             Objects.equals(scaleDownGroupName, other.scaleDownGroupName);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddMessage.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.persistence.Persister;
@@ -148,27 +149,21 @@ public final class ReplicationAddMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReplicationAddMessage other))
+      }
+      if (!(obj instanceof ReplicationAddMessage other)) {
          return false;
-      if (encodingData == null) {
-         if (other.encodingData != null)
-            return false;
-      } else if (!encodingData.equals(other.encodingData))
-         return false;
-      if (id != other.id)
-         return false;
-      if (journalID != other.journalID)
-         return false;
-      if (journalRecordType != other.journalRecordType)
-         return false;
-      if (operation != other.operation)
-         return false;
-      if (!Arrays.equals(recordData, other.recordData))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(encodingData, other.encodingData) &&
+             id == other.id &&
+             journalID == other.journalID &&
+             journalRecordType == other.journalRecordType &&
+             operation == other.operation &&
+             Arrays.equals(recordData, other.recordData);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddTXMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationAddTXMessage.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.persistence.Persister;
@@ -163,29 +164,22 @@ public class ReplicationAddTXMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReplicationAddTXMessage other))
+      }
+      if (!(obj instanceof ReplicationAddTXMessage other)) {
          return false;
-      if (encodingData == null) {
-         if (other.encodingData != null)
-            return false;
-      } else if (!encodingData.equals(other.encodingData))
-         return false;
-      if (id != other.id)
-         return false;
-      if (journalID != other.journalID)
-         return false;
-      if (operation != other.operation)
-         return false;
-      if (!Arrays.equals(recordData, other.recordData))
-         return false;
-      if (recordType != other.recordType)
-         return false;
-      if (txId != other.txId)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(encodingData, other.encodingData) &&
+             id == other.id &&
+             journalID == other.journalID &&
+             operation == other.operation &&
+             Arrays.equals(recordData, other.recordData) &&
+             recordType == other.recordType &&
+             txId == other.txId;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationCommitMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationCommitMessage.java
@@ -88,19 +88,19 @@ public final class ReplicationCommitMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReplicationCommitMessage other))
+      }
+      if (!(obj instanceof ReplicationCommitMessage other)) {
          return false;
-      if (journalID != other.journalID)
-         return false;
-      if (rollback != other.rollback)
-         return false;
-      if (txId != other.txId)
-         return false;
-      return true;
+      }
+
+      return journalID == other.journalID &&
+             rollback == other.rollback &&
+             txId == other.txId;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationDeleteMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationDeleteMessage.java
@@ -78,16 +78,17 @@ public final class ReplicationDeleteMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReplicationDeleteMessage other))
+      }
+      if (!(obj instanceof ReplicationDeleteMessage other)) {
          return false;
-      if (id != other.id)
-         return false;
-      if (journalID != other.journalID)
-         return false;
-      return true;
+      }
+
+      return id == other.id &&
+             journalID == other.journalID;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationDeleteTXMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationDeleteTXMessage.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
@@ -112,26 +113,20 @@ public class ReplicationDeleteTXMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (getClass() != obj.getClass())
+      }
+      if (!(obj instanceof ReplicationDeleteTXMessage other)) {
          return false;
-      ReplicationDeleteTXMessage other = (ReplicationDeleteTXMessage) obj;
-      if (encodingData == null) {
-         if (other.encodingData != null)
-            return false;
-      } else if (!encodingData.equals(other.encodingData))
-         return false;
-      if (id != other.id)
-         return false;
-      if (journalID != other.journalID)
-         return false;
-      if (!Arrays.equals(recordData, other.recordData))
-         return false;
-      if (txId != other.txId)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(encodingData, other.encodingData) &&
+             id == other.id &&
+             journalID == other.journalID &&
+             Arrays.equals(recordData, other.recordData) &&
+             txId == other.txId;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationLargeMessageBeginMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationLargeMessageBeginMessage.java
@@ -71,15 +71,16 @@ public class ReplicationLargeMessageBeginMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (getClass() != obj.getClass())
+      }
+      if (!(obj instanceof ReplicationLargeMessageBeginMessage other)) {
          return false;
-      ReplicationLargeMessageBeginMessage other = (ReplicationLargeMessageBeginMessage) obj;
-      if (messageId != other.messageId)
-         return false;
-      return true;
+      }
+
+      return messageId == other.messageId;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationLargeMessageEndMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationLargeMessageEndMessage.java
@@ -91,18 +91,18 @@ public class ReplicationLargeMessageEndMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (getClass() != obj.getClass())
+      }
+      if (!(obj instanceof ReplicationLargeMessageEndMessage other)) {
          return false;
-      ReplicationLargeMessageEndMessage other = (ReplicationLargeMessageEndMessage) obj;
-      if (messageId != other.messageId)
-         return false;
-      if (isDelete != other.isDelete)
-         return false;
-      return true;
+      }
+
+      return messageId == other.messageId &&
+             isDelete == other.isDelete;
    }
 
    public long getPendingRecordId() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationLargeMessageWriteMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationLargeMessageWriteMessage.java
@@ -89,16 +89,17 @@ public final class ReplicationLargeMessageWriteMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReplicationLargeMessageWriteMessage other))
+      }
+      if (!(obj instanceof ReplicationLargeMessageWriteMessage other)) {
          return false;
-      if (!Arrays.equals(body, other.body))
-         return false;
-      if (messageId != other.messageId)
-         return false;
-      return true;
+      }
+
+      return Arrays.equals(body, other.body) &&
+             messageId == other.messageId;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationPageEventMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationPageEventMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.protocol.core.impl.PacketImpl;
@@ -115,22 +117,18 @@ public class ReplicationPageEventMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (getClass() != obj.getClass())
+      }
+      if (!(obj instanceof ReplicationPageEventMessage other)) {
          return false;
-      ReplicationPageEventMessage other = (ReplicationPageEventMessage) obj;
-      if (isDelete != other.isDelete)
-         return false;
-      if (pageNumber != other.pageNumber)
-         return false;
-      if (storeName == null) {
-         if (other.storeName != null)
-            return false;
-      } else if (!storeName.equals(other.storeName))
-         return false;
-      return true;
+      }
+
+      return isDelete == other.isDelete &&
+             pageNumber == other.pageNumber &&
+             Objects.equals(storeName, other.storeName);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationPageWriteMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationPageWriteMessage.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -131,21 +133,18 @@ public class ReplicationPageWriteMessage extends PacketImpl implements MessagePa
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (getClass() != obj.getClass())
+      }
+      if (!(obj instanceof ReplicationPageWriteMessage other)) {
          return false;
-      ReplicationPageWriteMessage other = (ReplicationPageWriteMessage) obj;
-      if (pageNumber != other.pageNumber)
-         return false;
-      if (pagedMessage == null) {
-         if (other.pagedMessage != null)
-            return false;
-      } else if (!pagedMessage.equals(other.pagedMessage))
-         return false;
-      return true;
+      }
+
+      return pageNumber == other.pageNumber &&
+             Objects.equals(pagedMessage, other.pagedMessage);
    }
 
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationPrepareMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationPrepareMessage.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
@@ -108,22 +109,10 @@ public final class ReplicationPrepareMessage extends PacketImpl {
       if (!(obj instanceof ReplicationPrepareMessage other)) {
          return false;
       }
-      if (encodingData == null) {
-         if (other.encodingData != null) {
-            return false;
-         }
-      } else if (!encodingData.equals(other.encodingData)) {
-         return false;
-      }
-      if (journalID != other.journalID) {
-         return false;
-      }
-      if (!Arrays.equals(recordData, other.recordData)) {
-         return false;
-      }
-      if (txId != other.txId) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(encodingData, other.encodingData) &&
+             journalID == other.journalID &&
+             Arrays.equals(recordData, other.recordData) &&
+             txId == other.txId;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationStartSyncMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationStartSyncMessage.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.utils.DataConstants;
 import java.security.InvalidParameterException;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 
 /**
  * This message may signal start or end of the replication synchronization.
@@ -204,26 +205,21 @@ public class ReplicationStartSyncMessage extends PacketImpl {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (!super.equals(obj))
+      }
+      if (!super.equals(obj)) {
          return false;
-      if (!(obj instanceof ReplicationStartSyncMessage other))
+      }
+      if (!(obj instanceof ReplicationStartSyncMessage other)) {
          return false;
-      if (allowsAutoFailBack != other.allowsAutoFailBack)
-         return false;
-      if (dataType != other.dataType)
-         return false;
-      if (!Arrays.equals(ids, other.ids))
-         return false;
-      if (nodeID == null) {
-         if (other.nodeID != null)
-            return false;
-      } else if (!nodeID.equals(other.nodeID))
-         return false;
-      if (synchronizationIsFinished != other.synchronizationIsFinished)
-         return false;
-      return true;
+      }
+
+      return allowsAutoFailBack == other.allowsAutoFailBack &&
+             dataType == other.dataType &&
+             Arrays.equals(ids, other.ids) &&
+             Objects.equals(nodeID, other.nodeID) &&
+             synchronizationIsFinished == other.synchronizationIsFinished;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationSyncFileMessage.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/core/impl/wireformat/ReplicationSyncFileMessage.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.protocol.core.impl.wireformat;
 
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.Objects;
 import java.util.Set;
 
 import io.netty.buffer.ByteBuf;
@@ -241,36 +242,14 @@ public final class ReplicationSyncFileMessage extends PacketImpl {
       if (!(obj instanceof ReplicationSyncFileMessage other)) {
          return false;
       }
-      if (!Arrays.equals(byteArray, other.byteArray)) {
-         return false;
-      }
-      if (byteBuffer == null) {
-         if (other.byteBuffer != null) {
-            return false;
-         }
-      } else if (!byteBuffer.equals(other.byteBuffer)) {
-         return false;
-      }
-      if (dataSize != other.dataSize) {
-         return false;
-      }
-      if (fileId != other.fileId) {
-         return false;
-      }
-      if (fileType != other.fileType) {
-         return false;
-      }
-      if (journalType != other.journalType) {
-         return false;
-      }
-      if (pageStoreName == null) {
-         if (other.pageStoreName != null) {
-            return false;
-         }
-      } else if (!pageStoreName.equals(other.pageStoreName)) {
-         return false;
-      }
-      return true;
+
+      return Arrays.equals(byteArray, other.byteArray) &&
+             Objects.equals(byteBuffer, other.byteBuffer) &&
+             dataSize == other.dataSize &&
+             fileId == other.fileId &&
+             fileType == other.fileType &&
+             journalType == other.journalType &&
+             Objects.equals(pageStoreName, other.pageStoreName);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/User.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/security/User.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.artemis.core.security;
 
+import java.util.Objects;
+
 import org.apache.activemq.artemis.utils.PasswordMaskingUtil;
 
 public class User {
@@ -30,21 +32,15 @@ public class User {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof User other)) {
          return false;
       }
 
-      User user1 = (User) o;
-
-      if (!user.equals(user1.user)) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(user, other.user);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/QueueConfig.java
@@ -513,66 +513,40 @@ public final class QueueConfig {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
+      }
+      if (!(obj instanceof QueueConfig other)) {
          return false;
+      }
 
-      QueueConfig that = (QueueConfig) o;
-
-      if (id != that.id)
-         return false;
-      if (durable != that.durable)
-         return false;
-      if (temporary != that.temporary)
-         return false;
-      if (autoCreated != that.autoCreated)
-         return false;
-      if (address != null ? !address.equals(that.address) : that.address != null)
-         return false;
-      if (name != null ? !name.equals(that.name) : that.name != null)
-         return false;
-      if (filter != null ? !filter.equals(that.filter) : that.filter != null)
-         return false;
-      if (pageSubscription != null ? !pageSubscription.equals(that.pageSubscription) : that.pageSubscription != null)
-         return false;
-      if (routingType != that.routingType)
-         return false;
-      if (maxConsumers != that.maxConsumers)
-         return false;
-      if (exclusive != that.exclusive)
-         return false;
-      if (lastValue != that.lastValue)
-         return false;
-      if (lastValueKey != null ? !lastValueKey.equals(that.lastValueKey) : that.lastValueKey != null)
-         return false;
-      if (nonDestructive != that.nonDestructive)
-         return false;
-      if (purgeOnNoConsumers != that.purgeOnNoConsumers)
-         return false;
-      if (consumersBeforeDispatch != that.consumersBeforeDispatch)
-         return false;
-      if (delayBeforeDispatch != that.delayBeforeDispatch)
-         return false;
-      if (groupRebalance != that.groupRebalance)
-         return false;
-      if (groupBuckets != that.groupBuckets)
-         return false;
-      if (groupFirstKey != null ? !groupFirstKey.equals(that.groupFirstKey) : that.groupFirstKey != null)
-         return false;
-      if (autoDelete != that.autoDelete)
-         return false;
-      if (autoDeleteDelay != that.autoDeleteDelay)
-         return false;
-      if (autoDeleteMessageCount != that.autoDeleteMessageCount)
-         return false;
-      if (ringSize != that.ringSize)
-         return false;
-      if (configurationManaged != that.configurationManaged)
-         return false;
-      return user != null ? user.equals(that.user) : that.user == null;
-
+      return id == other.id &&
+             durable == other.durable &&
+             temporary == other.temporary &&
+             autoCreated == other.autoCreated &&
+             Objects.equals(address, other.address) &&
+             Objects.equals(name, other.name) &&
+             Objects.equals(filter, other.filter) &&
+             Objects.equals(pageSubscription, other.pageSubscription) &&
+             routingType == other.routingType &&
+             maxConsumers == other.maxConsumers &&
+             exclusive == other.exclusive &&
+             lastValue == other.lastValue &&
+             Objects.equals(lastValueKey, other.lastValueKey) &&
+             nonDestructive == other.nonDestructive &&
+             purgeOnNoConsumers == other.purgeOnNoConsumers &&
+             consumersBeforeDispatch == other.consumersBeforeDispatch &&
+             delayBeforeDispatch == other.delayBeforeDispatch &&
+             groupRebalance == other.groupRebalance &&
+             groupBuckets == other.groupBuckets &&
+             Objects.equals(groupFirstKey, other.groupFirstKey) &&
+             autoDelete == other.autoDelete &&
+             autoDeleteDelay == other.autoDeleteDelay &&
+             autoDeleteMessageCount == other.autoDeleteMessageCount &&
+             ringSize == other.ringSize &&
+             configurationManaged == other.configurationManaged &&
+             Objects.equals(user, other.user);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/address/FederatedAddressConsumerKey.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/address/FederatedAddressConsumerKey.java
@@ -94,13 +94,18 @@ public class FederatedAddressConsumerKey implements FederatedConsumerKey {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederatedAddressConsumerKey that)) return false;
-      return Objects.equals(address, that.address) &&
-            Objects.equals(queueNameFormat, that.queueNameFormat) &&
-            routingType == that.routingType &&
-            Objects.equals(queueFilterString, that.queueFilterString);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederatedAddressConsumerKey other)) {
+         return false;
+      }
+
+      return Objects.equals(address, other.address) &&
+             Objects.equals(queueNameFormat, other.queueNameFormat) &&
+             Objects.equals(routingType, other.routingType) &&
+             Objects.equals(queueFilterString, other.queueFilterString);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/queue/FederatedQueueConsumerKey.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/federation/queue/FederatedQueueConsumerKey.java
@@ -77,16 +77,21 @@ public class FederatedQueueConsumerKey implements FederatedConsumerKey {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) return true;
-      if (!(o instanceof FederatedQueueConsumerKey that)) return false;
-      return priority == that.priority &&
-            Objects.equals(address, that.address) &&
-            Objects.equals(queueName, that.queueName) &&
-            routingType == that.routingType &&
-            Objects.equals(queueFilterString, that.queueFilterString) &&
-            Objects.equals(filterString, that.filterString) &&
-            Objects.equals(fqqn, that.fqqn);
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
+      }
+      if (!(obj instanceof FederatedQueueConsumerKey other)) {
+         return false;
+      }
+
+      return priority == other.priority &&
+             Objects.equals(address, other.address) &&
+             Objects.equals(queueName, other.queueName) &&
+             routingType == other.routingType &&
+             Objects.equals(queueFilterString, other.queueFilterString) &&
+             Objects.equals(filterString, other.filterString) &&
+             Objects.equals(fqqn, other.fqqn);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/GroupingHandlerConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/group/impl/GroupingHandlerConfiguration.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.server.group.impl;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -135,27 +136,16 @@ public final class GroupingHandlerConfiguration implements Serializable {
 
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof GroupingHandlerConfiguration other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      GroupingHandlerConfiguration other = (GroupingHandlerConfiguration) obj;
-      if (address == null) {
-         if (other.address != null)
-            return false;
-      } else if (!address.equals(other.address))
-         return false;
-      if (name == null) {
-         if (other.name != null)
-            return false;
-      } else if (!name.equals(other.name))
-         return false;
-      if (timeout != other.timeout)
-         return false;
-      if (type != other.type)
-         return false;
-      return true;
+      }
+
+      return Objects.equals(address, other.address) &&
+             Objects.equals(name, other.name) &&
+             timeout == other.timeout &&
+             type == other.type;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/LastValueQueue.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.server.impl;
 
 import java.util.Collections;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ScheduledExecutorService;
@@ -227,17 +228,10 @@ public class LastValueQueue extends QueueImpl {
       if (!super.equals(obj)) {
          return false;
       }
-      if (!(obj instanceof LastValueQueue)) {
+      if (!(obj instanceof LastValueQueue other)) {
          return false;
       }
-      LastValueQueue other = (LastValueQueue) obj;
-      if (map == null) {
-         if (other.map != null) {
-            return false;
-         }
-      } else if (!map.equals(other.map)) {
-         return false;
-      }
-      return true;
+
+      return Objects.equals(map, other.map);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/MessageReferenceImpl.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import java.util.Comparator;
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import java.util.function.Consumer;
 
@@ -324,18 +325,15 @@ public class MessageReferenceImpl extends AbstractProtocolReference implements M
    }
 
    @Override
-   public boolean equals(Object other) {
-      if (this == other) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-
-      if (other instanceof MessageReferenceImpl otherRef) {
-
-         if (this.getMessage().equals(otherRef.getMessage()))
-            return true;
+      if (!(obj instanceof MessageReferenceImpl other)) {
+         return false;
       }
 
-      return false;
+      return Objects.equals(this.getMessage(), other.getMessage());
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/QueueImpl.java
@@ -2738,16 +2738,16 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
 
    // Public
    // -----------------------------------------------------------------------------
-
    @Override
-   public boolean equals(final Object other) {
-      if (this == other) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (!(other instanceof QueueImpl qother))
+      if (!(obj instanceof QueueImpl other)) {
          return false;
+      }
 
-      return queueConfiguration.getName().equals(qother.queueConfiguration.getName());
+      return Objects.equals(queueConfiguration.getName(), other.queueConfiguration.getName());
    }
 
    @Override
@@ -4103,11 +4103,15 @@ public class QueueImpl extends CriticalComponentImpl implements Queue {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) return true;
-         if (o == null || getClass() != o.getClass()) return false;
-         ConsumerHolder<?> that = (ConsumerHolder<?>) o;
-         return Objects.equals(consumer, that.consumer);
+      public boolean equals(Object obj) {
+         if (this == obj) {
+            return true;
+         }
+         if (!(obj instanceof ConsumerHolder<?> other)) {
+            return false;
+         }
+
+         return Objects.equals(consumer, other.consumer);
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/AddressSettings.java
@@ -1622,172 +1622,93 @@ public class AddressSettings implements Mergeable<AddressSettings>, Serializable
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
-      if (o == null || getClass() != o.getClass())
-         return false;
-
-      AddressSettings that = (AddressSettings) o;
-
-      if (addressFullMessagePolicy != that.addressFullMessagePolicy)
-         return false;
-      if (!Objects.equals(maxSizeBytes, that.maxSizeBytes))
-         return false;
-      if (!Objects.equals(maxReadPageBytes, that.maxReadPageBytes))
-         return false;
-      if (!Objects.equals(maxReadPageMessages, that.maxReadPageMessages))
-         return false;
-      if (!Objects.equals(prefetchPageBytes, that.prefetchPageBytes))
-         return false;
-      if (!Objects.equals(prefetchPageMessages, that.prefetchPageMessages))
-         return false;
-      if (!Objects.equals(pageLimitBytes, that.pageLimitBytes))
-         return false;
-      if (!Objects.equals(pageLimitMessages, that.pageLimitMessages))
-         return false;
-      if (pageFullMessagePolicy != that.pageFullMessagePolicy)
-         return false;
-      if (!Objects.equals(maxSizeMessages, that.maxSizeMessages))
-         return false;
-      if (!Objects.equals(pageSizeBytes, that.pageSizeBytes))
-         return false;
-      if (!Objects.equals(pageCacheMaxSize, that.pageCacheMaxSize))
-         return false;
-      if (!Objects.equals(dropMessagesWhenFull, that.dropMessagesWhenFull))
-         return false;
-      if (!Objects.equals(maxDeliveryAttempts, that.maxDeliveryAttempts))
-         return false;
-      if (!Objects.equals(messageCounterHistoryDayLimit, that.messageCounterHistoryDayLimit))
-         return false;
-      if (!Objects.equals(redeliveryDelay, that.redeliveryDelay))
-         return false;
-      if (!Objects.equals(redeliveryMultiplier, that.redeliveryMultiplier))
-         return false;
-      if (!Objects.equals(redeliveryCollisionAvoidanceFactor, that.redeliveryCollisionAvoidanceFactor))
-         return false;
-      if (!Objects.equals(maxRedeliveryDelay, that.maxRedeliveryDelay))
-         return false;
-      if (!Objects.equals(deadLetterAddress, that.deadLetterAddress))
-         return false;
-      if (!Objects.equals(expiryAddress, that.expiryAddress))
-         return false;
-      if (!Objects.equals(expiryDelay, that.expiryDelay))
-         return false;
-      if (!Objects.equals(minExpiryDelay, that.minExpiryDelay))
-         return false;
-      if (!Objects.equals(maxExpiryDelay, that.maxExpiryDelay))
-         return false;
-      if (!Objects.equals(noExpiry, that.noExpiry))
-         return false;
-      if (!Objects.equals(defaultLastValueQueue, that.defaultLastValueQueue))
-         return false;
-      if (!Objects.equals(defaultLastValueKey, that.defaultLastValueKey))
-         return false;
-      if (!Objects.equals(defaultNonDestructive, that.defaultNonDestructive))
-         return false;
-      if (!Objects.equals(defaultExclusiveQueue, that.defaultExclusiveQueue))
-         return false;
-      if (!Objects.equals(defaultGroupRebalance, that.defaultGroupRebalance))
-         return false;
-      if (!Objects.equals(defaultGroupRebalancePauseDispatch, that.defaultGroupRebalancePauseDispatch))
-         return false;
-      if (!Objects.equals(defaultGroupBuckets, that.defaultGroupBuckets))
-         return false;
-      if (!Objects.equals(defaultGroupFirstKey, that.defaultGroupFirstKey))
-         return false;
-      if (!Objects.equals(redistributionDelay, that.redistributionDelay))
-         return false;
-      if (!Objects.equals(sendToDLAOnNoRoute, that.sendToDLAOnNoRoute))
-         return false;
-      if (!Objects.equals(slowConsumerThreshold, that.slowConsumerThreshold))
-         return false;
-      if (slowConsumerThresholdMeasurementUnit != that.slowConsumerThresholdMeasurementUnit)
-         return false;
-      if (!Objects.equals(slowConsumerCheckPeriod, that.slowConsumerCheckPeriod))
-         return false;
-      if (slowConsumerPolicy != that.slowConsumerPolicy)
-         return false;
-      if (!Objects.equals(autoCreateJmsQueues, that.autoCreateJmsQueues))
-         return false;
-      if (!Objects.equals(autoDeleteJmsQueues, that.autoDeleteJmsQueues))
-         return false;
-      if (!Objects.equals(autoCreateJmsTopics, that.autoCreateJmsTopics))
-         return false;
-      if (!Objects.equals(autoDeleteJmsTopics, that.autoDeleteJmsTopics))
-         return false;
-      if (!Objects.equals(autoCreateQueues, that.autoCreateQueues))
-         return false;
-      if (!Objects.equals(autoDeleteQueues, that.autoDeleteQueues))
-         return false;
-      if (!Objects.equals(autoDeleteCreatedQueues, that.autoDeleteCreatedQueues))
-         return false;
-      if (!Objects.equals(autoDeleteQueuesDelay, that.autoDeleteQueuesDelay))
-         return false;
-      if (!Objects.equals(autoDeleteQueuesSkipUsageCheck, that.autoDeleteQueuesSkipUsageCheck))
-         return false;
-      if (!Objects.equals(autoDeleteQueuesMessageCount, that.autoDeleteQueuesMessageCount))
-         return false;
-      if (!Objects.equals(defaultRingSize, that.defaultRingSize))
-         return false;
-      if (!Objects.equals(retroactiveMessageCount, that.retroactiveMessageCount))
-         return false;
-      if (configDeleteQueues != that.configDeleteQueues)
-         return false;
-      if (!Objects.equals(autoCreateAddresses, that.autoCreateAddresses))
-         return false;
-      if (!Objects.equals(autoDeleteAddresses, that.autoDeleteAddresses))
-         return false;
-      if (!Objects.equals(autoDeleteAddressesDelay, that.autoDeleteAddressesDelay))
-         return false;
-      if (!Objects.equals(autoDeleteAddressesSkipUsageCheck, that.autoDeleteAddressesSkipUsageCheck))
-         return false;
-      if (configDeleteAddresses != that.configDeleteAddresses)
-         return false;
-      if (configDeleteDiverts != that.configDeleteDiverts)
-         return false;
-      if (!Objects.equals(managementBrowsePageSize, that.managementBrowsePageSize))
-         return false;
-      if (!Objects.equals(maxSizeBytesRejectThreshold, that.maxSizeBytesRejectThreshold))
-         return false;
-      if (!Objects.equals(defaultMaxConsumers, that.defaultMaxConsumers))
-         return false;
-      if (!Objects.equals(defaultPurgeOnNoConsumers, that.defaultPurgeOnNoConsumers))
-         return false;
-      if (!Objects.equals(defaultConsumersBeforeDispatch, that.defaultConsumersBeforeDispatch))
-         return false;
-      if (!Objects.equals(defaultDelayBeforeDispatch, that.defaultDelayBeforeDispatch))
-         return false;
-      if (defaultQueueRoutingType != that.defaultQueueRoutingType)
-         return false;
-      if (defaultAddressRoutingType != that.defaultAddressRoutingType)
-         return false;
-      if (!Objects.equals(defaultConsumerWindowSize, that.defaultConsumerWindowSize))
-         return false;
-      if (!Objects.equals(autoCreateDeadLetterResources, that.autoCreateDeadLetterResources))
-         return false;
-      if (!Objects.equals(deadLetterQueuePrefix, that.deadLetterQueuePrefix))
-         return false;
-      if (!Objects.equals(deadLetterQueueSuffix, that.deadLetterQueueSuffix))
-         return false;
-      if (!Objects.equals(autoCreateExpiryResources, that.autoCreateExpiryResources))
-         return false;
-      if (!Objects.equals(expiryQueuePrefix, that.expiryQueuePrefix))
-         return false;
-      if (!Objects.equals(expiryQueueSuffix, that.expiryQueueSuffix))
-         return false;
-      if (!Objects.equals(enableMetrics, that.enableMetrics))
-         return false;
-      if (!Objects.equals(managementMessageAttributeSizeLimit, that.managementMessageAttributeSizeLimit))
-         return false;
-      if (!Objects.equals(enableIngressTimestamp, that.enableIngressTimestamp))
-         return false;
-      if (!Objects.equals(idCacheSize, that.idCacheSize))
-         return false;
-      if (!Objects.equals(initialQueueBufferSize, that.initialQueueBufferSize)) {
+      }
+      if (!(obj instanceof AddressSettings other)) {
          return false;
       }
-      return Objects.equals(queuePrefetch, that.queuePrefetch);
+
+      return Objects.equals(addressFullMessagePolicy, other.addressFullMessagePolicy) &&
+             Objects.equals(maxSizeBytes, other.maxSizeBytes) &&
+             Objects.equals(maxReadPageBytes, other.maxReadPageBytes) &&
+             Objects.equals(maxReadPageMessages, other.maxReadPageMessages) &&
+             Objects.equals(prefetchPageBytes, other.prefetchPageBytes) &&
+             Objects.equals(prefetchPageMessages, other.prefetchPageMessages) &&
+             Objects.equals(pageLimitBytes, other.pageLimitBytes) &&
+             Objects.equals(pageLimitMessages, other.pageLimitMessages) &&
+             Objects.equals(pageFullMessagePolicy, other.pageFullMessagePolicy) &&
+             Objects.equals(maxSizeMessages, other.maxSizeMessages) &&
+             Objects.equals(pageSizeBytes, other.pageSizeBytes) &&
+             Objects.equals(pageCacheMaxSize, other.pageCacheMaxSize) &&
+             Objects.equals(dropMessagesWhenFull, other.dropMessagesWhenFull) &&
+             Objects.equals(maxDeliveryAttempts, other.maxDeliveryAttempts) &&
+             Objects.equals(messageCounterHistoryDayLimit, other.messageCounterHistoryDayLimit) &&
+             Objects.equals(redeliveryDelay, other.redeliveryDelay) &&
+             Objects.equals(redeliveryMultiplier, other.redeliveryMultiplier) &&
+             Objects.equals(redeliveryCollisionAvoidanceFactor, other.redeliveryCollisionAvoidanceFactor) &&
+             Objects.equals(maxRedeliveryDelay, other.maxRedeliveryDelay) &&
+             Objects.equals(deadLetterAddress, other.deadLetterAddress) &&
+             Objects.equals(expiryAddress, other.expiryAddress) &&
+             Objects.equals(expiryDelay, other.expiryDelay) &&
+             Objects.equals(minExpiryDelay, other.minExpiryDelay) &&
+             Objects.equals(maxExpiryDelay, other.maxExpiryDelay) &&
+             Objects.equals(noExpiry, other.noExpiry) &&
+             Objects.equals(defaultLastValueQueue, other.defaultLastValueQueue) &&
+             Objects.equals(defaultLastValueKey, other.defaultLastValueKey) &&
+             Objects.equals(defaultNonDestructive, other.defaultNonDestructive) &&
+             Objects.equals(defaultExclusiveQueue, other.defaultExclusiveQueue) &&
+             Objects.equals(defaultGroupRebalance, other.defaultGroupRebalance) &&
+             Objects.equals(defaultGroupRebalancePauseDispatch, other.defaultGroupRebalancePauseDispatch) &&
+             Objects.equals(defaultGroupBuckets, other.defaultGroupBuckets) &&
+             Objects.equals(defaultGroupFirstKey, other.defaultGroupFirstKey) &&
+             Objects.equals(redistributionDelay, other.redistributionDelay) &&
+             Objects.equals(sendToDLAOnNoRoute, other.sendToDLAOnNoRoute) &&
+             Objects.equals(slowConsumerThreshold, other.slowConsumerThreshold) &&
+             Objects.equals(slowConsumerThresholdMeasurementUnit, other.slowConsumerThresholdMeasurementUnit) &&
+             Objects.equals(slowConsumerCheckPeriod, other.slowConsumerCheckPeriod) &&
+             Objects.equals(slowConsumerPolicy, other.slowConsumerPolicy) &&
+             Objects.equals(autoCreateJmsQueues, other.autoCreateJmsQueues) &&
+             Objects.equals(autoDeleteJmsQueues, other.autoDeleteJmsQueues) &&
+             Objects.equals(autoCreateJmsTopics, other.autoCreateJmsTopics) &&
+             Objects.equals(autoDeleteJmsTopics, other.autoDeleteJmsTopics) &&
+             Objects.equals(autoCreateQueues, other.autoCreateQueues) &&
+             Objects.equals(autoDeleteQueues, other.autoDeleteQueues) &&
+             Objects.equals(autoDeleteCreatedQueues, other.autoDeleteCreatedQueues) &&
+             Objects.equals(autoDeleteQueuesDelay, other.autoDeleteQueuesDelay) &&
+             Objects.equals(autoDeleteQueuesSkipUsageCheck, other.autoDeleteQueuesSkipUsageCheck) &&
+             Objects.equals(autoDeleteQueuesMessageCount, other.autoDeleteQueuesMessageCount) &&
+             Objects.equals(defaultRingSize, other.defaultRingSize) &&
+             Objects.equals(retroactiveMessageCount, other.retroactiveMessageCount) &&
+             Objects.equals(configDeleteQueues, other.configDeleteQueues) &&
+             Objects.equals(autoCreateAddresses, other.autoCreateAddresses) &&
+             Objects.equals(autoDeleteAddresses, other.autoDeleteAddresses) &&
+             Objects.equals(autoDeleteAddressesDelay, other.autoDeleteAddressesDelay) &&
+             Objects.equals(autoDeleteAddressesSkipUsageCheck, other.autoDeleteAddressesSkipUsageCheck) &&
+             Objects.equals(configDeleteAddresses, other.configDeleteAddresses) &&
+             Objects.equals(configDeleteDiverts, other.configDeleteDiverts) &&
+             Objects.equals(managementBrowsePageSize, other.managementBrowsePageSize) &&
+             Objects.equals(maxSizeBytesRejectThreshold, other.maxSizeBytesRejectThreshold) &&
+             Objects.equals(defaultMaxConsumers, other.defaultMaxConsumers) &&
+             Objects.equals(defaultPurgeOnNoConsumers, other.defaultPurgeOnNoConsumers) &&
+             Objects.equals(defaultConsumersBeforeDispatch, other.defaultConsumersBeforeDispatch) &&
+             Objects.equals(defaultDelayBeforeDispatch, other.defaultDelayBeforeDispatch) &&
+             Objects.equals(defaultQueueRoutingType, other.defaultQueueRoutingType) &&
+             Objects.equals(defaultAddressRoutingType, other.defaultAddressRoutingType) &&
+             Objects.equals(defaultConsumerWindowSize, other.defaultConsumerWindowSize) &&
+             Objects.equals(autoCreateDeadLetterResources, other.autoCreateDeadLetterResources) &&
+             Objects.equals(deadLetterQueuePrefix, other.deadLetterQueuePrefix) &&
+             Objects.equals(deadLetterQueueSuffix, other.deadLetterQueueSuffix) &&
+             Objects.equals(autoCreateExpiryResources, other.autoCreateExpiryResources) &&
+             Objects.equals(expiryQueuePrefix, other.expiryQueuePrefix) &&
+             Objects.equals(expiryQueueSuffix, other.expiryQueueSuffix) &&
+             Objects.equals(enableMetrics, other.enableMetrics) &&
+             Objects.equals(managementMessageAttributeSizeLimit, other.managementMessageAttributeSizeLimit) &&
+             Objects.equals(enableIngressTimestamp, other.enableIngressTimestamp) &&
+             Objects.equals(idCacheSize, other.idCacheSize) &&
+             Objects.equals(initialQueueBufferSize, other.initialQueueBufferSize) &&
+             Objects.equals(queuePrefetch, other.queuePrefetch);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/Match.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.core.settings.impl;
 
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
@@ -92,18 +93,15 @@ public class Match<T> {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof Match other)) {
          return false;
       }
 
-      @SuppressWarnings("rawtypes")
-      Match that = (Match) o;
-
-      return !(match != null ? !match.equals(that.match) : that.match != null);
+      return Objects.equals(match, other.match);
 
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/NamedHierarchicalRepositoryChangeListener.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/NamedHierarchicalRepositoryChangeListener.java
@@ -39,18 +39,14 @@ public abstract class NamedHierarchicalRepositoryChangeListener implements Hiera
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o)
-         return true;
-      if (o == null || getClass() != o.getClass())
-         return false;
-
-      NamedHierarchicalRepositoryChangeListener that = (NamedHierarchicalRepositoryChangeListener) o;
-
-      if (!Objects.equals(name, that.name)) {
-         return false;
-      } else {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
+      if (!(obj instanceof NamedHierarchicalRepositoryChangeListener other)) {
+         return false;
+      }
+
+      return Objects.equals(name, other.name);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/ResourceLimitSettings.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/settings/impl/ResourceLimitSettings.java
@@ -155,23 +155,17 @@ public class ResourceLimitSettings implements Serializable, EncodingSupport {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof ResourceLimitSettings other)) {
          return false;
       }
 
-      ResourceLimitSettings that = (ResourceLimitSettings) o;
-
-      if (match != null ? !match.equals(that.match) : that.match != null) {
-         return false;
-      }
-      if (maxSessions != null ? !maxSessions.equals(that.maxSessions) : that.maxSessions != null) {
-         return false;
-      }
-      return maxQueues != null ? maxQueues.equals(that.maxQueues) : that.maxQueues == null;
+      return Objects.equals(match, other.match) &&
+             Objects.equals(maxSessions, other.maxSessions) &&
+             Objects.equals(maxQueues, other.maxQueues);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoader.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/PropertiesLoader.java
@@ -95,8 +95,8 @@ public class PropertiesLoader {
       }
 
       @Override
-      public boolean equals(Object other) {
-         return other instanceof FileNameKey fnk && this.absPath.equals(fnk.absPath);
+      public boolean equals(Object obj) {
+         return obj instanceof FileNameKey other && this.absPath.equals(other.absPath);
       }
 
       @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/RolePrincipal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/RolePrincipal.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.spi.core.security.jaas;
 
 import java.security.Principal;
+import java.util.Objects;
 
 public class RolePrincipal implements Principal {
 
@@ -36,21 +37,15 @@ public class RolePrincipal implements Principal {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof RolePrincipal other)) {
          return false;
       }
 
-      final RolePrincipal that = (RolePrincipal) o;
-
-      if (!name.equals(that.name)) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(name, other.name);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/UserPrincipal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/security/jaas/UserPrincipal.java
@@ -17,6 +17,7 @@
 package org.apache.activemq.artemis.spi.core.security.jaas;
 
 import java.security.Principal;
+import java.util.Objects;
 
 public class UserPrincipal implements Principal {
 
@@ -36,21 +37,15 @@ public class UserPrincipal implements Principal {
    }
 
    @Override
-   public boolean equals(Object o) {
-      if (this == o) {
+   public boolean equals(Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof UserPrincipal other)) {
          return false;
       }
 
-      final UserPrincipal that = (UserPrincipal) o;
-
-      if (!name.equals(that.name)) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(name, other.name);
    }
 
    @Override

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/list/PriorityLinkedListTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/list/PriorityLinkedListTest.java
@@ -1026,13 +1026,17 @@ public final class PriorityLinkedListTest {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o)
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
-         if (o == null || getClass() != o.getClass())
+         }
+         if (!(obj instanceof Wibble other)) {
             return false;
-         Wibble wibble = (Wibble) o;
-         return Objects.equals(s1, wibble.s1);
+         }
+
+         return Objects.equals(s1, other.s1) &&
+                Objects.equals(id, other.id) &&
+                Objects.equals(level, other.level);
       }
 
       @Override

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/PrincipalConversionLoginModuleTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/spi/core/security/jaas/PrincipalConversionLoginModuleTest.java
@@ -95,8 +95,8 @@ public class PrincipalConversionLoginModuleTest {
    static final class TestPrincipal implements Principal {
 
       @Override
-      public boolean equals(Object another) {
-         return this == another;
+      public boolean equals(Object obj) {
+         return this == obj;
       }
 
       @Override

--- a/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/XARecoveryConfig.java
+++ b/artemis-service-extensions/src/main/java/org/apache/activemq/artemis/service/extensions/xa/recovery/XARecoveryConfig.java
@@ -218,21 +218,15 @@ public class XARecoveryConfig {
     */
    @Override
    public boolean equals(Object obj) {
-      if (this == obj)
+      if (this == obj) {
          return true;
-      if (obj == null)
+      }
+      if (!(obj instanceof XARecoveryConfig other)) {
          return false;
-      if (getClass() != obj.getClass())
-         return false;
-      XARecoveryConfig other = (XARecoveryConfig) obj;
-      if (discoveryConfiguration == null) {
-         if (other.discoveryConfiguration != null)
-            return false;
-      } else if (!discoveryConfiguration.equals(other.discoveryConfiguration))
-         return false;
-      if (!Arrays.equals(transportConfiguration, other.transportConfiguration))
-         return false;
-      return true;
+      }
+
+      return Objects.equals(discoveryConfiguration, other.discoveryConfiguration) &&
+             Arrays.equals(transportConfiguration, other.transportConfiguration);
    }
 
    @Override

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/util/MessageIdList.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/util/MessageIdList.java
@@ -21,6 +21,7 @@ import javax.jms.Message;
 import javax.jms.MessageListener;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.CountDownLatch;
 
 import org.junit.Assert;
@@ -58,12 +59,15 @@ public class MessageIdList extends Assert implements MessageListener {
    }
 
    @Override
-   public boolean equals(Object that) {
-      if (that instanceof MessageIdList) {
-         MessageIdList thatList = (MessageIdList) that;
-         return getMessageIds().equals(thatList.getMessageIds());
+   public boolean equals(Object obj) {
+      if (this == obj) {
+         return true;
       }
-      return false;
+      if (!(obj instanceof MessageIdList other)) {
+         return false;
+      }
+
+      return Objects.equals(getMessageIds(), other.getMessageIds());
    }
 
    @Override

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpTransactionId.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/AmqpTransactionId.java
@@ -16,6 +16,8 @@
  */
 package org.apache.activemq.transport.amqp.client;
 
+import java.util.Objects;
+
 import org.apache.qpid.proton.amqp.Binary;
 
 /**
@@ -76,22 +78,10 @@ public class AmqpTransactionId {
       if (this == obj) {
          return true;
       }
-      if (obj == null) {
-         return false;
-      }
-      if (getClass() != obj.getClass()) {
+      if (!(obj instanceof AmqpTransactionId other)) {
          return false;
       }
 
-      AmqpTransactionId other = (AmqpTransactionId) obj;
-      if (txId == null) {
-         if (other.txId != null) {
-            return false;
-         }
-      } else if (!txId.equals(other.txId)) {
-         return false;
-      }
-
-      return true;
+      return Objects.equals(txId, other.txId);
    }
 }

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/TypeConversionSupport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/transport/amqp/client/util/TypeConversionSupport.java
@@ -19,6 +19,7 @@ package org.apache.activemq.transport.amqp.client.util;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Objects;
 
 public final class TypeConversionSupport {
 
@@ -35,17 +36,16 @@ public final class TypeConversionSupport {
       }
 
       @Override
-      public boolean equals(Object o) {
-         if (this == o) {
+      public boolean equals(Object obj) {
+         if (this == obj) {
             return true;
          }
-
-         if (o == null || o.getClass() != this.getClass()) {
+         if (!(obj instanceof ConversionKey other)) {
             return false;
          }
 
-         ConversionKey x = (ConversionKey) o;
-         return x.from == from && x.to == to;
+         return Objects.equals(from, other.from) &&
+                Objects.equals(to, other.to);
       }
 
       @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ReSendMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/client/ReSendMessageTest.java
@@ -33,6 +33,7 @@ import javax.jms.TextMessage;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.TransportConfiguration;
 import org.apache.activemq.artemis.api.core.client.ActiveMQClient;
@@ -196,21 +197,11 @@ public class ReSendMessageTest extends JMSTestBase {
          if (this == obj) {
             return true;
          }
-         if (obj == null) {
+         if (!(obj instanceof SomeSerializable other)) {
             return false;
          }
-         if (getClass() != obj.getClass()) {
-            return false;
-         }
-         SomeSerializable other = (SomeSerializable) obj;
-         if (txt == null) {
-            if (other.txt != null) {
-               return false;
-            }
-         } else if (!txt.equals(other.txt)) {
-            return false;
-         }
-         return true;
+
+         return Objects.equals(txt, other.txt);
       }
 
       SomeSerializable(final String txt) {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/MetricsPluginTest.java
@@ -107,13 +107,17 @@ public class MetricsPluginTest extends ActiveMQTestBase {
          }
 
          @Override
-         public boolean equals(Object o) {
-            if (this == o) return true;
-            if (o == null || getClass() != o.getClass()) return false;
-            Metric metric = (Metric) o;
-            return Objects.equals(name, metric.name) &&
-               Objects.equals(value, metric.value) &&
-               Objects.equals(tags, metric.tags);
+         public boolean equals(Object obj) {
+            if (this == obj) {
+               return true;
+            }
+            if (!(obj instanceof Metric other)) {
+               return false;
+            }
+
+            return Objects.equals(name, other.name) &&
+                   Objects.equals(value, other.value) &&
+                   Objects.equals(tags, other.tags);
          }
 
          @Override

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SomeObject.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/SomeObject.java
@@ -35,24 +35,16 @@ public class SomeObject implements Serializable {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (this == o) {
+   public boolean equals(final Object obj) {
+      if (this == obj) {
          return true;
       }
-      if (o == null || getClass() != o.getClass()) {
+      if (!(obj instanceof SomeObject other)) {
          return false;
       }
 
-      SomeObject that = (SomeObject) o;
-
-      if (i != that.i) {
-         return false;
-      }
-      if (j != that.j) {
-         return false;
-      }
-
-      return true;
+      return i == other.i &&
+             j == other.j;
    }
 
    @Override

--- a/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/foreign/ForeignTestObject.java
+++ b/tests/jms-tests/src/test/java/org/apache/activemq/artemis/jms/tests/message/foreign/ForeignTestObject.java
@@ -51,12 +51,11 @@ public class ForeignTestObject implements Serializable {
    }
 
    @Override
-   public boolean equals(final Object o) {
-      if (o instanceof ForeignTestObject to) {
-
-         return s1.equals(to.getS1()) && d1 == to.getD1();
+   public boolean equals(final Object obj) {
+      if (obj instanceof ForeignTestObject other) {
+         return s1.equals(other.getS1()) && d1 == other.getD1();
       }
-      return super.equals(o);
+      return super.equals(obj);
    }
 
    @Override


### PR DESCRIPTION
This commit enforces consistency for `Object#equals` implementations across the code-base via the following changes:

 - Use `Objects#equals` whenever possible.
 - Use `instanceof` rather than explicit null checks & `getClass`.
 - Use "obj" for parameter name and "other" for cast object name.
 - Always check identity using `==` first.
 - Use explicit curly brackets for conditionals to increase clarity.