### PR TITLE
ARTEMIS-5557 support Micrometer ExecutorService metrics

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/Run.java
@@ -179,7 +179,7 @@ public class Run extends LockAbstract {
          }
       }
 
-      shutdownTimer = new Timer("ActiveMQ Artemis Server Shutdown Timer", true);
+      shutdownTimer = new Timer("activemq-shutdown-timer", true);
       shutdownTimer.scheduleAtFixedRate(new TimerTask() {
          @Override
          public void run() {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQScheduledComponent.java
@@ -16,6 +16,7 @@
  */
 package org.apache.activemq.artemis.core.server;
 
+import java.lang.invoke.MethodHandles;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import java.util.Objects;
@@ -30,7 +31,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.activemq.artemis.utils.ActiveMQThreadFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 /**
  * This is for components with a scheduled at a fixed rate.
@@ -184,7 +184,7 @@ public abstract class ActiveMQScheduledComponent implements ActiveMQComponent, R
    }
 
    protected ActiveMQThreadFactory getThreadFactory() {
-      return new ActiveMQThreadFactory(this.getClass().getSimpleName() + "-scheduled-threads", false, getThisClassLoader());
+      return new ActiveMQThreadFactory(this.getClass().getSimpleName() + "-scheduled", false, getThisClassLoader());
    }
 
    private ClassLoader getThisClassLoader() {

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/core/server/NetworkHealthCheck.java
@@ -160,7 +160,7 @@ public class NetworkHealthCheck extends ActiveMQScheduledComponent {
 
    @Override
    protected ActiveMQThreadFactory getThreadFactory() {
-      return new ActiveMQThreadFactory("NetworkChecker", "Network-Checker-", false, getThisClassLoader());
+      return new ActiveMQThreadFactory("network-checker", false, getThisClassLoader());
    }
 
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/ActiveMQThreadFactory.java
@@ -62,7 +62,7 @@ public final class ActiveMQThreadFactory implements ThreadFactory {
     * @param tccl      the context class loader of newly created threads
     */
    public ActiveMQThreadFactory(final String groupName, String prefix, final boolean daemon, final ClassLoader tccl) {
-      this.groupName = groupName;
+      this.groupName = "activemq-" + StringUtil.convertPascalCaseToKebabCase(groupName);
 
       this.prefix = prefix;
 

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/StringUtil.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/StringUtil.java
@@ -59,4 +59,23 @@ public class StringUtil {
       }
       return list;
    }
+
+   public static String convertPascalCaseToKebabCase(String input) {
+      if (input == null || input.isEmpty()) {
+         return input;
+      }
+      StringBuilder builder = new StringBuilder();
+      for (int i = 0; i < input.length(); i++) {
+         char c = input.charAt(i);
+         if (Character.isUpperCase(c)) {
+            if (i > 0) {
+               builder.append('-');
+            }
+            builder.append(Character.toLowerCase(c));
+         } else {
+            builder.append(c);
+         }
+      }
+      return builder.toString();
+   }
 }

--- a/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerImpl.java
+++ b/artemis-commons/src/main/java/org/apache/activemq/artemis/utils/critical/CriticalAnalyzerImpl.java
@@ -59,7 +59,7 @@ public class CriticalAnalyzerImpl implements CriticalAnalyzer {
 
          @Override
          protected ActiveMQThreadFactory getThreadFactory() {
-            return new ActiveMQThreadFactory("CriticalAnalyzer", "Critical-Analyzer-", true, getThisClassLoader());
+            return new ActiveMQThreadFactory("critical-analyzer", true, getThisClassLoader());
          }
 
          private ClassLoader getThisClassLoader() {

--- a/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/StringUtilTest.java
+++ b/artemis-commons/src/test/java/org/apache/activemq/artemis/utils/StringUtilTest.java
@@ -14,14 +14,13 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.activemq.artemis.util;
+package org.apache.activemq.artemis.utils;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.ArrayList;
 import java.util.List;
 
-import org.apache.activemq.artemis.utils.StringUtil;
 import org.junit.jupiter.api.Test;
 
 public class StringUtilTest {
@@ -64,5 +63,10 @@ public class StringUtilTest {
       assertEquals("blue", result.get(1));
       assertEquals("yellow", result.get(2));
       assertEquals("green", result.get(3));
+   }
+
+   @Test
+   public void testPascalToKebab() throws Exception {
+      assertEquals("pascal-to-kebab", StringUtil.convertPascalCaseToKebabCase("PascalToKebab"));
    }
 }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/config/ActiveMQDefaultConfiguration.java
@@ -652,6 +652,9 @@ public final class ActiveMQDefaultConfiguration {
    // Whether or not to report JVM thread metrics
    private static final boolean DEFAULT_JVM_THREAD_METRICS = false;
 
+   // Whether or not to report executor service metrics
+   private static final boolean DEFAULT_EXECUTOR_SERVICE_METRICS = false;
+
    public static final String DEFAULT_UUID_NAMESPACE = "";
 
    @Deprecated(forRemoval = true)
@@ -1877,6 +1880,10 @@ public final class ActiveMQDefaultConfiguration {
     */
    public static boolean getDefaultJvmThreadMetrics() {
       return DEFAULT_JVM_THREAD_METRICS;
+   }
+
+   public static boolean getDefaultExecutorServiceMetrics() {
+      return DEFAULT_EXECUTOR_SERVICE_METRICS;
    }
 
    public static String getDefaultUuidNamespace() {

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/client/ActiveMQClient.java
@@ -245,12 +245,12 @@ public final class ActiveMQClient {
    }
 
    public static synchronized ExecutorService getGlobalThreadPool() {
-      globalThreadPool = internalGetGlobalThreadPool(globalThreadPool, "ActiveMQ-client-global-threads", ActiveMQClient.globalThreadPoolSize);
+      globalThreadPool = internalGetGlobalThreadPool(globalThreadPool, "client-global", ActiveMQClient.globalThreadPoolSize);
       return globalThreadPool;
    }
 
    public static synchronized ExecutorService getGlobalFlowControlThreadPool() {
-      globalFlowControlThreadPool = internalGetGlobalThreadPool(globalFlowControlThreadPool, "ActiveMQ-client-global-flow-control-threads", ActiveMQClient.globalFlowControlThreadPoolSize);
+      globalFlowControlThreadPool = internalGetGlobalThreadPool(globalFlowControlThreadPool, "client-global-flow-control", ActiveMQClient.globalFlowControlThreadPoolSize);
       return globalFlowControlThreadPool;
    }
 
@@ -269,7 +269,7 @@ public final class ActiveMQClient {
 
    public static synchronized ScheduledExecutorService getGlobalScheduledThreadPool() {
       if (globalScheduledThreadPool == null) {
-         ThreadFactory factory = AccessController.doPrivileged((PrivilegedAction<ThreadFactory>) () -> new ActiveMQThreadFactory("ActiveMQ-client-global-scheduled-threads", true, ClientSessionFactoryImpl.class.getClassLoader()));
+         ThreadFactory factory = AccessController.doPrivileged((PrivilegedAction<ThreadFactory>) () -> new ActiveMQThreadFactory("client-global-scheduled", true, ClientSessionFactoryImpl.class.getClassLoader()));
 
          globalScheduledThreadPool = new ScheduledThreadPoolExecutor(ActiveMQClient.globalScheduledThreadPoolSize, factory);
       }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -207,21 +207,21 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       } else {
          this.shutdownPool = true;
 
-         ThreadFactory factory = getThreadFactory("ActiveMQ-client-factory-threads-");
+         ThreadFactory factory = getThreadFactory("client-factory-");
          if (config.threadPoolMaxSize == -1) {
             threadPool = Executors.newCachedThreadPool(factory);
          } else {
             threadPool = new ActiveMQThreadPoolExecutor(0, config.threadPoolMaxSize, 60L, TimeUnit.SECONDS, factory);
          }
 
-         factory = getThreadFactory("ActiveMQ-client-factory-flow-control-threads-");
+         factory = getThreadFactory("client-factory-flow-control-");
          if (config.flowControlThreadPoolMaxSize == -1) {
             flowControlThreadPool = Executors.newCachedThreadPool(factory);
          } else {
             flowControlThreadPool = new ActiveMQThreadPoolExecutor(0, config.flowControlThreadPoolMaxSize, 60L, TimeUnit.SECONDS, factory);
          }
 
-         factory = getThreadFactory("ActiveMQ-client-factory-pinger-threads-");
+         factory = getThreadFactory("client-factory-pinger-");
          scheduledThreadPool = Executors.newScheduledThreadPool(config.scheduledThreadPoolMaxSize, factory);
       }
       this.updateArrayActor = new Actor<>(threadPool, this::internalUpdateArray);

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/cluster/DiscoveryGroup.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/cluster/DiscoveryGroup.java
@@ -111,12 +111,7 @@ public final class DiscoveryGroup implements ActiveMQComponent {
 
       started = true;
 
-      ThreadFactory tfactory = AccessController.doPrivileged(new PrivilegedAction<>() {
-         @Override
-         public ThreadFactory run() {
-            return new ActiveMQThreadFactory("DiscoveryGroup-" + System.identityHashCode(this), "activemq-discovery-group-thread-" + name, true, DiscoveryGroup.class.getClassLoader());
-         }
-      });
+      ThreadFactory tfactory = AccessController.doPrivileged((PrivilegedAction<ThreadFactory>) () -> new ActiveMQThreadFactory("discovery-group-" + name, true, DiscoveryGroup.class.getClassLoader()));
 
       thread = tfactory.newThread(new DiscoveryRunnable());
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/SharedEventLoopGroup.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/SharedEventLoopGroup.java
@@ -61,7 +61,7 @@ public class SharedEventLoopGroup extends DelegatingEventLoopGroup {
             f.cancel(false);
          }
       } else {
-         instance = new SharedEventLoopGroup(eventLoopGroupSupplier.apply((ThreadFactory) AccessController.doPrivileged((PrivilegedAction) () -> new ActiveMQThreadFactory("ActiveMQ-client-netty-threads", true, ClientSessionFactoryImpl.class.getClassLoader()))));
+         instance = new SharedEventLoopGroup(eventLoopGroupSupplier.apply((ThreadFactory) AccessController.doPrivileged((PrivilegedAction) () -> new ActiveMQThreadFactory("client-remoting", true, ClientSessionFactoryImpl.class.getClassLoader()))));
       }
       instance.channelFactoryCount.incrementAndGet();
       return instance;

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/AbstractSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/AbstractSequentialFile.java
@@ -18,11 +18,11 @@ package org.apache.activemq.artemis.core.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.file.Files;
 import java.util.List;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 
 import io.netty.buffer.ByteBuf;
@@ -39,9 +39,8 @@ import org.apache.activemq.artemis.core.journal.impl.SimpleWaitIOCallback;
 import org.apache.activemq.artemis.journal.ActiveMQJournalBundle;
 import org.apache.activemq.artemis.journal.ActiveMQJournalLogger;
 import org.apache.activemq.artemis.utils.ByteUtil;
-import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public abstract class AbstractSequentialFile implements SequentialFile {
 
@@ -67,8 +66,7 @@ public abstract class AbstractSequentialFile implements SequentialFile {
 
    public AbstractSequentialFile(final File directory,
                                  final String file,
-                                 final SequentialFileFactory factory,
-                                 final Executor writerExecutor) {
+                                 final SequentialFileFactory factory) {
       super();
       this.file = new File(directory, file);
       this.directory = directory;

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFile.java
@@ -18,9 +18,9 @@ package org.apache.activemq.artemis.core.io.aio;
 
 import java.io.File;
 import java.io.IOException;
+import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.util.PriorityQueue;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.activemq.artemis.api.core.ActiveMQException;
@@ -31,9 +31,8 @@ import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.SequentialFile;
 import org.apache.activemq.artemis.core.journal.impl.SimpleWaitIOCallback;
 import org.apache.activemq.artemis.nativo.jlibaio.LibaioFile;
-import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * This class is implementing Runnable to reuse a callback to close it.
@@ -69,9 +68,8 @@ public class AIOSequentialFile extends AbstractSequentialFile  {
                             final int bufferSize,
                             final long bufferTimeoutMilliseconds,
                             final File directory,
-                            final String fileName,
-                            final Executor writerExecutor) {
-      super(directory, fileName, factory, writerExecutor);
+                            final String fileName) {
+      super(directory, fileName, factory);
       this.aioFactory = factory;
    }
 
@@ -92,7 +90,7 @@ public class AIOSequentialFile extends AbstractSequentialFile  {
 
    @Override
    public SequentialFile cloneFile() {
-      return new AIOSequentialFile(aioFactory, -1, -1, getFile().getParentFile(), getFile().getName(), null);
+      return new AIOSequentialFile(aioFactory, -1, -1, getFile().getParentFile(), getFile().getName());
    }
 
 

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/aio/AIOSequentialFileFactory.java
@@ -138,7 +138,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
 
    @Override
    public SequentialFile createSequentialFile(final String fileName) {
-      return new AIOSequentialFile(this, bufferSize, bufferTimeout, journalDir, fileName, writeExecutor);
+      return new AIOSequentialFile(this, bufferSize, bufferTimeout, journalDir, fileName);
    }
 
    @Override
@@ -439,7 +439,7 @@ public final class AIOSequentialFileFactory extends AbstractSequentialFileFactor
    private class PollerThread extends Thread {
 
       private PollerThread() {
-         super("Apache ActiveMQ Artemis libaio poller");
+         super("activemq-libaio-poller");
       }
 
       @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFile.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFile.java
@@ -21,13 +21,13 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.nio.ByteBuffer;
 import java.nio.channels.ClosedChannelException;
 import java.nio.channels.FileChannel;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.Executor;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.buffer.ByteBuf;
@@ -45,7 +45,6 @@ import org.apache.activemq.artemis.journal.ActiveMQJournalBundle;
 import org.apache.activemq.artemis.utils.Env;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 public class NIOSequentialFile extends AbstractSequentialFile {
 
@@ -73,9 +72,8 @@ public class NIOSequentialFile extends AbstractSequentialFile {
    public NIOSequentialFile(final SequentialFileFactory factory,
                             final File directory,
                             final String file,
-                            final int maxIO,
-                            final Executor writerExecutor) {
-      super(directory, file, factory, writerExecutor);
+                            final int maxIO) {
+      super(directory, file, factory);
       this.maxIO = maxIO;
    }
 
@@ -375,7 +373,7 @@ public class NIOSequentialFile extends AbstractSequentialFile {
 
    @Override
    public SequentialFile cloneFile() {
-      return new NIOSequentialFile(factory, directory, getFileName(), maxIO, null);
+      return new NIOSequentialFile(factory, directory, getFileName(), maxIO);
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFileFactory.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/io/nio/NIOSequentialFileFactory.java
@@ -116,7 +116,7 @@ public class NIOSequentialFileFactory extends AbstractSequentialFileFactory {
 
    @Override
    public SequentialFile createSequentialFile(final String fileName) {
-      return new NIOSequentialFile(this, journalDir, fileName, maxIO, writeExecutor);
+      return new NIOSequentialFile(this, journalDir, fileName, maxIO);
    }
 
    @Override

--- a/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
+++ b/artemis-journal/src/main/java/org/apache/activemq/artemis/core/journal/impl/JournalImpl.java
@@ -2836,7 +2836,7 @@ public class JournalImpl extends JournalBase implements TestableJournal, Journal
       }
 
       if (providedIOThreadPool == null) {
-         ThreadFactory factory = AccessController.doPrivileged((PrivilegedAction<ThreadFactory>) () -> new ActiveMQThreadFactory("ArtemisIOThread", true, JournalImpl.class.getClassLoader()));
+         ThreadFactory factory = AccessController.doPrivileged((PrivilegedAction<ThreadFactory>) () -> new ActiveMQThreadFactory("io", true, JournalImpl.class.getClassLoader()));
 
          threadPool = new ThreadPoolExecutor(0, Integer.MAX_VALUE, 60L, TimeUnit.SECONDS, new SynchronousQueue(), factory);
          ioExecutorFactory = new OrderedExecutorFactory(threadPool);

--- a/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
+++ b/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivation.java
@@ -351,7 +351,7 @@ public class ActiveMQActivation {
             }
          };
 
-         Thread threadTearDown = startThread("TearDown/HornetQActivation", runTearDown);
+         Thread threadTearDown = startThread("resource-adapter-activation-teardown", runTearDown);
 
          try {
             threadTearDown.join(timeout);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/MetricsConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/MetricsConfiguration.java
@@ -32,6 +32,7 @@ public class MetricsConfiguration implements Serializable {
    private boolean uptime = ActiveMQDefaultConfiguration.getDefaultUptimeMetrics();
    private boolean logging = ActiveMQDefaultConfiguration.getDefaultLoggingMetrics();
    private boolean securityCaches = ActiveMQDefaultConfiguration.getDefaultSecurityCacheMetrics();
+   private boolean executorServices = ActiveMQDefaultConfiguration.getDefaultExecutorServiceMetrics();
    private ActiveMQMetricsPlugin plugin;
 
    public boolean isJvmMemory() {
@@ -121,6 +122,15 @@ public class MetricsConfiguration implements Serializable {
 
    public MetricsConfiguration setSecurityCaches(boolean securityCaches) {
       this.securityCaches = securityCaches;
+      return this;
+   }
+
+   public boolean isExecutorServices() {
+      return executorServices;
+   }
+
+   public MetricsConfiguration setExecutorServices(boolean executorServices) {
+      this.executorServices = executorServices;
       return this;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/deployers/impl/FileConfigurationParser.java
@@ -1053,6 +1053,8 @@ public final class FileConfigurationParser extends XMLConfigurationUtil {
                metricsConfiguration.setLogging(XMLUtil.parseBoolean(child));
             } else if (child.getNodeName().equals("security-caches")) {
                metricsConfiguration.setSecurityCaches(XMLUtil.parseBoolean(child));
+            } else if (child.getNodeName().equals("executor-services")) {
+               metricsConfiguration.setExecutorServices(XMLUtil.parseBoolean(child));
             } else if (child.getNodeName().equals("plugin")) {
                metricsConfiguration.setPlugin(parseMetricsPlugin(child, config));
             }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/invm/InVMAcceptorFactory.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
+import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.AcceptorFactory;
@@ -37,7 +38,9 @@ public class InVMAcceptorFactory implements AcceptorFactory {
                                   final ServerConnectionLifeCycleListener listener,
                                   final Executor threadPool,
                                   final ScheduledExecutorService scheduledThreadPool,
-                                  final Map<String, ProtocolManager> protocolMap) {
+                                  final Map<String, ProtocolManager> protocolMap,
+                                  String threadFactoryGroupName,
+                                  MetricsManager metricsManager) {
       return new InVMAcceptor(name, clusterConnection, configuration, handler, listener, protocolMap, threadPool);
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptorFactory.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
+import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.AcceptorFactory;
@@ -38,8 +39,10 @@ public class NettyAcceptorFactory implements AcceptorFactory {
                                   final ServerConnectionLifeCycleListener listener,
                                   final Executor threadPool,
                                   final ScheduledExecutorService scheduledThreadPool,
-                                  final Map<String, ProtocolManager> protocolMap) {
+                                  final Map<String, ProtocolManager> protocolMap,
+                                  final String threadFactoryGroupName,
+                                  MetricsManager metricsManager) {
       Executor failureExecutor = new OrderedExecutor(threadPool);
-      return new NettyAcceptor(name, connection, configuration, handler, listener, scheduledThreadPool, failureExecutor, protocolMap);
+      return new NettyAcceptor(name, connection, configuration, handler, listener, scheduledThreadPool, failureExecutor, protocolMap, threadFactoryGroupName, metricsManager);
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServer.java
@@ -153,6 +153,8 @@ public interface ActiveMQServer extends ServiceComponent {
 
    void removeMirrorControl();
 
+   String getThreadGroupName(String groupName);
+
    ServiceRegistry getServiceRegistry();
 
    RemotingService getRemotingService();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ReplicationPrimaryActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ReplicationPrimaryActivation.java
@@ -17,8 +17,9 @@
 package org.apache.activemq.artemis.core.server.impl;
 
 import javax.annotation.concurrent.GuardedBy;
+import java.lang.invoke.MethodHandles;
 import java.util.Objects;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -49,7 +50,6 @@ import org.apache.activemq.artemis.lockmanager.UnavailableStateException;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 import static org.apache.activemq.artemis.core.server.ActiveMQServer.SERVER_STATE.STARTED;
 import static org.apache.activemq.artemis.core.server.impl.quorum.ActivationSequenceStateMachine.awaitNextCommittedActivationSequence;
@@ -374,12 +374,12 @@ public class ReplicationPrimaryActivation extends PrimaryActivation implements D
    }
 
    private void onReplicationConnectionClose() {
-      ExecutorService executorService = activeMQServer.getThreadPool();
-      if (executorService != null) {
+      Executor executor = activeMQServer.getThreadPool();
+      if (executor != null) {
          if (stoppingServer.get()) {
             return;
          }
-         executorService.execute(() -> {
+         executor.execute(() -> {
             synchronized (replicationLock) {
                if (replicationManager == null) {
                   return;

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingPrimaryActivation.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/SharedNothingPrimaryActivation.java
@@ -16,9 +16,10 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
+import java.lang.invoke.MethodHandles;
 import java.util.List;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.ActiveMQAlreadyReplicatingException;
@@ -61,7 +62,6 @@ import org.apache.activemq.artemis.core.server.cluster.quorum.QuorumManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
 
 public class SharedNothingPrimaryActivation extends PrimaryActivation {
 
@@ -243,9 +243,9 @@ public class SharedNothingPrimaryActivation extends PrimaryActivation {
       }
 
       private void handleClose(boolean failed) {
-         ExecutorService executorService = activeMQServer.getThreadPool();
-         if (executorService != null) {
-            executorService.execute(() -> {
+         Executor executor = activeMQServer.getThreadPool();
+         if (executor != null) {
+            executor.execute(() -> {
                synchronized (replicationLock) {
                   if (replicationManager != null) {
                      activeMQServer.getStorageManager().stopReplication();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/BrokerMetricNames.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/BrokerMetricNames.java
@@ -29,4 +29,8 @@ public class BrokerMetricNames {
    public static final String ACTIVE = "active";
    public static final String AUTHENTICATION_COUNT = "authentication.count";
    public static final String AUTHORIZATION_COUNT = "authorization.count";
+   public static final String GENERAL_EXECUTOR_SERVICE = "general.executor.service";
+   public static final String IO_EXECUTOR_SERVICE = "io.executor.service";
+   public static final String PAGE_EXECUTOR_SERVICE = "paging.executor.service";
+   public static final String SCHEDULED_EXECUTOR_SERVICE = "scheduled.executor.service";
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/NettyPooledAllocatorMetrics.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/metrics/NettyPooledAllocatorMetrics.java
@@ -19,16 +19,16 @@ package org.apache.activemq.artemis.core.server.metrics;
 import java.util.List;
 import java.util.function.Function;
 
+import io.micrometer.core.instrument.FunctionCounter;
 import io.micrometer.core.instrument.Gauge;
 import io.micrometer.core.instrument.MeterRegistry;
 import io.micrometer.core.instrument.Tags;
 import io.micrometer.core.instrument.binder.MeterBinder;
+import io.netty.buffer.PoolArenaMetric;
 import io.netty.buffer.PoolChunkListMetric;
 import io.netty.buffer.PoolChunkMetric;
 import io.netty.buffer.PoolSubpageMetric;
 import io.netty.buffer.PooledByteBufAllocatorMetric;
-import io.micrometer.core.instrument.FunctionCounter;
-import io.netty.buffer.PoolArenaMetric;
 
 public final class NettyPooledAllocatorMetrics implements MeterBinder {
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Acceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/Acceptor.java
@@ -26,6 +26,8 @@ import org.apache.activemq.artemis.core.server.ActiveMQComponent;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.management.NotificationService;
 
+import static org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants.DEFAULT_AUTO_START;
+
 /**
  * An Acceptor is used by the RemotingService to allow clients to connect. It should take care of dispatching client
  * requests to the RemotingService's Dispatcher.
@@ -93,5 +95,9 @@ public interface Acceptor extends ActiveMQComponent {
     */
    default int getActualPort() {
       return -1;
+   }
+
+   default boolean isAutoStart() {
+      return DEFAULT_AUTO_START;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AcceptorFactory.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/spi/core/remoting/AcceptorFactory.java
@@ -21,6 +21,7 @@ import java.util.concurrent.Executor;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
+import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 
 /**
@@ -49,7 +50,9 @@ public interface AcceptorFactory {
                            ServerConnectionLifeCycleListener listener,
                            Executor threadPool,
                            ScheduledExecutorService scheduledThreadPool,
-                           Map<String, ProtocolManager> protocolMap);
+                           Map<String, ProtocolManager> protocolMap,
+                           String threadFactoryGroupName,
+                           MetricsManager metricsManager);
 
    default boolean supportsRemote() {
       return true;

--- a/artemis-server/src/main/resources/schema/artemis-configuration.xsd
+++ b/artemis-server/src/main/resources/schema/artemis-configuration.xsd
@@ -5231,6 +5231,14 @@
                </xsd:annotation>
             </xsd:element>
 
+            <xsd:element name="executor-services" type="xsd:boolean" default="false" maxOccurs="1" minOccurs="0">
+               <xsd:annotation>
+                  <xsd:documentation>
+                     whether to report metrics for the internal executor services (i.e. thread pools)
+                  </xsd:documentation>
+               </xsd:annotation>
+            </xsd:element>
+
             <xsd:element name="plugin" maxOccurs="1" minOccurs="0">
                <xsd:complexType>
                   <xsd:annotation>

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/DefaultsFileConfigurationTest.java
@@ -161,5 +161,7 @@ public class DefaultsFileConfigurationTest extends AbstractConfigurationTestBase
       assertEquals(ActiveMQDefaultConfiguration.getDefaultLoggingMetrics(), conf.getMetricsConfiguration().isLogging());
 
       assertEquals(ActiveMQDefaultConfiguration.getDefaultSecurityCacheMetrics(), conf.getMetricsConfiguration().isSecurityCaches());
+
+      assertEquals(ActiveMQDefaultConfiguration.getDefaultExecutorServiceMetrics(), conf.getMetricsConfiguration().isExecutorServices());
    }
 }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/FileConfigurationTest.java
@@ -685,6 +685,7 @@ public class FileConfigurationTest extends AbstractConfigurationTestBase {
       assertTrue(metricsConfiguration.isUptime());
       assertTrue(metricsConfiguration.isLogging());
       assertTrue(metricsConfiguration.isSecurityCaches());
+      assertTrue(metricsConfiguration.isExecutorServices());
    }
 
    private void verifyAddresses() {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/uri/AcceptorParserTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/uri/AcceptorParserTest.java
@@ -53,7 +53,7 @@ public class AcceptorParserTest {
       assertEquals(33, ConfigurationHelper.getIntProperty(TransportConstants.QUIET_PERIOD, -1, configs.get(0).getParams()));
       assertEquals(55, ConfigurationHelper.getIntProperty(TransportConstants.SHUTDOWN_TIMEOUT, -1, configs.get(0).getParams()));
 
-      NettyAcceptor nettyAcceptor = new NettyAcceptor("name", null, configs.get(0).getParams(), null, null, null, null, new HashMap<>());
+      NettyAcceptor nettyAcceptor = new NettyAcceptor("name", null, configs.get(0).getParams(), null, null, null, null, new HashMap<>(), "threadFactoryGroupName", null);
 
       assertEquals(33, nettyAcceptor.getQuietPeriod());
       assertEquals(55, nettyAcceptor.getShutdownTimeout());

--- a/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-full-config.xml
@@ -400,6 +400,7 @@
          <uptime>true</uptime>
          <logging>true</logging>
          <security-caches>true</security-caches>
+         <executor-services>true</executor-services>
          <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin">
             <property key="foo" value="x"/>
             <property key="bar" value="y"/>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-config.xml
@@ -288,6 +288,7 @@
          <uptime>true</uptime>
          <logging>true</logging>
          <security-caches>true</security-caches>
+         <executor-services>true</executor-services>
          <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin">
             <property key="foo" value="x"/>
             <property key="bar" value="y"/>

--- a/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-metrics.xml
+++ b/artemis-server/src/test/resources/ConfigurationTest-xinclude-schema-config-metrics.xml
@@ -24,6 +24,7 @@
    <uptime>true</uptime>
    <logging>true</logging>
    <security-caches>true</security-caches>
+   <executor-services>true</executor-services>
    <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin">
       <property key="foo" value="x"/>
       <property key="bar" value="y"/>

--- a/artemis-server/src/test/resources/metrics.xml
+++ b/artemis-server/src/test/resources/metrics.xml
@@ -29,6 +29,7 @@
          <uptime>true</uptime>
          <logging>true</logging>
          <security-caches>true</security-caches>
+         <executor-services>true</executor-services>
          <plugin class-name="org.apache.activemq.artemis.core.config.impl.FileConfigurationTest$FakeMetricPlugin">
             <property key="key1" value="value1"/>
             <property key="key2" value="value2"/>

--- a/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/tests/extensions/ThreadLeakCheckDelegate.java
+++ b/artemis-unit-test-support/src/main/java/org/apache/activemq/artemis/tests/extensions/ThreadLeakCheckDelegate.java
@@ -239,7 +239,7 @@ public class ThreadLeakCheckDelegate {
          return true;
       } else if (threadName.contains("globalEventExecutor")) {
          return true;
-      } else if (threadName.contains("netty-threads")) {
+      } else if (threadName.contains("activemq-remoting") || threadName.contains("activemq-client-remoting")) {
          // This is ok as we use EventLoopGroup.shutdownGracefully() which will shutdown things with a bit of delay
          // if the EventLoop's are still busy.
          return true;

--- a/docs/user-manual/configuration-index.adoc
+++ b/docs/user-manual/configuration-index.adoc
@@ -519,7 +519,7 @@ In most cases this should be set to '1'.
 | <<resource-limit-type,a list of resource-limits>>
 | n/a
 
-| xref:thread-pooling.adoc#server-scheduled-thread-pool[scheduled-thread-pool-max-size]
+| xref:thread-pooling.adoc#scheduled-thread-pool[scheduled-thread-pool-max-size]
 | Maximum number of threads to use for the scheduled thread pool.
 | 5
 

--- a/docs/user-manual/metrics.adoc
+++ b/docs/user-manual/metrics.adoc
@@ -104,57 +104,97 @@ However, these metrics can be deduced by aggregating the lower level metrics (e.
 There are a handful of other useful metrics that are related to the JVM, the underlying operating system, etc.
 These metrics are provided specifically by Micrometer and therefore do not have the `artmemis.` prefix.
 
-JVM memory metrics::
+==== JVM memory metrics
 Gauges buffer and memory pool utilization.
 Underlying data gathered from Java's https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/BufferPoolMXBean.html[BufferPoolMXBeans] and https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html[MemoryPoolMXBeans].
-+
+
 Enabled by default.
-JVM GC::
+
+==== JVM GC
 Gauges max and live data size, promotion and allocation rates, and the number of times the GC pauses (or concurrent phase time in the case of CMS).
 Underlying data gathered from Java's https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/MemoryPoolMXBean.html[MemoryPoolMXBeans].
-+
+
 Disabled by default.
-JVM thread::
+
+==== JVM thread
 Gauges thread peak, the number of daemon threads, and live threads.
 Underlying data gathered from Java's https://docs.oracle.com/en/java/javase/11/docs/api/java.management/java/lang/management/ThreadMXBean.html[ThreadMXBean].
-+
+
 Disabled by default.
-Netty::
+
+==== Netty Allocator
 Collects metrics from Netty's https://netty.io/4.1/api/io/netty/buffer/PooledByteBufAllocatorMetric.html[PooledByteBufAllocatorMetric].
-+
+
 Disabled by default.
 File descriptors::
 Gauges current and max-allowed open files.
-+
+
 Disabled by default.
-Processor::
+
+==== Processor
 Gauges system CPU count, CPU usage, and 1-minute load average as well as process CPU usage.
-+
+
 Disabled by default.
-Uptime::
+
+==== Uptime
 Gauges process start time and uptime.
-+
+
 Disabled by default.
-Logging::
+
+==== Logging
 Counts the number of logging events per logging category (e.g. `WARN`, `ERROR`, etc.).
-+
+
 Disabled by default.
-+
+
 [WARNING]
 ====
 This works _exclusively_ with Log4j2 (i.e the default logging implementation shipped with the broker).
 If you're embedding the broker and using a different logging implementation (e.g. Log4j 1.x, JUL, Logback, etc.) and you enable these metrics then the broker will fail to start with a `java.lang.NoClassDefFoundError` as it attempts to locate Log4j2 classes that don't exist on the classpath.
 ====
-Security caches::
-The following authentication & authorization cache metrics are exported. They are all tagged by `cache` (either `authentication` or `authorization`). Additional tags are noted.
+
+==== Security caches
+The following authentication & authorization cache metrics are exported.
+They are all tagged by `cache` (either `authentication` or `authorization`).
+Additional tags are noted.
+
 * `cache.size`
 * `cache.puts`
 * `cache.gets` tagged by `result` - either `hit` or `miss`
 * `cache.evictions`
 * `cache.eviction.weight`
 
-+
 Disabled by default.
+
+==== Executor Services
+
+Metrics for executor services cover both the major instances of https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/concurrent/ExecutorService.html[`java.util.concurrent.ExecutorService`] used by the broker to manage threads as well as https://netty.io/4.1/api/io/netty/util/concurrent/EventExecutor.html[`EventExecutors`] associated with instances of Netty's https://netty.io/4.1/api/io/netty/channel/EventLoopGroup.html[`EventLoopGroup`].
+
+Executor service metrics are disabled by default.
+
+===== Java Executor Services
+
+All metrics are tagged with the name of the broker and with the executor service name which corresponds to the role it plays within the broker (e.g. general, io, paging, scheduled).
+
+* `executor`
+* `executor.completed`
+* `executor.active`
+* `executor.idle`
+* `executor.queued`
+* `executor.queue.remaining`
+* `executor.pool.core`
+* `executor.pool.size`
+* `executor.pool.max`
+
+Any `ExecutorService` instance used to schedule tasks also has these metrics:
+
+* `executor.scheduled.repetitively`
+* `executor.scheduled.once`
+
+====== Netty Event Executors
+
+All metrics are tagged with the name of the broker and with the name of the underlying Netty `EventExecutor`.
+
+* `netty.eventexecutor.tasks.pending`
 
 == Configuration
 
@@ -176,6 +216,7 @@ Here's a configuration with all optional metrics:
    <uptime>true</uptime> <!-- defaults to false -->
    <logging>true</logging> <!-- defaults to false -->
    <security-caches>true</security-caches> <!-- defaults to false -->
+   <executor-services>true</executor-services> <!-- defaults to false -->
    <plugin class-name="org.apache.activemq.artemis.core.server.metrics.plugins.LoggingMetricsPlugin"/>
 </metrics>
 ----

--- a/docs/user-manual/thread-pooling.adoc
+++ b/docs/user-manual/thread-pooling.adoc
@@ -5,62 +5,111 @@
 
 This chapter describes how Apache ActiveMQ Artemis uses and pools threads and how you can manage them.
 
-First we'll discuss how threads are managed and used on the server side, then we'll look at the client side.
+First we'll discuss how threads are managed and used on the server side then we'll look at the client side.
 
 == Server-Side Thread Management
 
-Each Apache ActiveMQ Artemis Server maintains a single thread pool for general use, and a scheduled thread pool for scheduled use.
-A Java scheduled thread pool cannot be configured to use a standard thread pool, otherwise we could use a single thread pool for both scheduled and non scheduled activity.
+Thread pools exist for each of the following:
 
-Apache ActiveMQ Artemis will, by default, cap its thread pool at three times the number of cores (or hyper-threads) as reported by `             Runtime.getRuntime().availableProcessors()`` for processing incoming packets.
-To override this value, you can set the number of threads by specifying the parameter ``nioRemotingThreads` in the transport configuration.
-See the xref:configuring-transports.adoc#configuring-the-transport[configuring transports] for more information on this.
+* scheduled tasks
+* general use
+* asynchronous IO
+* paging
+* remoting (managed by Netty on a per-acceptor basis)
 
-There are also a small number of other places where threads are used directly, we'll discuss each in turn.
+[IMPORTANT]
+.Broker Identification in Thread Names
+====
+Many thread names contain broker identification.
+This is done to assist in cases where multiple brokers are running in the same JVM (e.g. in the test-suite).
+The identification which appears in the thread name is determined by the following in order of precedence:
 
-=== Server Scheduled Thread Pool
+* `identity` set in the internal `ConfigurationImpl` object (done by tests)
+* `name` set in `broker.xml`
+* the hexadecimal representation of the `ActiveMQServerImpl` Java Object's identity acquired via https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/lang/System.html#identityHashCode(java.lang.Object)[`System.identityHashCode`]
+====
 
-The server scheduled thread pool is used for most activities on the server side that require running periodically or with delays.
-It maps internally to a `java.util.concurrent.ScheduledThreadPoolExecutor` instance.
+=== Scheduled Thread Pool
 
-The maximum number of thread used by this pool is configure in `broker.xml` with the `scheduled-thread-pool-max-size` parameter.
-The default value is `5` threads.
-A small number of threads is usually sufficient for this pool.
+The scheduled thread pool is used for most activities on the server side that require running periodically or with delays.
+This includes tasks like scanning:
 
-=== General Purpose Server Thread Pool
+* queues for expired messages or scheduled deliveries
+* configuration files for changes
+* unused addresses & queues for deletion
+
+The maximum number of thread used by this pool is configure in `broker.xml` with the `scheduled-thread-pool-max-size` parameter, e.g.:
+
+[,xml]
+----
+<scheduled-thread-pool-max-size>10</scheduled-thread-pool-max-size>
+----
+
+The default `scheduled-thread-pool-max-size` is `5` . A value of `0` is not allowed.
+
+The name for threads from this pool will contain `activemq-scheduled`.
+
+=== General Purpose Thread Pool
 
 This general purpose thread pool is used for most asynchronous actions on the server side.
-It maps internally to a `java.util.concurrent.ThreadPoolExecutor` instance.
+The maximum number of threads used by this pool is configure in `broker.xml` with the `thread-pool-max-size` parameter, e.g.:
 
-The maximum number of thread used by this pool is configure in `broker.xml` with the `thread-pool-max-size` parameter.
+[,xml]
+----
+<thread-pool-max-size>60</thread-pool-max-size>
+----
 
-If a value of `-1` is used this signifies that the thread pool has no upper bound and new threads will be created on demand if there are not enough threads available to satisfy a request.
-If activity later subsides then threads are timed-out and closed.
+The default `thread-pool-max-size` is `30`.
+A value of `-1` signifies that the thread pool has _no upper bound_ and new threads will be created on demand if there are not enough threads already available to satisfy demand.
+A value of `0` is not allowed.
 
-If a value of `n` where ``n``is a positive integer greater than zero is used this signifies that the thread pool is bounded.
-If more requests come in and there are no free threads in the pool and the pool is full then requests will block until a thread becomes available.
-It is recommended that a bounded thread pool is used with caution since it can lead to dead-lock situations if the upper bound is chosen to be too low.
+Any threads in this pool which are idle for `60` seconds will be terminated.
 
-The default value for `thread-pool-max-size` is `30`.
-
-See the https://docs.oracle.com/javase/8/docs/api/java/util/concurrent/ThreadPoolExecutor.html[J2SE javadoc] for more information on unbounded (cached), and bounded (fixed) thread pools.
-
-=== Expiry Reaper Thread
-
-A single thread is also used on the server side to scan for expired messages in queues.
-We cannot use either of the thread pools for this since this thread needs to run at its own configurable priority.
-
-For more information on configuring the reaper, please see xref:message-expiry.adoc#message-expiry[message expiry].
+The name for threads from this pool will contain `activemq-<brokerName>`.
 
 === Asynchronous IO
 
-Asynchronous IO has a thread pool for receiving and dispatching events out of the native layer.
-You will find it on a thread dump with the prefix ActiveMQ-AIO-poller-pool.
-Apache ActiveMQ Artemis uses one thread per opened file on the journal (there is usually one).
+Threads from this pool are used for journal-related disk I/O, JDBC, & replication.
 
-There is also a single thread used to invoke writes on libaio.
-We do that to avoid context switching on libaio that would cause performance issues.
-You will find this thread on a thread dump with the prefix ActiveMQ-AIO-writer-pool.
+The name for threads from this pool will contain `activemq-io-<brokerName>`.
+
+=== Paging
+
+Threads from this pool are used to write to and read from paging (disk or JDBC).
+
+The name for threads from this pool will contain `activemq-paging-<brokerName>`.
+
+=== Netty Acceptors
+
+Apache ActiveMQ Artemis will, by default, cap Netty threads on a per-acceptor basis at three times the number of cores (or hyper-threads) as reported by `Runtime.getRuntime().availableProcessors()` for processing network traffic.
+To override this value, you can set the number of threads by specifying the parameter `remotingThreads` in the transport configuration.
+See the xref:configuring-transports.adoc#configuring-the-transport[configuring transports] for more information on this.
+
+Threads names will include the name of their corresponding acceptor with the prefix `activemq-remoting-`.
+For example, for the acceptor named `amqp` the corresponding thread names will contain `activemq-remoting-amqp-<brokerName>`.
+
+=== Other Server-Side Threads
+
+A thread dump from the server's JVM will have other threads as well.
+Here's other names you might find in a thread dump and the function they perform.
+
+`activemq-web`::
+thread pool managed by Jetty (i.e. the xref:web-server.adoc[embedded web server]) to handle HTTP connections (e.g. from the web console or other Jolokia clients)
+`activemq-failure-check-thread`::
+checks TTL on incoming connections
+`activemq-buffer-timeout`::
+flushes disk IO buffers upon timeout
+`activemq-libaio-poller`::
+polls AIO for callbacks
+`activemq-critical-analyzer`::
+monitors for timeouts of various critical server operations
+`activemq-shutdown-timer`::
+monitors configuration directory for status file to stop the server
+`activemq-remoting-service`::
+in-vm connectivity and invoking failure listeners for Netty
+`Log4j2-TF-\*-Scheduled-*`::
+executes Log4j2 tasks related to `CronTriggeringPolicy` used by default `log4j2.properties`
+
 
 == Client-Side Thread Management
 

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -13,6 +13,59 @@ NOTE: If the upgrade spans multiple versions then the steps from *each* version 
 
 NOTE: Follow the general upgrade procedure outlined in the xref:upgrading.adoc#upgrading-the-broker[Upgrading the Broker]  chapter in addition to any version-specific upgrade instructions outlined here.
 
+== 2.43.0
+
+https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=XXX[Full release notes]
+
+=== Highlights
+
+* Broker observability has improved with the new ability to export xref:metrics.adoc#executor-services[metrics for executor services] (aka thread pools).
+
+=== Upgrading from 2.41.0
+
+* As part of the work for https://issues.apache.org/jira/browse/ARTEMIS-5557[ARTEMIS-5557] to report executor service metrics the names of many ActiveMQ-related threads were changed to be more clear and consistent.
+This will be visible, for example, when inspecting thread dumps or if you happen to include the thread name in your logging output.
+Here's examples of old names vs. the new ones.
++
+|===
+|Old Thread Name |New Thread Name
+
+|Thread-0 (ActiveMQ-scheduled-threads)
+|Thread-0 (activemq-scheduled-0.0.0.0)
+
+|Thread-0 (ActiveMQ-server-ActiveMQServerImpl::name=0.0.0.0)
+|Thread-0 (activemq-0.0.0.0)
+
+|Thread-0 (ActiveMQ-IO-server-ActiveMQServerImpl::name=0.0.0.0)
+|Thread-0 (activemq-io-0.0.0.0)
+
+|Thread-0 (ActiveMQ-PageExecutor-server-org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl$2@7841111)
+|Thread-0 (activemq-paging-0.0.0.0)
+
+|Thread-0 (activemq-netty-threads)
+|Thread-0 (activemq-remoting-amqp-0.0.0.0)
+
+|ActiveMQ Artemis Server Shutdown Timer
+|activemq-shutdown-timer
+
+|Critical-Analyzer-0 (CriticalAnalyzer)
+|Thread-0 (activemq-critical-analyzer)
+
+|Network-Checker-0 (NetworkChecker)
+|Thread-0 (activemq-network-checker)
+
+|Apache ActiveMQ Artemis libaio poller
+|activemq-libaio-poller
+
+|qtp748316439-74
+|Thread-0 (activemq-web)
+
+|Scheduler-624545052-1
+|activemq-web-scheduled-1
+|===
++
+See the xref:thread-pooling.adoc[Thread Pooling] documentation for more details.
+
 == 2.42.0
 
 https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&version=12355900[Full release notes]

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/ServerLargeMessageTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/largemessage/ServerLargeMessageTest.java
@@ -377,7 +377,7 @@ public class ServerLargeMessageTest extends ActiveMQTestBase {
       private SequentialFile originalFile;
 
       MockSequentialFile(SequentialFile originalFile) throws Exception {
-         super(originalFile.getJavaFile().getParentFile(), originalFile.getFileName(), new FakeSequentialFileFactory(), null);
+         super(originalFile.getJavaFile().getParentFile(), originalFile.getFileName(), new FakeSequentialFileFactory());
          this.originalFile = originalFile;
          this.originalFile.close();
       }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/ExecutorServiceMetricsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/plugin/ExecutorServiceMetricsTest.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.plugin;
+
+import java.util.Arrays;
+import java.util.Set;
+
+import io.micrometer.core.instrument.Meter;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+import org.apache.activemq.artemis.core.config.MetricsConfiguration;
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.metrics.BrokerMetricNames;
+import org.apache.activemq.artemis.core.server.metrics.plugins.SimpleMetricsPlugin;
+import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
+import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class ExecutorServiceMetricsTest extends ActiveMQTestBase {
+
+   @Test
+   public void testExecutorServiceMetricsPositive() throws Exception {
+      internalTestMetrics(true);
+   }
+
+   @Test
+   public void testExecutorServiceMetricsNegative() throws Exception {
+      internalTestMetrics(false);
+   }
+
+   private void internalTestMetrics(boolean enabled) throws Exception {
+      ActiveMQServer server = createServer(false, createDefaultNettyConfig().addAcceptorConfiguration("foo", "tcp://127.0.0.1:61617").setMetricsConfiguration(new MetricsConfiguration().setPlugin(new SimpleMetricsPlugin().init(null)).setExecutorServices(enabled)));
+      server.start();
+      Set<Meter.Id> metrics = MetricsPluginTest.getMetrics(server).keySet();
+      for (String nameTagValue : Arrays.asList(BrokerMetricNames.GENERAL_EXECUTOR_SERVICE, BrokerMetricNames.IO_EXECUTOR_SERVICE, BrokerMetricNames.PAGE_EXECUTOR_SERVICE, BrokerMetricNames.SCHEDULED_EXECUTOR_SERVICE)) {
+         Tags defaultTags = Tags.of(Tag.of("broker", server.getConfiguration().getName()), Tag.of("name", nameTagValue));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.completed", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.active", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.idle", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.queued", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.queue.remaining", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.pool.core", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.pool.size", defaultTags, null, null, null)));
+         assertEquals(enabled, metrics.contains(new Meter.Id("executor.pool.max", defaultTags, null, null, null)));
+         if (nameTagValue.equals(BrokerMetricNames.SCHEDULED_EXECUTOR_SERVICE)) {
+            assertEquals(enabled, metrics.contains(new Meter.Id("executor.scheduled.repetitively", defaultTags, null, null, null)));
+            assertEquals(enabled, metrics.contains(new Meter.Id("executor.scheduled.once", defaultTags, null, null, null)));
+         }
+      }
+      boolean nettyAcceptorExists = false;
+      for (Acceptor acceptor : server.getRemotingService().getAcceptors().values()) {
+         if (acceptor instanceof NettyAcceptor nettyAcceptor) {
+            nettyAcceptorExists = true;
+            for (int i = 0; i < nettyAcceptor.getRemotingThreads(); i++) {
+               Tags defaultTags = Tags.of(Tag.of("broker", "localhost"), Tag.of("name", "Thread-" + i + " (activemq-remoting-" + nettyAcceptor.getName() + "-" + server.getConfiguration().getName() + ")"));
+               assertEquals(enabled, metrics.contains(new Meter.Id("netty.eventexecutor.tasks.pending", defaultTags, null, null, null)));
+            }
+            acceptor.stop();
+            metrics = MetricsPluginTest.getMetrics(server).keySet();
+            for (int i = 0; i < nettyAcceptor.getRemotingThreads(); i++) {
+               Tags defaultTags = Tags.of(Tag.of("broker", "localhost"), Tag.of("name", "Thread-" + i + " (activemq-remoting-" + nettyAcceptor.getName() + "-" + server.getConfiguration().getName() + ")"));
+               assertFalse(metrics.contains(new Meter.Id("netty.eventexecutor.tasks.pending", defaultTags, null, null, null)));
+            }
+         }
+      }
+      assertTrue(nettyAcceptorExists);
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/SharedNothingReplicationFlowControlTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/replication/SharedNothingReplicationFlowControlTest.java
@@ -16,21 +16,17 @@
  */
 package org.apache.activemq.artemis.tests.integration.replication;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.StringWriter;
+import java.lang.invoke.MethodHandles;
 import java.lang.management.ManagementFactory;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -76,12 +72,12 @@ import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.core.server.JournalType;
 import org.apache.activemq.artemis.core.server.impl.ActiveMQServerImpl;
-import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
 import org.apache.activemq.artemis.spi.core.security.ActiveMQJAASSecurityManager;
 import org.apache.activemq.artemis.spi.core.security.jaas.InVMLoginModule;
 import org.apache.activemq.artemis.tests.extensions.TargetTempDirFactory;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.ExecutorFactory;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -89,7 +85,10 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import java.lang.invoke.MethodHandles;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class SharedNothingReplicationFlowControlTest extends ActiveMQTestBase {
 
@@ -324,7 +323,7 @@ public class SharedNothingReplicationFlowControlTest extends ActiveMQTestBase {
 
       @Override
       public SequentialFile createSequentialFile(String fileName) {
-         return new TestableSequentialFile(this, journalDir, fileName, maxIO, writeExecutor);
+         return new TestableSequentialFile(this, journalDir, fileName, maxIO);
       }
 
       private static File newFolder(File root, String... subDirs) throws IOException {
@@ -360,9 +359,8 @@ public class SharedNothingReplicationFlowControlTest extends ActiveMQTestBase {
       public TestableSequentialFile(SequentialFileFactory factory,
                                     File directory,
                                     String file,
-                                    int maxIO,
-                                    Executor writerExecutor) {
-         super(factory, directory, file, maxIO, writerExecutor);
+                                    int maxIO) {
+         super(factory, directory, file, maxIO);
       }
 
       @Override

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/nettynative/NettyNativeTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/nettynative/NettyNativeTest.java
@@ -37,6 +37,7 @@ import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
 import java.io.File;
+import java.util.Arrays;
 
 public class NettyNativeTest extends SmokeTestBase {
 
@@ -92,8 +93,10 @@ public class NettyNativeTest extends SmokeTestBase {
       }
 
       File artemisLog = new File("target/" + SERVER_NAME + "/log/artemis.log");
-      assertTrue(findLogRecord(artemisLog,  "Acceptor using native"));
-      assertFalse(findLogRecord(artemisLog, "Acceptor using nio"));
+      for (String protocol : Arrays.asList("artemis", "amqp", "stomp", "hornetq", "mqtt")) {
+         assertTrue(findLogRecord(artemisLog, "Acceptor " + protocol + " using native"));
+         assertFalse(findLogRecord(artemisLog, "Acceptor " + protocol + " using nio"));
+      }
    }
 
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/journal/impl/TimedBufferTest.java
@@ -227,7 +227,7 @@ public class TimedBufferTest extends ActiveMQTestBase {
       NIOSequentialFileFactory factory = new NIOSequentialFileFactory(getTestDirfile(), 1) {
          @Override
          public SequentialFile createSequentialFile(final String fileName) {
-            return new NIOSequentialFile(this, journalDir, fileName, maxIO, writeExecutor) {
+            return new NIOSequentialFile(this, journalDir, fileName, maxIO) {
                @Override
                protected void syncChannel(FileChannel channel) throws IOException {
                   try {

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorFactoryTest.java
@@ -68,7 +68,7 @@ public class NettyAcceptorFactoryTest extends ActiveMQTestBase {
 
       };
 
-      Acceptor acceptor = factory.createAcceptor("netty", null, params, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize(), ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), new HashMap<>());
+      Acceptor acceptor = factory.createAcceptor("netty", null, params, handler, listener, Executors.newCachedThreadPool(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), Executors.newScheduledThreadPool(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize(), ActiveMQThreadFactory.defaultThreadFactory(getClass().getName())), new HashMap<>(), null, null);
 
       assertInstanceOf(NettyAcceptor.class, acceptor);
    }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/impl/netty/NettyAcceptorTest.java
@@ -96,7 +96,7 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       };
       pool2 = Executors.newScheduledThreadPool(ActiveMQDefaultConfiguration.getDefaultScheduledThreadPoolMaxSize(), ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
       pool3 = Executors.newSingleThreadExecutor(ActiveMQThreadFactory.defaultThreadFactory(getClass().getName()));
-      NettyAcceptor acceptor = new NettyAcceptor("netty", null, params, handler, listener, pool2, pool3, new HashMap<>());
+      NettyAcceptor acceptor = new NettyAcceptor("netty", null, params, handler, listener, pool2, pool3, new HashMap<>(), null, null);
 
       addActiveMQComponent(acceptor);
       acceptor.start();
@@ -149,7 +149,7 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, "true");
 
       try {
-         new NettyAcceptor("netty", null, params, null, null, null, null, Map.of());
+         new NettyAcceptor("netty", null, params, null, null, null, null, Map.of(), null, null);
          fail("This should have failed with an IllegalArgumentException");
       } catch (IllegalArgumentException e) {
          // expected
@@ -161,7 +161,7 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, "true");
       params.put(TransportConstants.KEYSTORE_PROVIDER_PROP_NAME, RandomUtil.randomUUIDString());
-      new NettyAcceptor("netty", null, params, null, null, null, null, Map.of());
+      new NettyAcceptor("netty", null, params, null, null, null, null, Map.of(), null, null);
    }
 
    @Test
@@ -169,6 +169,6 @@ public class NettyAcceptorTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.SSL_ENABLED_PROP_NAME, "true");
       params.put(TransportConstants.SSL_CONTEXT_PROP_NAME, RandomUtil.randomUUIDString());
-      new NettyAcceptor("netty", null, params, null, null, null, null, Map.of());
+      new NettyAcceptor("netty", null, params, null, null, null, null, Map.of(), null, null);
    }
 }

--- a/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
+++ b/tests/unit-tests/src/test/java/org/apache/activemq/artemis/tests/unit/core/remoting/server/impl/fake/FakeAcceptorFactory.java
@@ -25,6 +25,7 @@ import org.apache.activemq.artemis.api.core.BaseInterceptor;
 import org.apache.activemq.artemis.core.security.ActiveMQPrincipal;
 import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.core.server.management.NotificationService;
+import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.spi.core.protocol.ProtocolManager;
 import org.apache.activemq.artemis.spi.core.remoting.Acceptor;
 import org.apache.activemq.artemis.spi.core.remoting.AcceptorFactory;
@@ -43,7 +44,9 @@ public class FakeAcceptorFactory implements AcceptorFactory {
                                   ServerConnectionLifeCycleListener listener,
                                   Executor threadPool,
                                   ScheduledExecutorService scheduledThreadPool,
-                                  Map<String, ProtocolManager> protocolMap) {
+                                  Map<String, ProtocolManager> protocolMap,
+                                  String threadFactoryGroupName,
+                                  MetricsManager metricsManager) {
       return new FakeAcceptor();
    }
 


### PR DESCRIPTION
Aside from supporting Micrometer ExecutorService metrics this commit improves the consistency and clarity of both the documentation and code related to thread pooling. Changes include:

 - Also support Netty EventExecutor metrics
 - Remove redundant "threads" from thread group names
 - Use kebab case in ActiveMQThreadFactory for consistent naming
 - Use "activemq-" prefix in ActiveMQThreadFactory for consistent naming
 - Use consistent broker identification in thread group names
 - Remove unused executor from SequentialFile classes
 - Big refactor of thread pooling documentation
 - Update release notes with relevant naming changes
 - Deduplicate some repeated code
 - Pass custom ActiveMQThreadFactory and Scheduler to Jetty for consistent thread naming
 - Name Netty threads according to corresponding acceptor