### PR TITLE
ARTEMIS-5625 Allow address federation to include bindings filters

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressBindingsConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressBindingsConsumer.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import java.lang.invoke.MethodHandles;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Set;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.core.io.IOCallback;
+import org.apache.activemq.artemis.core.persistence.OperationContext;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
+import org.apache.activemq.artemis.core.persistence.impl.journal.OperationContextImpl;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.PostOffice;
+import org.apache.activemq.artemis.core.server.LargeServerMessage;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationMetrics.ConsumerMetrics;
+import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.activemq.artemis.utils.collections.ConcurrentHashSet;
+import org.apache.qpid.proton.amqp.messaging.Accepted;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Receiver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Consumer implementation for Federated Addresses that receives from a remote AMQP peer and forwards those messages
+ * onto the internal bindings on a given address that matched criteria of the given {@link FederationConsumerInfo}.
+ * The consumer is subscribed to the remote address likely using a filter that matches the filter of one or more
+ * local bindings on an address which defines the local demand. Once a message is sent from the remote this consumer
+ * routes that message to each of the local consumers that triggered the federation link.
+ * <p>
+ * The goal of this federation consumer implementation is to allow consumption of a more limited set of messages
+ * from a remote address by applying filters for local address consumers and routing the resulting messages directly
+ * to them. The possible down side here is that if the filters being used aren't fine grained enough that consumers
+ * with differing filters might still have overlaps in the messages they receive which would then produce more message
+ * traffic across the federation than would be generated if using the standard conduit consumer pattern (this can also
+ * happen if filtered and non-filtered consumers are mixed on the local address).
+ */
+public final class AMQPFederationAddressBindingsConsumer extends AMQPFederationAddressConsumer {
+
+   private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
+
+   private final Set<Binding> bindings = new ConcurrentHashSet<>();
+   private final PostOffice postOffice;
+   private final StorageManager storageManager;
+
+   public AMQPFederationAddressBindingsConsumer(AMQPFederationAddressPolicyManager manager,
+                                                AMQPFederationConsumerConfiguration configuration,
+                                                AMQPSessionContext session, FederationConsumerInfo consumerInfo,
+                                                ConsumerMetrics metrics) {
+      super(manager, configuration, session, consumerInfo, metrics);
+
+      this.postOffice = manager.getFederation().getServer().getPostOffice();
+      this.storageManager = federation.getServer().getStorageManager();
+   }
+
+   @Override
+   protected AMQPFederatedAddressDeliveryHandler createDeliveryHandler(Receiver receiver) {
+      return new AMQPFederatedAddressBindingsDeliveryReceiver(session, consumerInfo, receiver);
+   }
+
+   /**
+    * Adds a collection of {@link Binding} instances that should have any received messages routed
+    * to them as they arrive from the remote.
+    *
+    * @param currentBindings
+    *    The bindings that should receive any messages sent from the remote
+    */
+   public void addBindings(Collection<Binding> currentBindings) {
+      bindings.addAll(currentBindings);
+   }
+
+   /**
+    * Adds a {@link Binding} to the set of bindings that should receive messages from the remote
+    * to the collection of tracked bindings.
+    *
+    * @param binding
+    *    The {@link Binding} to add to the tracked collection.
+    */
+   public void addBinding(Binding binding) {
+      bindings.add(binding);
+   }
+
+   /**
+    * Removes a {@link Binding} from the set of bindings that should receive messages from the remote
+    * to the collection of tracked bindings.
+    *
+    * @param binding
+    *    The {@link Binding} to remove from the tracked collection.
+    */
+   public void removeBinding(Binding binding) {
+      bindings.remove(binding);
+   }
+
+   /**
+    * Wrapper around the standard receiver context that provides federation specific entry points and customizes inbound
+    * delivery handling for this Address receiver.
+    */
+   private class AMQPFederatedAddressBindingsDeliveryReceiver extends AMQPFederatedAddressDeliveryHandler {
+
+      /**
+       * Creates the federation receiver instance.
+       *
+       * @param session
+       *    The server session context bound to the receiver instance.
+       * @param consumerInfo
+       *    The {@link FederationConsumerInfo} that defines the remote consumer link.
+       * @param receiver
+       *    The proton receiver that will be wrapped in this server context instance.
+       */
+      AMQPFederatedAddressBindingsDeliveryReceiver(AMQPSessionContext session, FederationConsumerInfo consumerInfo, Receiver receiver) {
+         super(session, consumerInfo, receiver);
+      }
+
+      @Override
+      protected void routeFederatedMessage(Message message, Delivery delivery, Receiver receiver, Transaction tx) {
+         incrementSettle();
+
+         final Collection<Binding> targets = new ArrayList<>(bindings);
+
+         // In case bindings are going away and we receive a message before the consumer is closed
+         // due to lack of demand we don't want to try and route the message.
+         if (targets.isEmpty()) {
+            acceptUnroutableMessage(message, delivery);
+            return;
+         }
+
+         delivery.setContext(message);
+
+         message.setAddress(consumerInfo.getAddress());
+         message.setConnectionID(receiver.getSession().getConnection().getRemoteContainer());
+         if (message.getMessageID() <= 0) {
+            message.setMessageID(storageManager.generateID());
+         }
+
+         final OperationContext oldContext = recoverContext();
+
+         try {
+            routingContext.clear();
+
+            logger.trace("Address federation consumer routing incoming message to {} bindings on address: {}", bindings.size(), cachedAddress);
+
+            for (Binding binding : targets) {
+               binding.route(message, routingContext);
+            }
+
+            // Process route will throw in some cases such as the address being full which
+            // triggers a disposition of Rejected being sent back to the federation sender.
+            postOffice.processRoute(message, routingContext, false);
+
+            storageManager.afterCompleteOperations(new IOCallback() {
+
+               @Override
+               public void done() {
+                  connection.runNow(() -> {
+                     delivery.disposition(Accepted.getInstance());
+                     settle(delivery);
+                     connection.flush();
+                  });
+               }
+
+               @Override
+               public void onError(int errorCode, String errorMessage) {
+                  logger.warn("Address federation bindings consumer error after IO completion{}-{}", errorCode, errorMessage);
+               }
+            });
+         } catch (Exception e) {
+            logger.warn("Address federation failed routing incoming message: {}", e.getMessage(), e);
+            deliveryFailed(delivery, receiver, e);
+            connection.flush();
+         } finally {
+            OperationContextImpl.setContext(oldContext);
+         }
+      }
+
+      private void acceptUnroutableMessage(Message message, Delivery delivery) {
+         delivery.disposition(Accepted.getInstance());
+         settle(delivery);
+         connection.flush();
+         if (message.isLargeMessage()) {
+            try {
+               ((LargeServerMessage) message).deleteFile();
+            } catch (Exception e) {
+               logger.debug("Error during delete of large message file when no bindings remain on federation consumer:", e);
+            }
+         }
+         return;
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConduitConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConduitConsumer.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.protocol.amqp.connect.federation;
+
+import org.apache.activemq.artemis.api.core.Message;
+import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationMetrics.ConsumerMetrics;
+import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
+import org.apache.qpid.proton.engine.Delivery;
+import org.apache.qpid.proton.engine.Receiver;
+
+/**
+ * Consumer implementation for Federated Addresses that receives from a remote AMQP peer and then routes the messages to
+ * the target address for dispatch to all attached bindings. The consumer serves as a conduit for message sent to the
+ * remote address passing across the federation link and then being sent to the local address to be routed to all the
+ * current bindings on that address, any messages that are not consumed by local bindings (due to filters) are discarded.
+ */
+public final class AMQPFederationAddressConduitConsumer extends AMQPFederationAddressConsumer {
+
+   public AMQPFederationAddressConduitConsumer(AMQPFederationAddressPolicyManager manager,
+                                               AMQPFederationConsumerConfiguration configuration,
+                                               AMQPSessionContext session, FederationConsumerInfo consumerInfo,
+                                               ConsumerMetrics metrics) {
+      super(manager, configuration, session, consumerInfo, metrics);
+   }
+
+   @Override
+   protected AMQPFederatedAddressDeliveryHandler createDeliveryHandler(Receiver receiver) {
+      return new AMQPFederatedAddressConduitDeliveryHandler(session, consumerInfo, receiver);
+   }
+
+   /**
+    * Wrapper around the standard receiver context that provides federation specific entry points and customizes inbound
+    * delivery handling for this Address receiver.
+    */
+   private class AMQPFederatedAddressConduitDeliveryHandler extends AMQPFederatedAddressDeliveryHandler {
+
+      /**
+       * Creates the federation receiver instance.
+       *
+       * @param session
+       *    The server session context bound to the receiver instance.
+       * @param consumerInfo
+       *    The {@link FederationConsumerInfo} that defines the remote consumer link.
+       * @param receiver
+       *    The proton receiver that will be wrapped in this server context instance.
+       */
+      AMQPFederatedAddressConduitDeliveryHandler(AMQPSessionContext session, FederationConsumerInfo consumerInfo, Receiver receiver) {
+         super(session, consumerInfo, receiver);
+      }
+
+      @Override
+      protected void routeFederatedMessage(Message message, Delivery delivery, Receiver receiver, Transaction tx) throws Exception {
+         sessionSPI.serverSend(this, tx, receiver, delivery, cachedAddress, routingContext, message);
+      }
+   }
+}

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConfiguration.java
@@ -17,15 +17,8 @@
 
 package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
-import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
-import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
-
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_ADDRESS_BINDING_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_PRIORITIES;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.LARGE_MESSAGE_THRESHOLD;
@@ -35,6 +28,14 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS_LOW;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_QUIESCE_TIMEOUT;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPConnectionContext;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
 
 /**
  * A configuration class that contains API for getting federation specific configuration either from a {@link Map} of
@@ -62,18 +63,25 @@ public final class AMQPFederationConfiguration {
    public static final boolean DEFAULT_CORE_MESSAGE_TUNNELING_ENABLED = true;
 
    /**
+    * Default value for the filtering applied to federation address consumers that controls if the filter specified by an
+    * address binding is used or if the filters are ignored and a single conduit type subscription is used for all messages
+    * sent to the remote address.
+    */
+   public static final boolean DEFAULT_IGNORE_ADDRESS_BINDING_FILTERS = true;
+
+   /**
     * Default value for the filtering applied to federation queue consumers that controls if the filter specified by a
     * consumer subscription is used or if the higher level queue filter only is applied when creating a federation queue
     * consumer.
     */
-   public static final boolean DEFAULT_IGNNORE_QUEUE_CONSUMER_FILTERS = false;
+   public static final boolean DEFAULT_IGNORE_QUEUE_CONSUMER_FILTERS = false;
 
    /**
     * Default value for the priority applied to federation queue consumers that controls if the priority specified by a
     * consumer subscription is used or if the policy priority offset value is simply applied to the default consumer
     * priority value.
     */
-   public static final boolean DEFAULT_IGNNORE_QUEUE_CONSUMER_PRIORITIES = true;
+   public static final boolean DEFAULT_IGNORE_QUEUE_CONSUMER_PRIORITIES = true;
 
    /**
     * Default timeout (milliseconds) applied to federation receivers that are being stopped due to removal of local
@@ -201,6 +209,20 @@ public final class AMQPFederationConfiguration {
    }
 
    /**
+    * {@return {@code true} if federation is configured to ignore filters on individual address bindings}
+    */
+   public boolean isIgnoreAddressBindingFilters() {
+      final Object property = properties.get(IGNORE_ADDRESS_BINDING_FILTERS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return DEFAULT_IGNORE_ADDRESS_BINDING_FILTERS;
+      }
+   }
+
+   /**
     * {@return {@code true} if federation is configured to ignore filters on individual queue consumers}
     */
    public boolean isIgnoreSubscriptionFilters() {
@@ -210,7 +232,7 @@ public final class AMQPFederationConfiguration {
       } else if (property instanceof String string) {
          return Boolean.parseBoolean(string);
       } else {
-         return DEFAULT_IGNNORE_QUEUE_CONSUMER_FILTERS;
+         return DEFAULT_IGNORE_QUEUE_CONSUMER_FILTERS;
       }
    }
 
@@ -224,7 +246,7 @@ public final class AMQPFederationConfiguration {
       } else if (property instanceof String string) {
          return Boolean.parseBoolean(string);
       } else {
-         return DEFAULT_IGNNORE_QUEUE_CONSUMER_PRIORITIES;
+         return DEFAULT_IGNORE_QUEUE_CONSUMER_PRIORITIES;
       }
    }
 
@@ -290,6 +312,7 @@ public final class AMQPFederationConfiguration {
       configMap.put(PULL_RECEIVER_BATCH_SIZE, getPullReceiverBatchSize());
       configMap.put(LARGE_MESSAGE_THRESHOLD, getLargeMessageThreshold());
       configMap.put(LINK_ATTACH_TIMEOUT, getLinkAttachTimeout());
+      configMap.put(IGNORE_ADDRESS_BINDING_FILTERS, isIgnoreAddressBindingFilters());
       configMap.put(IGNORE_QUEUE_CONSUMER_FILTERS, isIgnoreSubscriptionFilters());
       configMap.put(IGNORE_QUEUE_CONSUMER_PRIORITIES, isIgnoreSubscriptionPriorities());
       configMap.put(AmqpSupport.TUNNEL_CORE_MESSAGES, isCoreMessageTunnelingEnabled());

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -144,6 +144,18 @@ public final class AMQPFederationConstants {
    public static final String LARGE_MESSAGE_THRESHOLD = "minLargeMessageSize";
 
    /**
+    * Configuration property used to convey the local side value to use when considering if federation address consumers
+    * should filter using the filters defined on individual bindings, this can be sent to the peer so that dual federation
+    * configurations share the same configuration on both sides of the connection. This value can be used to reduce the
+    * amount of messages that are federated for an address if the local consumers use filters but must be enabled with care
+    * as it can easily lead to duplicate messages being dispatched from the remote as each unique address binding filter
+    * creates a remote consumer with that matching filter. If any filters overlap in the messages they allow to pass or
+    * there are bindings without a filter then the remote will be sending the same message to multiple federation consumers
+    * in order to provide each group of bindings with their matching messages.
+    */
+   public static final String IGNORE_ADDRESS_BINDING_FILTERS = "ignoreAddressBindingFilters";
+
+   /**
     * Configuration property used to convey the local side value to use when considering if federation queue consumers
     * should filter using the filters defined on individual queue subscriptions, this can be sent to the peer so that
     * dual federation configurations share the same configuration on both sides of the connection. This can be used to

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConsumerConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConsumerConfiguration.java
@@ -17,14 +17,8 @@
 
 package org.apache.activemq.artemis.protocol.amqp.connect.federation;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Objects;
-
-import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
-
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_ADDRESS_BINDING_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_PRIORITIES;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.LARGE_MESSAGE_THRESHOLD;
@@ -34,6 +28,13 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS_LOW;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_QUIESCE_TIMEOUT;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
 
 /**
  * Configuration options applied to a consumer created from federation policies for address or queue federation. The
@@ -184,6 +185,20 @@ public final class AMQPFederationConsumerConfiguration {
          return Boolean.parseBoolean(string);
       } else {
          return configuration.isCoreMessageTunnelingEnabled();
+      }
+   }
+
+   /**
+    * {@return {@code true} if federation is configured to ignore filters on individual address bindings}
+    */
+   public boolean isIgnoreAddressBindingFilters() {
+      final Object property = properties.get(IGNORE_ADDRESS_BINDING_FILTERS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return configuration.isIgnoreAddressBindingFilters();
       }
    }
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationLocalPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationLocalPolicyManager.java
@@ -49,6 +49,13 @@ public abstract class AMQPFederationLocalPolicyManager extends AMQPFederationPol
     */
    public abstract FederationReceiveFromResourcePolicy getPolicy();
 
+   /**
+    * {@return the active configuration at this time the method is called}
+    */
+   protected AMQPFederationConsumerConfiguration getConfiguration() {
+      return configuration;
+   }
+
    @Override
    protected final void handleManagerInitialized() {
       server.registerBrokerPlugin(this);
@@ -101,16 +108,6 @@ public abstract class AMQPFederationLocalPolicyManager extends AMQPFederationPol
          scanAllBindings();
       }
    }
-
-   /**
-    * Create a new {@link AMQPFederationConsumer} instance using the consumer information given. This is called when
-    * local demand for a matched resource requires a new consumer to be created. A subclass must override this to
-    * perform the create operation.
-    *
-    * @param consumerInfo The {@link FederationConsumerInfo} that defines the consumer to be created.
-    * @return a new {@link AMQPFederationConsumer} instance that will reside in this manager
-    */
-   protected abstract AMQPFederationConsumer createFederationConsumer(FederationConsumerInfo consumerInfo);
 
    /**
     * Scans all bindings and push them through the normal bindings checks that would be done on an add. This allows for

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPBridgeFromQueueTest.java
@@ -16,31 +16,31 @@
  */
 package org.apache.activemq.artemis.tests.integration.amqp.connect;
 
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.BRIDGE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_PULL_CREDIT_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_PRIORITY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_ATTACH_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_DELAY;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LINK_RECOVERY_INITIAL_DELAY;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.MAX_LINK_RECOVERY_ATTEMPTS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PRESETTLE_SEND_MODE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AMQPTunneledMessageConstants.AMQP_TUNNELED_CORE_MESSAGE_FORMAT;
 import static org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport.TUNNEL_CORE_MESSAGES;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.BRIDGE_RECEIVER_PRIORITY;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_PULL_CREDIT_BATCH_SIZE;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
-import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_PRIORITY;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.hamcrest.CoreMatchers.allOf;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.not;
 
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
@@ -846,6 +846,7 @@ public class AMQPBridgeFromQueueTest extends AmqpClientTestSupport {
 
             connection.start();
 
+            peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
             peer.expectFlow().withLinkCredit(1000).withDrain(true)
                              .respond()
                              .withLinkCredit(0).withDeliveryCount(1000).withDrain(true);

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
@@ -30,16 +30,19 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADD_ADDRESS_POLICY;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADD_QUEUE_POLICY;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_BASE_VALIDATION_ADDRESS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONFIGURATION;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONTROL_LINK_PREFIX;
-import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_BASE_VALIDATION_ADDRESS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENTS_LINK_PREFIX;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_EVENT_LINK;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_NAME;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_V1;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_V2;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_VERSION;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_ADDRESS_BINDING_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_PRIORITIES;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.LARGE_MESSAGE_THRESHOLD;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.LINK_ATTACH_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.OPERATION_TYPE;
@@ -53,8 +56,8 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS_LOW;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_QUIESCE_TIMEOUT;
-import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
-import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.IGNORE_QUEUE_CONSUMER_PRIORITIES;
+import static org.hamcrest.CoreMatchers.allOf;
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -62,8 +65,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.allOf;
 
 import java.lang.invoke.MethodHandles;
 import java.net.URI;
@@ -75,6 +76,7 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.TimeUnit;
+
 import javax.jms.Connection;
 import javax.jms.ConnectionFactory;
 import javax.jms.JMSException;
@@ -253,6 +255,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       final boolean AMQP_TUNNEL_CORE_MESSAGES = false;
       final boolean AMQP_INGNORE_CONSUMER_FILTERS = false;
       final boolean AMQP_INGNORE_CONSUMER_PRIORITIES = false;
+      final boolean AMQP_INGNORE_ADDRESS_BINDING_FILTERS = false;
 
       final Map<String, Object> federationConfiguration = new HashMap<>();
       federationConfiguration.put(RECEIVER_CREDITS, AMQP_CREDITS);
@@ -265,6 +268,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       federationConfiguration.put(LINK_ATTACH_TIMEOUT, AMQP_LINK_ATTACH_TIMEOUT);
       federationConfiguration.put(IGNORE_QUEUE_CONSUMER_FILTERS, AMQP_INGNORE_CONSUMER_FILTERS);
       federationConfiguration.put(IGNORE_QUEUE_CONSUMER_PRIORITIES, AMQP_INGNORE_CONSUMER_PRIORITIES);
+      federationConfiguration.put(IGNORE_ADDRESS_BINDING_FILTERS, AMQP_INGNORE_ADDRESS_BINDING_FILTERS);
       federationConfiguration.put(AmqpSupport.TUNNEL_CORE_MESSAGES, AMQP_TUNNEL_CORE_MESSAGES);
 
       final String controlLinkAddress = "test-control-address";
@@ -305,6 +309,7 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          federation.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, AMQP_ADDRESS_RECEIVER_IDLE_TIMEOUT);
          federation.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, AMQP_QUEUE_RECEIVER_IDLE_TIMEOUT);
          federation.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.toString(AMQP_INGNORE_CONSUMER_PRIORITIES));
+         federation.addProperty(IGNORE_ADDRESS_BINDING_FILTERS, Boolean.toString(AMQP_INGNORE_ADDRESS_BINDING_FILTERS));
          amqpConnection.addElement(federation);
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();


### PR DESCRIPTION
Adds support to create federation receivers that carry the filter of the address binding or bindings that generated the demand on the address. This can reduce traffic across federation links if the bindings filters are sufficiently partitioning messages across consumers but can be less efficient than the default conduit subscription if poorly partitioned.