### PR TITLE
ARTEMIS-5576: Fix OpenWire backslash escaping in dest name conversion

### DIFF
--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/OpenWireConnection.java
@@ -918,7 +918,12 @@ public class OpenWireConnection extends AbstractRemotingConnection implements Se
          return;
       }
 
-      SimpleString qName = SimpleString.of(dest.getPhysicalName());
+      // Use normalized core name for broker lookup / auto-create, but keep the
+      // original ActiveMQDestination for advisories / state (back-compat).
+      final String coreLookupName = dest.isQueue()
+         ? org.apache.activemq.artemis.core.protocol.openwire.util.OpenWireUtil.toCoreProduceAddress(dest)
+         : dest.getPhysicalName();
+      SimpleString qName = SimpleString.of(coreLookupName);
 
       AutoCreateResult autoCreateResult = internalSession.checkAutoCreate(QueueConfiguration.of(qName)
                                                                              .setRoutingType(dest.isQueue() ? RoutingType.ANYCAST : RoutingType.MULTICAST)

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumer.java
@@ -42,6 +42,7 @@ import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireConnection;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireConstants;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireMessageConverter;
+import org.apache.activemq.artemis.core.protocol.openwire.util.OpenWireUtil;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.QueueQueryResult;
 import org.apache.activemq.artemis.core.server.ServerConsumer;
@@ -169,8 +170,7 @@ public class AMQConsumer {
          }
       }
 
-      SimpleString destinationName = SimpleString.of(session.convertWildcard(openwireDestination));
-
+      SimpleString destinationName = SimpleString.of(OpenWireUtil.toCoreConsumePattern(openwireDestination, session.getCoreServer()));
       if (openwireDestination.isTopic()) {
          SimpleString queueName = createTopicSubscription(info.isDurable(), info.getClientId(), destinationName.toString(), info.getSubscriptionName(), selector, destinationName);
 

--- a/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/util/OpenWireUtil.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/openwire/util/OpenWireUtil.java
@@ -16,9 +16,15 @@
  */
 package org.apache.activemq.artemis.core.protocol.openwire.util;
 
+import java.util.function.Function;
+
+import org.apache.activemq.advisory.AdvisorySupport;
 import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.transaction.impl.XidImpl;
+import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQQueue;
 import org.apache.activemq.command.ActiveMQTopic;
@@ -28,13 +34,21 @@ import org.apache.activemq.command.XATransactionId;
 
 public class OpenWireUtil {
 
-   public static final WildcardConfiguration OPENWIRE_WILDCARD = new WildcardConfiguration().setDelimiter('.').setAnyWords('>').setSingleWord('*');
+   private static final String SCHEME_SEPARATOR = "://";
+   private static final String QUEUE_SCHEME = "queue";
+   private static final String TOPIC_SCHEME = "topic";
+   private static final String CONSUMER_PREFIX = "Consumer.";
+   private static final String VIRTUAL_TOPIC_MARKER = ".VirtualTopic.";
+
+   public static final WildcardConfiguration OPENWIRE_WILDCARD = new WildcardConfiguration().setDelimiter('.')
+                                                                                            .setAnyWords('>')
+                                                                                            .setSingleWord('*');
 
    public static final String SELECTOR_AWARE_OPTION = "selectorAware";
 
    public static String extractFilterStringOrNull(final ConsumerInfo info, final ActiveMQDestination openWireDest) {
       if (info.getSelector() != null) {
-         if (openWireDest.getOptions()  != null) {
+         if (openWireDest.getOptions() != null) {
             if (Boolean.valueOf(openWireDest.getOptions().get(SELECTOR_AWARE_OPTION))) {
                return info.getSelector();
             }
@@ -69,5 +83,119 @@ public class OpenWireUtil {
 
    public static XidImpl toXID(XATransactionId xaXid) {
       return new XidImpl(xaXid.getBranchQualifier(), xaXid.getFormatId(), xaXid.getGlobalTransactionId());
+   }
+
+   /**
+    * Converts an ActiveMQ destination to a core produce address.
+    * <p/>
+    * This method handles different types of destinations:
+    * - Returns the physical name for temporary or advisory destinations
+    * - For FQQN addresses, escapes backslashes in the address part only
+    * - For other addresses, returns the stripped and escaped address
+    *
+    * @param destination the ActiveMQ destination to convert
+    * @return the core produce address, or null if the destination is null
+    */
+   public static String toCoreProduceAddress(ActiveMQDestination destination) {
+      if (destination == null) {
+         return null;
+      }
+
+      if (destination.isTemporary() || AdvisorySupport.isAdvisoryTopic(destination)) {
+         return destination.getPhysicalName();
+      }
+
+      final String strippedAddress = stripAddressScheme(destination.getPhysicalName(), destination);
+
+      if (isFqqn(strippedAddress)) {
+         return handleFqqn(strippedAddress, OpenWireUtil::escapeBackslashes);
+      }
+
+      return escapeBackslashes(strippedAddress);
+   }
+
+   /**
+    * Converts an ActiveMQ destination to a core consume pattern.
+    * <p/>
+    * This method handles different types of destinations:
+    * - Returns the physical name for temporary or advisory destinations
+    * - For FQQN addresses, converts wildcards in the address part only
+    * - For virtual topic consumer queues, returns the stripped address
+    * - For other addresses, returns the wildcard-converted pattern
+    *
+    * @param destination the ActiveMQ destination to convert
+    * @param server      the ActiveMQ server for wildcard configuration
+    * @return the core consume pattern, or null if the destination is null
+    */
+   public static String toCoreConsumePattern(ActiveMQDestination destination, ActiveMQServer server) {
+      if (destination == null) {
+         return null;
+      }
+
+      if (destination.isTemporary() || AdvisorySupport.isAdvisoryTopic(destination)) {
+         return destination.getPhysicalName();
+      }
+
+      String strippedAddress = stripAddressScheme(destination.getPhysicalName(), destination);
+
+      if (isFqqn(strippedAddress)) {
+         return handleFqqn(strippedAddress, addr -> convertWildcard(addr, server));
+      }
+
+      if (destination.isQueue() && isVirtualTopicConsumerName(strippedAddress)) {
+         return strippedAddress;
+      }
+
+      return convertWildcard(strippedAddress, server);
+   }
+
+   private static String stripAddressScheme(String address, ActiveMQDestination destination) {
+      if (address == null || !address.contains(SCHEME_SEPARATOR)) {
+         return address;
+      }
+
+      int schemeIndex = address.indexOf(SCHEME_SEPARATOR);
+      String scheme = address.substring(0, schemeIndex).toLowerCase();
+
+      if (destination == null || (destination.isQueue() && QUEUE_SCHEME.equals(scheme)) || (destination.isTopic() && TOPIC_SCHEME.equals(scheme))) {
+         return address.substring(schemeIndex + SCHEME_SEPARATOR.length());
+      }
+
+      return address;
+   }
+
+   private static boolean isVirtualTopicConsumerName(String address) {
+      if (address == null || isFqqn(address)) {
+         return false;
+      }
+
+      String normalizedAddr = stripAddressScheme(address, null);
+      return normalizedAddr.startsWith(CONSUMER_PREFIX) && normalizedAddr.contains(VIRTUAL_TOPIC_MARKER);
+   }
+
+   private static String handleFqqn(String address, Function<String, String> addressConverter) {
+      SimpleString fullAddress = SimpleString.of(address);
+      // Extract address and queue parts from the FQQN
+      SimpleString addr = CompositeAddress.extractAddressName(fullAddress);
+      SimpleString queue = CompositeAddress.extractQueueName(fullAddress);
+      // Apply the converter function to the address part
+      String convertedAddr = addressConverter.apply(addr.toString());
+      // Reconstruct the FQQN with the converted address
+      return CompositeAddress.toFullyQualified(SimpleString.of(convertedAddr), queue).toString();
+   }
+
+   private static String escapeBackslashes(String input) {
+      return input == null ? null : input.replace("\\", "\\\\");
+   }
+
+   private static String convertWildcard(String address, ActiveMQServer server) {
+      return OPENWIRE_WILDCARD.convert(address, server.getConfiguration().getWildcardConfiguration());
+   }
+
+   private static boolean isFqqn(String address) {
+      if (address != null) {
+         return CompositeAddress.isFullyQualified(SimpleString.of(address));
+      }
+      return false;
    }
 }

--- a/artemis-protocols/artemis-openwire-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumerTest.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/openwire/amq/AMQConsumerTest.java
@@ -16,15 +16,10 @@
  */
 package org.apache.activemq.artemis.core.protocol.openwire.amq;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-
-import java.util.concurrent.ScheduledExecutorService;
-
 import org.apache.activemq.artemis.api.core.ICoreMessage;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireConnection;
 import org.apache.activemq.artemis.core.protocol.openwire.OpenWireMessageConverter;
@@ -39,7 +34,6 @@ import org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl;
 import org.apache.activemq.artemis.reader.MessageUtil;
 import org.apache.activemq.artemis.utils.UUID;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
-import org.apache.activemq.command.ActiveMQDestination;
 import org.apache.activemq.command.ActiveMQMessage;
 import org.apache.activemq.command.ActiveMQTopic;
 import org.apache.activemq.command.ConsumerInfo;
@@ -48,6 +42,13 @@ import org.apache.activemq.wireformat.WireFormat;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
+
+import java.util.concurrent.ScheduledExecutorService;
+
+import static org.apache.activemq.artemis.core.config.WildcardConfiguration.DEFAULT_WILDCARD_CONFIGURATION;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AMQConsumerTest {
    final OpenWireFormatFactory formatFactory = new OpenWireFormatFactory();
@@ -87,7 +88,10 @@ public class AMQConsumerTest {
       UUID nodeId = UUIDGenerator.getInstance().generateUUID();
       ActiveMQServer coreServer = Mockito.mock(ActiveMQServer.class);
       NodeManager nodeManager = Mockito.mock(NodeManager.class);
+      Configuration configuration = Mockito.mock(Configuration.class);
+      Mockito.when(configuration.getWildcardConfiguration()).thenReturn(DEFAULT_WILDCARD_CONFIGURATION);
       Mockito.when(coreServer.getNodeManager()).thenReturn(nodeManager);
+      Mockito.when(coreServer.getConfiguration()).thenReturn(configuration);
       Mockito.when(nodeManager.getUUID()).thenReturn(nodeId);
 
       ServerSession coreSession = Mockito.mock(ServerSession.class);
@@ -100,7 +104,6 @@ public class AMQConsumerTest {
       Mockito.when(session.getConnection()).thenReturn(Mockito.mock(OpenWireConnection.class));
       Mockito.when(session.getCoreServer()).thenReturn(coreServer);
       Mockito.when(session.getCoreSession()).thenReturn(coreSession);
-      Mockito.when(session.convertWildcard(ArgumentMatchers.any(ActiveMQDestination.class))).thenReturn("");
 
       ConsumerInfo info = new ConsumerInfo();
       info.setPrefetchSize(prefetchSize);

--- a/artemis-protocols/artemis-openwire-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/openwire/util/OpenWireUtilTest.java
+++ b/artemis-protocols/artemis-openwire-protocol/src/test/java/org/apache/activemq/artemis/core/protocol/openwire/util/OpenWireUtilTest.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.core.protocol.openwire.util;
+
+import org.apache.activemq.advisory.AdvisorySupport;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.WildcardConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.apache.activemq.command.ActiveMQTempQueue;
+import org.apache.activemq.command.ActiveMQTopic;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class OpenWireUtilTest {
+
+   // toCoreProduceAddress tests
+   @Test
+   void toCoreProduceAddress_shouldReturnNullForNullDestination() {
+      assertNull(OpenWireUtil.toCoreProduceAddress(null));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldReturnPhysicalNameForTemporaryDestination() {
+      ActiveMQDestination temporaryDestination = new ActiveMQTempQueue("temp-queue://ID:123");
+      assertEquals("temp-queue://ID:123", OpenWireUtil.toCoreProduceAddress(temporaryDestination));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldReturnPhysicalNameForAdvisoryTopic() {
+      ActiveMQDestination advisoryTopic = AdvisorySupport.getConnectionAdvisoryTopic();
+      assertEquals(advisoryTopic.getPhysicalName(), OpenWireUtil.toCoreProduceAddress(advisoryTopic));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldPreserveFQQNAddress() {
+      ActiveMQDestination fqqnDestination = new ActiveMQQueue("address::queue");
+      assertEquals("address::queue", OpenWireUtil.toCoreProduceAddress(fqqnDestination));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldEscapeBackslashesInNonFQQNAddress() {
+      ActiveMQDestination nonFqqnDestination = new ActiveMQQueue("my\\queue\\name");
+      assertEquals("my\\\\queue\\\\name", OpenWireUtil.toCoreProduceAddress(nonFqqnDestination));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldOnlyEscapeAddressPartInFQQNWithBackslash() {
+      ActiveMQDestination d = new ActiveMQQueue("addr\\\\part::q\\\\name");
+      assertEquals("addr\\\\\\\\part::q\\\\name", OpenWireUtil.toCoreProduceAddress(d));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldNotStripMismatchedScheme() {
+      ActiveMQDestination d = new ActiveMQTopic("queue://foo\\bar");
+      assertEquals("queue://foo\\\\bar", OpenWireUtil.toCoreProduceAddress(d));
+   }
+
+   @Test
+   void toCoreProduceAddress_shouldStripMatchingScheme() {
+      ActiveMQDestination d = new ActiveMQQueue("queue://foo\\bar");
+      assertEquals("foo\\\\bar", OpenWireUtil.toCoreProduceAddress(d));
+   }
+
+   // toCoreConsumePattern tests
+   @Test
+   void toCoreConsumePattern_shouldReturnNullForNullDestination() {
+      ActiveMQServer server = mock(ActiveMQServer.class);
+      assertNull(OpenWireUtil.toCoreConsumePattern(null, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldReturnPhysicalNameForTemporaryDestination() {
+      ActiveMQServer server = mock(ActiveMQServer.class);
+      ActiveMQDestination temporaryDestination = new ActiveMQTempQueue("temp-queue://ID:123");
+      assertEquals("temp-queue://ID:123", OpenWireUtil.toCoreConsumePattern(temporaryDestination, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldReturnPhysicalNameForAdvisoryTopic() {
+      ActiveMQServer server = mock(ActiveMQServer.class);
+      ActiveMQDestination advisoryTopic = AdvisorySupport.getConnectionAdvisoryTopic();
+      assertEquals(advisoryTopic.getPhysicalName(), OpenWireUtil.toCoreConsumePattern(advisoryTopic, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldHandleFQQNWithWildcards() {
+      ActiveMQServer server = mockServerWith(new WildcardConfiguration().setDelimiter('.')
+                                                                        .setAnyWords('%')
+                                                                        .setSingleWord('*'));
+      ActiveMQDestination fqqnDestination = new ActiveMQQueue("address.*.topic::my.queue");
+      assertEquals("address.*.topic::my.queue", OpenWireUtil.toCoreConsumePattern(fqqnDestination, server));
+
+      fqqnDestination = new ActiveMQQueue("address.>.topic::my.queue");
+      assertEquals("address.%.topic::my.queue", OpenWireUtil.toCoreConsumePattern(fqqnDestination, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldPreserveVirtualTopicConsumerQueue() {
+      ActiveMQServer server = mock(ActiveMQServer.class);
+      ActiveMQDestination virtualTopicConsumerQueue = new ActiveMQQueue("Consumer.A.VirtualTopic.Test");
+      assertEquals("Consumer.A.VirtualTopic.Test", OpenWireUtil.toCoreConsumePattern(virtualTopicConsumerQueue, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldConvertNonFqqnWildcard() {
+      ActiveMQServer server = mockServerWith(new WildcardConfiguration().setDelimiter('.')
+                                                                        .setAnyWords('%')
+                                                                        .setSingleWord('*'));
+      ActiveMQDestination d = new ActiveMQQueue("a.>.b.*");
+      assertEquals("a.%.b.*", OpenWireUtil.toCoreConsumePattern(d, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldPassthroughVirtualTopicConsumerWithScheme() {
+      ActiveMQServer server = mockServerWithDefaults();
+      ActiveMQDestination d = new ActiveMQQueue("queue://Consumer.A.VirtualTopic.Orders.>");
+      assertEquals("Consumer.A.VirtualTopic.Orders.>", OpenWireUtil.toCoreConsumePattern(d, server));
+   }
+
+   @Test
+   void toCoreConsumePattern_shouldTreatPatternDestinationAsWildcard() {
+      ActiveMQServer server = mockServerWith(new WildcardConfiguration().setDelimiter('.')
+                                                                        .setAnyWords('#')
+                                                                        .setSingleWord('*'));
+      ActiveMQQueue d = new ActiveMQQueue("foo.>.bar");
+      assertEquals("foo.#.bar", OpenWireUtil.toCoreConsumePattern(d, server));
+   }
+
+   // Helper methods
+   private ActiveMQServer mockServerWith(WildcardConfiguration wc) {
+      ActiveMQServer server = mock(ActiveMQServer.class);
+      Configuration cfg = mock(Configuration.class);
+      when(server.getConfiguration()).thenReturn(cfg);
+      when(cfg.getWildcardConfiguration()).thenReturn(wc);
+      return server;
+   }
+
+   private ActiveMQServer mockServerWithDefaults() {
+      WildcardConfiguration wc = new WildcardConfiguration().setDelimiter('.').setAnyWords('>').setSingleWord('*');
+      return mockServerWith(wc);
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/EscapedAddressDeliveryTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/openwire/EscapedAddressDeliveryTest.java
@@ -1,0 +1,200 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.openwire;
+
+import javax.jms.Connection;
+import javax.jms.Destination;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+import javax.jms.TemporaryQueue;
+import javax.jms.TextMessage;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.postoffice.impl.LocalQueueBinding;
+import org.apache.activemq.artemis.tests.util.Wait;
+import org.apache.activemq.command.ActiveMQQueue;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Tests for escaped address delivery in OpenWire protocol.
+ * <p>
+ * This test suite verifies that OpenWire destinations with special characters
+ * (particularly backslashes) are properly handled during message routing and delivery.
+ * It ensures that address escaping works correctly for various destination types
+ * including regular queues, FQQN addresses, temporary queues, and literal scheme names.
+ */
+public class EscapedAddressDeliveryTest extends BasicOpenWireTest {
+
+   private static final String ESCAPED_QUEUE_LOGICAL_NAME = "foo\\foo";
+   private static final String ESCAPED_QUEUE_CORE_NAME = "foo\\\\foo";
+   private static final String BROKER_CONNECTION_URL = "tcp://localhost:61616";
+   private static final int MESSAGE_RECEIVE_TIMEOUT_MS = 3000;
+
+   @Test
+   public void shouldDeliverMessageToEscapedAddress() throws Exception {
+      final Destination escapedQueueDestination = setupEscapedQueue();
+      sendAndReceiveMessage(escapedQueueDestination, "hello");
+   }
+
+   @Test
+   public void shouldTargetCorrectEscapedCoreAddressWhenProducing() throws Exception {
+      final Destination escapedQueueDestination = setupEscapedQueue();
+
+      ActiveMQConnectionFactory connectionFactory = createTestConnectionFactory();
+      try (Connection jmsConnection = connectionFactory.createConnection();
+           Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+           MessageProducer messageProducer = jmsSession.createProducer(escapedQueueDestination)) {
+
+         jmsConnection.start();
+         messageProducer.send(jmsSession.createTextMessage("ping"));
+      }
+
+      assertTrue(hasBindingForAddress(ESCAPED_QUEUE_CORE_NAME), "Expected a binding under core address: " + ESCAPED_QUEUE_CORE_NAME);
+   }
+
+   @Test
+   public void shouldPreserveFQQNAddressWhenSendingAndReceiving() throws Exception {
+      final String fqqnAddress = "addrA";
+      final String fqqnQueueName = "qA";
+      final String fullyQualifiedQueueName = fqqnAddress + "::" + fqqnQueueName;
+
+      server.createQueue(QueueConfiguration.of(SimpleString.of(fqqnQueueName))
+                                           .setAddress(SimpleString.of(fqqnAddress))
+                                           .setRoutingType(RoutingType.ANYCAST)
+                                           .setDurable(false));
+
+      Destination fqqnDestination = new ActiveMQQueue(fullyQualifiedQueueName);
+      sendAndReceiveMessage(fqqnDestination, "fqqn-ok");
+
+      assertTrue(hasBindingForQueue(fqqnQueueName), "Expected only the pre-created FQQN queue/binding.");
+   }
+
+   @Test
+   public void shouldDeliverMessageToTemporaryQueue() throws Exception {
+      ActiveMQConnectionFactory connectionFactory = createTestConnectionFactory();
+      try (Connection jmsConnection = connectionFactory.createConnection();
+           Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+
+         jmsConnection.start();
+         TemporaryQueue temporaryQueue = jmsSession.createTemporaryQueue();
+
+         try (MessageProducer tempQueueProducer = jmsSession.createProducer(temporaryQueue);
+              MessageConsumer tempQueueConsumer = jmsSession.createConsumer(temporaryQueue)) {
+
+            tempQueueProducer.send(jmsSession.createTextMessage("temp-ok"));
+            Message receivedTempMessage = tempQueueConsumer.receive(MESSAGE_RECEIVE_TIMEOUT_MS);
+
+            assertNotNull(receivedTempMessage);
+            assertEquals("temp-ok", ((TextMessage) receivedTempMessage).getText());
+         } finally {
+            temporaryQueue.delete();
+         }
+      }
+   }
+
+   @Test
+   public void shouldReceiveAdvisoryOnTemporaryQueueRemoval() throws Exception {
+      ActiveMQConnectionFactory connectionFactory = createTestConnectionFactory();
+      try (Connection jmsConnection = connectionFactory.createConnection();
+           Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE)) {
+
+         jmsConnection.start();
+
+         TemporaryQueue temporaryQueue = jmsSession.createTemporaryQueue();
+         Destination tempQueueAdvisoryTopic = org.apache.activemq.advisory.AdvisorySupport.getDestinationAdvisoryTopic(temporaryQueue);
+
+         try (MessageConsumer advisoryMessageConsumer = jmsSession.createConsumer(tempQueueAdvisoryTopic)) {
+            temporaryQueue.delete();
+
+            Message tempQueueRemovalAdvisory = advisoryMessageConsumer.receive(MESSAGE_RECEIVE_TIMEOUT_MS);
+            assertNotNull(tempQueueRemovalAdvisory, "Expected advisory on temp queue removal");
+         }
+      }
+   }
+
+   @Test
+   public void shouldPreserveLiteralSchemeName() throws Exception {
+      final String literalSchemeName = "queue://literal";
+
+      server.createQueue(QueueConfiguration.of(literalSchemeName)
+                                           .setAddress(literalSchemeName)
+                                           .setRoutingType(RoutingType.ANYCAST)
+                                           .setDurable(false));
+
+      Destination literalSchemeDestination = new ActiveMQQueue("queue://" + literalSchemeName);
+      sendAndReceiveMessage(literalSchemeDestination, "literal-ok");
+
+      assertTrue(hasBindingForAddress(literalSchemeName), "Expected binding under literal core address: " + literalSchemeName);
+   }
+
+   private Destination setupEscapedQueue() throws Exception {
+      final Destination escapedQueueDestination = new ActiveMQQueue("queue://" + ESCAPED_QUEUE_LOGICAL_NAME);
+      server.createQueue(QueueConfiguration.of(ESCAPED_QUEUE_CORE_NAME)
+                                           .setAddress(ESCAPED_QUEUE_CORE_NAME)
+                                           .setRoutingType(RoutingType.ANYCAST)
+                                           .setDurable(false));
+      return escapedQueueDestination;
+   }
+
+   private ActiveMQConnectionFactory createTestConnectionFactory() {
+      return new ActiveMQConnectionFactory(BROKER_CONNECTION_URL);
+   }
+
+   private void sendAndReceiveMessage(Destination testDestination, String expectedMessageText) throws Exception {
+      ActiveMQConnectionFactory connectionFactory = createTestConnectionFactory();
+      try (Connection jmsConnection = connectionFactory.createConnection();
+           Session jmsSession = jmsConnection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+           MessageConsumer messageConsumer = jmsSession.createConsumer(testDestination);
+           MessageProducer messageProducer = jmsSession.createProducer(testDestination)) {
+
+         jmsConnection.start();
+         messageProducer.send(jmsSession.createTextMessage(expectedMessageText));
+
+         Message receivedMessage = messageConsumer.receive(MESSAGE_RECEIVE_TIMEOUT_MS);
+         assertNotNull(receivedMessage, "Expected a message but got null");
+         assertEquals(expectedMessageText, ((TextMessage) receivedMessage).getText());
+      }
+   }
+
+   private boolean hasBindingForAddress(String expectedCoreAddress) throws Exception {
+      PostOffice brokerPostOffice = server.getPostOffice();
+      return Wait.waitFor(() -> brokerPostOffice.getAllBindings()
+                                                .filter(binding -> binding instanceof LocalQueueBinding)
+                                                .map(Binding::getAddress)
+                                                .anyMatch(bindingAddress -> bindingAddress != null && expectedCoreAddress.equals(bindingAddress.toString())), MESSAGE_RECEIVE_TIMEOUT_MS);
+   }
+
+   private boolean hasBindingForQueue(String expectedQueueName) throws Exception {
+      PostOffice brokerPostOffice = server.getPostOffice();
+      return Wait.waitFor(() -> brokerPostOffice.getAllBindings()
+                                                .filter(binding -> binding instanceof LocalQueueBinding)
+                                                .map(Binding::getUniqueName)
+                                                .anyMatch(queueName -> expectedQueueName.equals(queueName.toString())), MESSAGE_RECEIVE_TIMEOUT_MS);
+   }
+}


### PR DESCRIPTION
Centralize and unify address translation for producers/consumers to preserve '\' in names and avoid mismatches. Keeps temp/advisory/FQQN/ VirtualTopic behavior unchanged and adds tests for all cases.

Changes include:
- Replace ad-hoc wildcard and escape handling in AMQSession,  AMQConsumer, and OpenWireConnection with central OpenWireUtil methods.
- Preserve temp/advisory destinations, FQQN structure, and VirtualTopic  consumer naming conventions.
- Strip matching queue:// or topic:// scheme prefixes only when type  matches.
- Add unit and integration tests covering escape rules, wildcard conversion, FQQN handling, and advisory/temp queue cases.
- Remove obsolete AMQSession.convertWildcard().

I think this change is 100% backward compatible and requires no client changes.