### PR TITLE
ARTEMIS-5562: Fix NPE on closeConnectionFactory

### DIFF
--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -1490,10 +1490,18 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
    }
 
    public synchronized void closeConnectionFactory(ConnectionFactoryProperties properties) {
-      Pair<ActiveMQConnectionFactory, AtomicInteger> pair = knownConnectionFactories.get(properties);
-      int references = pair.getB().decrementAndGet();
-      if (pair.getA() != null && pair.getA() != defaultActiveMQConnectionFactory && references == 0) {
-         knownConnectionFactories.remove(properties).getA().close();
+      Pair<ActiveMQConnectionFactory, AtomicInteger> factoryPair = knownConnectionFactories.get(properties);
+      if (factoryPair == null) {
+         logger.debug("No connection factory found for client '{}', probably already closed.", properties.getClientID());
+         return;
+      }
+
+     ActiveMQConnectionFactory factory = factoryPair.getA();
+     int referenceCount = factoryPair.getB().decrementAndGet();
+
+      if (factory != null && factory != defaultActiveMQConnectionFactory && referenceCount == 0) {
+         knownConnectionFactories.remove(properties);
+         factory.close();
       }
    }
 

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/ActiveMQResourceAdapter.java
@@ -1496,8 +1496,8 @@ public class ActiveMQResourceAdapter implements ResourceAdapter, Serializable {
          return;
       }
 
-     ActiveMQConnectionFactory factory = factoryPair.getA();
-     int referenceCount = factoryPair.getB().decrementAndGet();
+      ActiveMQConnectionFactory factory = factoryPair.getA();
+      int referenceCount = factoryPair.getB().decrementAndGet();
 
       if (factory != null && factory != defaultActiveMQConnectionFactory && referenceCount == 0) {
          knownConnectionFactories.remove(properties);

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
@@ -655,4 +655,23 @@ public class ResourceAdapterTest extends ActiveMQTestBase {
          server.stop();
       }
    }
+    @Test
+    public void testCloseConnectionFactoryMultipleTimesDoesNotThrow() throws Exception {
+        ActiveMQResourceAdapter ra = new ActiveMQResourceAdapter();
+        ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
+
+        ConnectionFactoryProperties properties = new ConnectionFactoryProperties();
+        properties.setClientID("test-client");
+
+        ActiveMQConnectionFactory factory = ra.getConnectionFactory(properties);
+        assertNotNull(factory);
+
+        ra.closeConnectionFactory(properties);
+
+        try {
+            ra.closeConnectionFactory(properties);
+        } catch (NullPointerException e) {
+            fail("NullPointerException was thrown when closing connection factory multiple times");
+        }
+    }
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/ra/ResourceAdapterTest.java
@@ -655,23 +655,23 @@ public class ResourceAdapterTest extends ActiveMQTestBase {
          server.stop();
       }
    }
-    @Test
-    public void testCloseConnectionFactoryMultipleTimesDoesNotThrow() throws Exception {
-        ActiveMQResourceAdapter ra = new ActiveMQResourceAdapter();
-        ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
+   @Test
+   public void testCloseConnectionFactoryMultipleTimesDoesNotThrow() throws Exception {
+      ActiveMQResourceAdapter ra = new ActiveMQResourceAdapter();
+      ra.setConnectorClassName(INVM_CONNECTOR_FACTORY);
 
-        ConnectionFactoryProperties properties = new ConnectionFactoryProperties();
-        properties.setClientID("test-client");
+      ConnectionFactoryProperties properties = new ConnectionFactoryProperties();
+      properties.setClientID("test-client");
 
-        ActiveMQConnectionFactory factory = ra.getConnectionFactory(properties);
-        assertNotNull(factory);
+      ActiveMQConnectionFactory factory = ra.getConnectionFactory(properties);
+      assertNotNull(factory);
 
-        ra.closeConnectionFactory(properties);
+      ra.closeConnectionFactory(properties);
 
-        try {
-            ra.closeConnectionFactory(properties);
-        } catch (NullPointerException e) {
-            fail("NullPointerException was thrown when closing connection factory multiple times");
-        }
-    }
+      try {
+         ra.closeConnectionFactory(properties);
+      } catch (NullPointerException e) {
+         fail("NullPointerException was thrown when closing connection factory multiple times");
+      }
+   }
 }


### PR DESCRIPTION
A NullPointerException was thrown by
ActiveMQResourceAdapter.closeConnectionFactory() if called multiple times with same properties due to factory already been removed from knownConnectionFactories.

Note: this was mostly a "cosmetic" issue since exception was caught by caller in ActiveMQRAManagedConnection.destroy() and stacktrace logged

Fixed by adding proper null check and a debug log, also adding unit test proving issue is solved.