### PR TITLE
ARTEMIS-5578: Update to netty 4.1.124

### DIFF
--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -29,6 +29,9 @@
 	</feature>
 
 	<feature name="netty-core" version="${netty.version}" description="Netty libraries">
+		<!-- The wrap feature and svm dep can be removed once netty-common is fixed in 4.1.125 -->
+		<feature prerequisite="true">wrap</feature>
+		<bundle>wrap:mvn:org.graalvm.nativeimage/svm/19.3.6</bundle>
 		<bundle>mvn:io.netty/netty-common/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-resolver/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport/${netty.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <checkstyle.version>11.0.0</checkstyle.version>
       <mockito.version>5.18.0</mockito.version>
       <jctools.version>4.0.5</jctools.version>
-      <netty.version>4.1.123.Final</netty.version>
+      <netty.version>4.1.124.Final</netty.version>
       <hdrhistogram.version>2.2.2</hdrhistogram.version>
       <curator.version>5.9.0</curator.version>
       <zookeeper.version>3.9.3</zookeeper.version>


### PR DESCRIPTION
Adds svm dep to karaf feature to work around netty manifest bug and allow resolving netty-common so the build can complete (problem reported in https://github.com/netty/netty/issues/15557, fixed in https://github.com/netty/netty/pull/15558).