### PR TITLE
ARTEMIS-5637 reduce MQTT-to-Core session ratio

### DIFF
--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTConnectionManager.java
@@ -73,10 +73,7 @@ public class MQTTConnectionManager {
       sessionState.setFailed(false);
       ServerSessionImpl serverSession = createServerSession(username, password, validatedUser);
       serverSession.start();
-      ServerSessionImpl internalServerSession = createServerSession(username, password, validatedUser);
-      internalServerSession.disableSecurity();
-      internalServerSession.start();
-      session.setServerSession(serverSession, internalServerSession);
+      session.setServerSession(serverSession);
 
       if (cleanStart) {
          /*

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTLogger.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTLogger.java
@@ -17,9 +17,9 @@
 package org.apache.activemq.artemis.core.protocol.mqtt;
 
 import org.apache.activemq.artemis.core.server.MessageReference;
+import org.apache.activemq.artemis.logs.BundleFactory;
 import org.apache.activemq.artemis.logs.annotation.LogBundle;
 import org.apache.activemq.artemis.logs.annotation.LogMessage;
-import org.apache.activemq.artemis.logs.BundleFactory;
 
 /**
  * Logger Codes 830000 - 839999

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTRetainMessageManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTRetainMessageManager.java
@@ -19,6 +19,7 @@ package org.apache.activemq.artemis.core.protocol.mqtt;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.journal.LargeServerMessageImpl;
 import org.apache.activemq.artemis.core.server.BindingQueryResult;
 import org.apache.activemq.artemis.core.server.MessageReference;
@@ -58,8 +59,9 @@ public class MQTTRetainMessageManager {
       queue.deleteAllReferences();
 
       if (!reset) {
-         Message message = LargeServerMessageImpl.checkLargeMessage(messageParameter, session.getServer().getStorageManager());
-         sendToQueue(message.copy(session.getServer().getStorageManager().generateID()), queue, tx);
+         StorageManager storageManager = session.getServer().getStorageManager();
+         Message message = LargeServerMessageImpl.checkLargeMessage(messageParameter, storageManager);
+         MQTTUtil.sendMessageDirectlyToQueue(storageManager, session.getServer().getPostOffice(), message.copy(storageManager.generateID()), queue, tx);
       }
    }
 
@@ -84,7 +86,7 @@ public class MQTTRetainMessageManager {
                   }
                   Message message = ref.getMessage().copy(session.getServer().getStorageManager().generateID());
                   message.putStringProperty(MQTT_MESSAGE_RETAIN_INITIAL_DISTRIBUTION_KEY, (String) null);
-                  sendToQueue(message, queue, tx);
+                  MQTTUtil.sendMessageDirectlyToQueue(session.getServer().getStorageManager(), session.getServer().getPostOffice(), message, queue, tx);
                }
             }
          }

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTSession.java
@@ -49,8 +49,6 @@ public class MQTTSession {
 
    private ServerSessionImpl serverSession;
 
-   private ServerSessionImpl internalServerSession;
-
    private MQTTPublishManager mqttPublishManager;
 
    private MQTTConnectionManager mqttConnectionManager;
@@ -129,11 +127,6 @@ public class MQTTSession {
             serverSession.close(failure);
          }
 
-         if (internalServerSession != null) {
-            internalServerSession.stop();
-            internalServerSession.close(failure);
-         }
-
          state.setAttached(false);
          state.setDisconnectedTime(System.currentTimeMillis());
          state.clearTopicAliases();
@@ -193,10 +186,6 @@ public class MQTTSession {
       return serverSession;
    }
 
-   ServerSessionImpl getInternalServerSession() {
-      return internalServerSession;
-   }
-
    ActiveMQServer getServer() {
       return protocolHandler.getServer();
    }
@@ -213,9 +202,8 @@ public class MQTTSession {
       return sessionCallback;
    }
 
-   void setServerSession(ServerSessionImpl serverSession, ServerSessionImpl internalServerSession) {
+   void setServerSession(ServerSessionImpl serverSession) {
       this.serverSession = serverSession;
-      this.internalServerSession = internalServerSession;
    }
 
    void setSessionState(MQTTSessionState state) {

--- a/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTStateManager.java
+++ b/artemis-protocols/artemis-mqtt-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/mqtt/MQTTStateManager.java
@@ -33,11 +33,10 @@ import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.core.filter.impl.FilterImpl;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
+import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.MessageReference;
 import org.apache.activemq.artemis.core.server.Queue;
-import org.apache.activemq.artemis.core.transaction.Transaction;
-import org.apache.activemq.artemis.core.transaction.impl.TransactionImpl;
 import org.apache.activemq.artemis.utils.collections.LinkedListIterator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,10 +178,8 @@ public class MQTTStateManager {
    public void storeDurableSubscriptionState(MQTTSessionState state) throws Exception {
       if (subscriptionPersistenceEnabled) {
          logger.debug("Adding durable MQTT subscription record for: {}", state.getClientId());
-         Transaction tx = new TransactionImpl(server.getStorageManager());
-         tx.setAsync(true);
-         server.getPostOffice().route(serializeState(state, server.getStorageManager().generateID()), tx, false);
-         tx.commit();
+         StorageManager storageManager = server.getStorageManager();
+         MQTTUtil.sendMessageDirectlyToQueue(storageManager, server.getPostOffice(), serializeState(state, storageManager.generateID()), sessionStore, null);
       }
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ServerSession.java
@@ -122,6 +122,15 @@ public interface ServerSession extends SecurityAuth {
                                  boolean supportLargeMessage,
                                  Integer credits) throws Exception;
 
+   ServerConsumer createConsumer(long consumerID,
+                                 SimpleString queueName,
+                                 SimpleString filterString,
+                                 int priority,
+                                 boolean browseOnly,
+                                 boolean supportLargeMessage,
+                                 Integer credits,
+                                 boolean enforceSecurity) throws Exception;
+
    /**
     * To be used by protocol heads that needs to control the transaction outside the session context.
     */

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt/MQTTTest.java
@@ -332,7 +332,7 @@ public class MQTTTest extends MQTTTestSupport {
          assertEquals(payload, new String(message));
       }
 
-      final Queue queue = server.locateQueue(SimpleString.of(MQTTUtil.MANAGEMENT_QUEUE_PREFIX + clientId));
+      final Queue queue = server.locateQueue(SimpleString.of(MQTTUtil.QOS2_MANAGEMENT_QUEUE_PREFIX + clientId));
 
       Wait.waitFor(() -> queue.getMessageCount() == 0, 1000, 100);
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5Test.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/MQTT5Test.java
@@ -914,4 +914,14 @@ public class MQTT5Test extends MQTT5TestSupport {
       assertTrue(latch.await(1, TimeUnit.MINUTES), "not all tasks finished");
       assertFalse(failed.get());
    }
+
+   @Test
+   @Timeout(DEFAULT_TIMEOUT_SEC)
+   public void testSessionCount() throws Exception {
+      MqttClient subscriber = createPahoClient("subscriber");
+      subscriber.connect();
+      MqttClient producer = createPahoClient("producer");
+      producer.connect();
+      assertEquals(2, server.getActiveMQServerControl().getSessionCount());
+   }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/QoSTests.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/mqtt5/spec/QoSTests.java
@@ -370,8 +370,8 @@ public class QoSTests extends MQTT5TestSupport {
          if (packet.fixedHeader().messageType() == MqttMessageType.PUBCOMP) {
             try {
                // ensure the message is still in the management queue before we get the PUBCOMP from the client
-               Wait.assertEquals(1L, () -> server.locateQueue(MQTTUtil.MANAGEMENT_QUEUE_PREFIX + CONSUMER_ID).getMessageCount(), 2000, 100);
-               Wait.assertEquals(1L, () -> server.locateQueue(MQTTUtil.MANAGEMENT_QUEUE_PREFIX + CONSUMER_ID).getDeliveringCount(), 2000, 100);
+               Wait.assertEquals(1L, () -> server.locateQueue(MQTTUtil.QOS2_MANAGEMENT_QUEUE_PREFIX + CONSUMER_ID).getMessageCount(), 2000, 100);
+               Wait.assertEquals(1L, () -> server.locateQueue(MQTTUtil.QOS2_MANAGEMENT_QUEUE_PREFIX + CONSUMER_ID).getDeliveringCount(), 2000, 100);
             } catch (Exception e) {
                return false;
             }


### PR DESCRIPTION
This commit includes the following changes:

 - Eliminate the "internal" Core session used by MQTT.
 - Consolidate MQTT-specific logic to send a message directly to a queue.
 - Rename some variables in MQTTPublishManager to be more clear.
 - Refactor some methods in MQTTPublishManager to be more clear.
 - Move createPubRelMessage method from MQTTUtil to MQTTPublishManager.
 - Add new methods to ServerSession to allow creating a consumer with no security checks (i.e. an "internal" consumer).
 - Add a test to verify 1:1 MQTT connection to Core sessio ratio.