### PR TITLE
ARTEMIS-5582: Update to errorprone 2.40.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,7 +118,7 @@ jobs:
         if: matrix.java != '17'
         run: |
           cd activemq-artemis
-          mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Pjmh install
+          mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Pjmh -Popenwire-tests -DskipActiveMQ5Tests install
 
       - name: Set Examples Version to Artemis Version
         run: |

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
       <jetty.version>12.0.23</jetty.version>
       <jetty-servlet-api.version>5.0.2</jetty-servlet-api.version>
       <jgroups.version>5.3.13.Final</jgroups.version>
-      <errorprone.version>2.39.0</errorprone.version>
+      <errorprone.version>2.40.0</errorprone.version>
       <maven.bundle.plugin.version>5.1.9</maven.bundle.plugin.version>
       <jib.maven.plugin.version>3.4.6</jib.maven.plugin.version>
       <versions.maven.plugin.version>2.16.1</versions.maven.plugin.version>

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/FailoverConsumerOutstandingCommitTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/FailoverConsumerOutstandingCommitTest.java
@@ -67,11 +67,6 @@ public class FailoverConsumerOutstandingCommitTest extends OpenwireArtemisBaseTe
       }
    }
 
-   public void startServer() throws Exception {
-      server = createBroker();
-      server.start();
-   }
-
    @Test
    @BMRules(
       rules = {@BMRule(

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/FailoverDuplicateTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/FailoverDuplicateTest.java
@@ -64,20 +64,10 @@ public class FailoverDuplicateTest extends OpenwireArtemisBaseTest {
       stopBroker();
    }
 
-   public void stopBroker() throws Exception {
+   protected void stopBroker() throws Exception {
       if (broker != null) {
          broker.stop();
       }
-   }
-
-   public void startBroker(boolean deleteAllMessagesOnStartup) throws Exception {
-      broker = createBroker();
-      broker.start();
-   }
-
-   public void startBroker() throws Exception {
-      broker = createBroker();
-      broker.start();
    }
 
    public void configureConnectionFactory(ActiveMQConnectionFactory factory) {

--- a/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/FailoverPrefetchZeroTest.java
+++ b/tests/activemq5-unit-tests/src/test/java/org/apache/activemq/transport/failover/FailoverPrefetchZeroTest.java
@@ -66,11 +66,6 @@ public class FailoverPrefetchZeroTest extends OpenwireArtemisBaseTest {
       }
    }
 
-   public void startBroker() throws Exception {
-      broker = createBroker();
-      broker.start();
-   }
-
    @Test
    @BMRules(
       rules = {@BMRule(


### PR DESCRIPTION
Update to errorprone 2.40.0.

Also Builds, but doesnt run, the optional activemq5-unit-tests module in check builds > JDK17 to more consistently fail across all runs. Removes unused methods / reduces visibility to appease errorprone checks for broken JUnit 4 test method definitions.

Replaces #5824 