### PR TITLE
ARTEMIS-5565 Allow for offered capabilities in broker connection Open

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -237,7 +237,7 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    @Override
    public ConnectionEntry createConnectionEntry(Acceptor acceptorUsed, Connection remotingConnection) {
-      return internalConnectionEntry(remotingConnection, false, null, null, null);
+      return internalConnectionEntry(remotingConnection, false, null, null, null, null);
    }
 
    /**
@@ -245,22 +245,22 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
     * AMQP Bridges
     */
    public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection) {
-      return internalConnectionEntry(remotingConnection, true, null, null, null);
+      return internalConnectionEntry(remotingConnection, true, null, null, null, null);
    }
 
    public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection, ClientSASLFactory saslFactory) {
-      return internalConnectionEntry(remotingConnection, true, saslFactory, null, null);
+      return internalConnectionEntry(remotingConnection, true, saslFactory, null, null, null);
    }
 
    public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties) {
-      return internalConnectionEntry(remotingConnection, true, saslFactory, connectionProperties, null);
+      return internalConnectionEntry(remotingConnection, true, saslFactory, connectionProperties, null, null);
    }
 
-   public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties, Symbol[] desiredCapabilities) {
-      return internalConnectionEntry(remotingConnection, true, saslFactory, connectionProperties, desiredCapabilities);
+   public ConnectionEntry createOutgoingConnectionEntry(Connection remotingConnection, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties, Symbol[] offeredCapabilities, Symbol[] desiredCapabilities) {
+      return internalConnectionEntry(remotingConnection, true, saslFactory, connectionProperties, offeredCapabilities, desiredCapabilities);
    }
 
-   private ConnectionEntry internalConnectionEntry(Connection remotingConnection, boolean outgoing, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties, Symbol[] desiredCapabilities) {
+   private ConnectionEntry internalConnectionEntry(Connection remotingConnection, boolean outgoing, ClientSASLFactory saslFactory, Map<Symbol, Object> connectionProperties, Symbol[] offeredCapabilities, Symbol[] desiredCapabilities) {
       AMQPConnectionCallback connectionCallback = new AMQPConnectionCallback(this, remotingConnection, server.getExecutorFactory().getExecutor(), server);
       long ttl = ActiveMQClient.DEFAULT_CONNECTION_TTL;
 
@@ -278,7 +278,10 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
       String id = server.getNodeID().toString();
       boolean useCoreSubscriptionNaming = server.getConfiguration().isAmqpUseCoreSubscriptionNaming();
-      AMQPConnectionContext amqpConnection = new AMQPConnectionContext(this, connectionCallback, id, (int) ttl, getMaxFrameSize(), AMQPConstants.Connection.DEFAULT_CHANNEL_MAX, useCoreSubscriptionNaming, server.getScheduledPool(), true, saslFactory, connectionProperties, desiredCapabilities, outgoing);
+      AMQPConnectionContext amqpConnection = new AMQPConnectionContext(
+         this, connectionCallback, id, (int) ttl, getMaxFrameSize(), AMQPConstants.Connection.DEFAULT_CHANNEL_MAX,
+         useCoreSubscriptionNaming, server.getScheduledPool(), true, saslFactory, connectionProperties,
+         offeredCapabilities, desiredCapabilities, outgoing);
 
       Executor executor = server.getExecutorFactory().getExecutor();
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/AMQPClientConnectionFactory.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/client/AMQPClientConnectionFactory.java
@@ -41,13 +41,21 @@ public class AMQPClientConnectionFactory {
    private final Map<Symbol, Object> connectionProperties;
    private final int ttl;
    private final boolean useCoreSubscriptionNaming;
+   private final Symbol[] desiredCapabilities;
+   private final Symbol[] offeredCapabilities;
 
    public AMQPClientConnectionFactory(ActiveMQServer server, String containerId, Map<Symbol, Object> connectionProperties, int ttl) {
+      this(server, containerId, connectionProperties, ttl, null, null);
+   }
+
+   public AMQPClientConnectionFactory(ActiveMQServer server, String containerId, Map<Symbol, Object> connectionProperties, int ttl, Symbol[] offeredCapabilities, Symbol[] desiredCapabilities) {
       this.server = server;
       this.containerId = containerId;
       this.connectionProperties = connectionProperties;
       this.ttl = ttl;
       this.useCoreSubscriptionNaming = false;
+      this.offeredCapabilities = offeredCapabilities;
+      this.desiredCapabilities = desiredCapabilities;
    }
 
    public ActiveMQProtonRemotingConnection createConnection(ProtonProtocolManager protocolManager, Connection connection, Optional<EventHandler> eventHandler, ClientSASLFactory clientSASLFactory) {
@@ -55,7 +63,10 @@ public class AMQPClientConnectionFactory {
 
       Executor executor = server.getExecutorFactory().getExecutor();
 
-      AMQPConnectionContext amqpConnection = new AMQPConnectionContext(protocolManager, connectionCallback, containerId, ttl, protocolManager.getMaxFrameSize(), AMQPConstants.Connection.DEFAULT_CHANNEL_MAX, useCoreSubscriptionNaming, server.getScheduledPool(), false, clientSASLFactory, connectionProperties, null);
+      AMQPConnectionContext amqpConnection = new AMQPConnectionContext(
+         protocolManager, connectionCallback, containerId, ttl, protocolManager.getMaxFrameSize(),
+         AMQPConstants.Connection.DEFAULT_CHANNEL_MAX, useCoreSubscriptionNaming, server.getScheduledPool(),
+         false, clientSASLFactory, connectionProperties, offeredCapabilities, desiredCapabilities);
       eventHandler.ifPresent(amqpConnection::addEventHandler);
 
       ActiveMQProtonRemotingConnection delegate = new ActiveMQProtonRemotingConnection(protocolManager, amqpConnection, connection, executor);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/AMQPBrokerConnection.java
@@ -505,7 +505,7 @@ public class AMQPBrokerConnection implements ClientConnectionLifeCycleListener, 
          final Symbol[] brokerDesiredCapabilities = bridgeManagers == null ? null : new Symbol[] {SHARED_SUBS};
 
          NettyConnectorCloseHandler connectorCloseHandler = new NettyConnectorCloseHandler(connector, connectExecutor);
-         ConnectionEntry entry = protonProtocolManager.createOutgoingConnectionEntry(connection, saslFactory, brokerConnectionProperties, brokerDesiredCapabilities);
+         ConnectionEntry entry = protonProtocolManager.createOutgoingConnectionEntry(connection, saslFactory, brokerConnectionProperties, null, brokerDesiredCapabilities);
          server.getRemotingService().addConnectionEntry(connection, entry);
          protonRemotingConnection = (ActiveMQProtonRemotingConnection) entry.connection;
          protonRemotingConnection.getAmqpConnection().addLinkRemoteCloseListener(getName(), this::linkClosed);

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/handler/ProtonHandler.java
@@ -630,10 +630,11 @@ public class ProtonHandler extends ProtonInitializable implements SaslListener {
       flush();
    }
 
-   public void open(String containerId, Map<Symbol, Object> connectionProperties, Symbol[] desiredCapabilities) {
+   public void open(String containerId, Map<Symbol, Object> connectionProperties, Symbol[] offeredCapabilities, Symbol[] desiredCapabilities) {
       this.transport.open();
       this.connection.setContainer(containerId);
       this.connection.setProperties(connectionProperties);
+      this.connection.setOfferedCapabilities(offeredCapabilities);
       this.connection.setDesiredCapabilities(desiredCapabilities);
       this.connection.open();
       flush();

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContextTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/AMQPConnectionContextTest.java
@@ -77,6 +77,7 @@ public class AMQPConnectionContextTest {
          false,
          null,
          null,
+         null,
          null);
 
       connectionContext.onRemoteOpen(connection);


### PR DESCRIPTION
When opening a broker connection to another broker instance we should provide a means of setting the offered capabilities as we do the desired capabilites so that future work could send offered capabilities that the remote side can make use of which it could not currently as the broker connection can't configure them.