### PR TITLE
ARTEMIS-5609 Add support for acceptor updates on config reload

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/ManagementService.java
@@ -16,9 +16,10 @@
  */
 package org.apache.activemq.artemis.core.server.management;
 
-import javax.management.ObjectName;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
+
+import javax.management.ObjectName;
 
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
@@ -46,11 +47,11 @@ import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.QueueFactory;
 import org.apache.activemq.artemis.core.server.RemoteBrokerConnection;
-import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
 import org.apache.activemq.artemis.core.server.cluster.BroadcastGroup;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
@@ -106,6 +107,8 @@ public interface ManagementService extends NotificationService, ActiveMQComponen
    void unregisterQueue(SimpleString name, SimpleString address, RoutingType routingType) throws Exception;
 
    void registerAcceptor(Acceptor acceptor, TransportConfiguration configuration) throws Exception;
+
+   void unregisterAcceptor(String acceptorName) throws Exception;
 
    void unregisterAcceptors();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/management/impl/ManagementServiceImpl.java
@@ -399,6 +399,7 @@ public class ManagementServiceImpl implements ManagementService {
       }
    }
 
+   @Override
    public void unregisterAcceptor(final String name) throws Exception {
       unregisterFromJMX(objectNameBuilder.getAcceptorObjectName(name));
       unregisterFromRegistry(ResourceNames.ACCEPTOR + name);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/reload/ReloadManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/reload/ReloadManager.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.core.server.reload;
 
+import java.net.URI;
 import java.net.URL;
 
 import org.apache.activemq.artemis.core.server.ActiveMQComponent;
@@ -23,6 +24,14 @@ import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 public interface ReloadManager extends ActiveMQComponent {
 
    void addCallback(URL uri, ReloadCallback callback);
+
+   /**
+    * Remove any callback instances previously registered with this manager.
+    *
+    * @param uri
+    *    The {@link URI} used to add callback instances to this manager
+    */
+   void removeCallbacks(URL uri);
 
    /**
     * Callback for the next tick

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/group/impl/ClusteredResetMockTest.java
@@ -18,11 +18,12 @@ package org.apache.activemq.artemis.core.server.group.impl;
 
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import javax.management.ObjectName;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
+
+import javax.management.ObjectName;
 
 import org.apache.activemq.artemis.api.core.BroadcastGroupConfiguration;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
@@ -50,15 +51,15 @@ import org.apache.activemq.artemis.core.server.Divert;
 import org.apache.activemq.artemis.core.server.Queue;
 import org.apache.activemq.artemis.core.server.QueueFactory;
 import org.apache.activemq.artemis.core.server.RemoteBrokerConnection;
-import org.apache.activemq.artemis.core.server.management.GuardInvocationHandler;
-import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.server.cluster.Bridge;
 import org.apache.activemq.artemis.core.server.cluster.BroadcastGroup;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
+import org.apache.activemq.artemis.core.server.management.GuardInvocationHandler;
 import org.apache.activemq.artemis.core.server.management.ManagementService;
 import org.apache.activemq.artemis.core.server.management.Notification;
 import org.apache.activemq.artemis.core.server.management.NotificationListener;
+import org.apache.activemq.artemis.core.server.routing.ConnectionRouter;
 import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.core.transaction.ResourceManager;
@@ -278,6 +279,11 @@ public class ClusteredResetMockTest extends ServerTestBase {
 
       @Override
       public void registerAcceptor(Acceptor acceptor, TransportConfiguration configuration) throws Exception {
+
+      }
+
+      @Override
+      public void unregisterAcceptor(String name) {
 
       }
 

--- a/docs/user-manual/config-reload.adoc
+++ b/docs/user-manual/config-reload.adoc
@@ -16,6 +16,7 @@ Once the configuration file is changed (broker.xml) the following modules will b
 * Diverts
 * Addresses & Queues
 * Bridges
+* Acceptors
 
 If using xref:configuration-index.adoc#modularising-broker-xml[modularised `broker.xml`] ensure you also read xref:configuration-index.adoc#reloading-modular-configuration-files[reloading modular configuration files]
 
@@ -549,6 +550,9 @@ Below lists the effects of adding, deleting and updating of an element/attribute
 | The queue user will be set to the default `null` after reloading
 | The queue user will be set to the new value after reloading
 |===
+
+==== `<acceptors>`
+Adding, updating and removing an `<acceptor>` is supported, updating or removing an `<acceptor>` results in the closure of all connections that were accepted previously. Added or updated acceptors are automatically started during the configuration reload process unless the `auto-start` option is set to false.
 
 === `<jms>` _(Deprecated)_
 

--- a/tests/integration-tests/src/test/resources/reload-acceptor-add-new.xml
+++ b/tests/integration-tests/src/test/resources/reload-acceptor-add-new.xml
@@ -1,0 +1,37 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>false</persistence-enabled>
+      <security-enabled>false</security-enabled>
+
+      <acceptors>
+         <acceptor name="artemis1">tcp://127.0.0.2:61617</acceptor>
+         <acceptor name="artemis2">tcp://127.0.0.3:61618?autoStart=false</acceptor>
+      </acceptors>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-acceptor-updated.xml
+++ b/tests/integration-tests/src/test/resources/reload-acceptor-updated.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>false</persistence-enabled>
+      <security-enabled>false</security-enabled>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://127.0.0.1:61616?autoStart=false</acceptor>
+      </acceptors>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-acceptor.xml
+++ b/tests/integration-tests/src/test/resources/reload-acceptor.xml
@@ -1,0 +1,36 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>false</persistence-enabled>
+      <security-enabled>false</security-enabled>
+
+      <acceptors>
+         <acceptor name="artemis">tcp://127.0.0.1:61616</acceptor>
+      </acceptors>
+   </core>
+</configuration>

--- a/tests/integration-tests/src/test/resources/reload-no-acceptor-config.xml
+++ b/tests/integration-tests/src/test/resources/reload-no-acceptor-config.xml
@@ -1,0 +1,33 @@
+<?xml version='1.0'?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+
+<configuration xmlns="urn:activemq"
+               xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+               xsi:schemaLocation="urn:activemq /schema/artemis-configuration.xsd">
+
+   <core xmlns="urn:activemq:core">
+
+      <configuration-file-refresh-period>100</configuration-file-refresh-period>
+
+      <persistence-enabled>false</persistence-enabled>
+      <security-enabled>false</security-enabled>
+
+   </core>
+</configuration>


### PR DESCRIPTION
Allows acceptors to be added, updated and removed from configuation and that change is handled via the reload manager. Removed or updated acceptors have all connections under them closed as a consequence of that action.