### PR TITLE
ARTEMIS-5581 Fixing deadlock on ServerLocatorImpl.close

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -1421,12 +1421,10 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       }
 
       if (discoveryGroup != null) {
-         synchronized (this) {
-            try {
-               discoveryGroup.stop();
-            } catch (Exception e) {
-               ActiveMQClientLogger.LOGGER.failedToStopDiscovery(e);
-            }
+         try {
+            discoveryGroup.stop();
+         } catch (Exception e) {
+            ActiveMQClientLogger.LOGGER.failedToStopDiscovery(e);
          }
       } else {
          staticConnector.disconnect();


### PR DESCRIPTION
This is fixing NettyFileStorageSymmetricClusterWithDiscoveryTest

In particular I used testRouteWhenNoConsumersFalseNonLoadBalancedQueues in loop on my IDE to validate the fix.