### PR TITLE
ARTEMIS-5605 Use correct reference to proton receiver in initialize

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressReceiver.java
@@ -332,7 +332,7 @@ public class AMQPBridgeFromAddressReceiver extends AMQPBridgeReceiver {
          }
 
          // If we offered core tunneling then check if the remote indicated support and enabled the readers
-         if (configuration.isCoreMessageTunnelingEnabled() && verifyDesiredCapability(protonReceiver, CORE_MESSAGE_TUNNELING_SUPPORT)) {
+         if (configuration.isCoreMessageTunnelingEnabled() && verifyDesiredCapability(receiver, CORE_MESSAGE_TUNNELING_SUPPORT)) {
             enableCoreTunneling();
          }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueueReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueueReceiver.java
@@ -301,7 +301,7 @@ public class AMQPBridgeFromQueueReceiver extends AMQPBridgeReceiver {
          }
 
          // If we offered core tunneling then check if the remote indicated support and enabled the readers
-         if (configuration.isCoreMessageTunnelingEnabled() && verifyDesiredCapability(protonReceiver, CORE_MESSAGE_TUNNELING_SUPPORT)) {
+         if (configuration.isCoreMessageTunnelingEnabled() && verifyDesiredCapability(receiver, CORE_MESSAGE_TUNNELING_SUPPORT)) {
             enableCoreTunneling();
          }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
@@ -376,7 +376,7 @@ public final class AMQPFederationAddressConsumer extends AMQPFederationConsumer 
          if (configuration.isCoreMessageTunnelingEnabled()) {
             // We will have offered it if the option is enabled, but the remote needs to indicate it desires it
             // otherwise we want to fail on any tunneled core messages that arrives which is the default.
-            if (verifyDesiredCapability(protonReceiver, AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT)) {
+            if (verifyDesiredCapability(receiver, AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT)) {
                enableCoreTunneling();
             }
          }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
@@ -315,7 +315,7 @@ public final class AMQPFederationQueueConsumer extends AMQPFederationConsumer {
          if (configuration.isCoreMessageTunnelingEnabled()) {
             // We will have offered it if the option is enabled, but the remote needs to indicate it desires it
             // otherwise we want to fail on any tunneled core messages that arrives which is the default.
-            if (verifyDesiredCapability(protonReceiver, AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT)) {
+            if (verifyDesiredCapability(receiver, AmqpSupport.CORE_MESSAGE_TUNNELING_SUPPORT)) {
                enableCoreTunneling();
             }
          }


### PR DESCRIPTION
When initializing bridge and federation receiver links use the correct reference to the proton Receiver when validating capabilities to ensure it cannot be null if the bridge or federation receiver link is closed before the remote attach arrives.