### PR TITLE
ARTEMIS-5586: Update to jackson 2.20.0

### DIFF
--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -886,37 +886,6 @@
          </dependency>
 
          <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-core</artifactId>
-            <version>${jackson.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-databind</artifactId>
-            <version>${jackson-databind.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>com.fasterxml.jackson.core</groupId>
-            <artifactId>jackson-annotations</artifactId>
-            <version>${jackson.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>com.fasterxml.jackson.jaxrs</groupId>
-            <artifactId>jackson-jaxrs-json-provider</artifactId>
-            <version>${jackson.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>com.fasterxml.jackson.dataformat</groupId>
-            <artifactId>jackson-dataformat-yaml</artifactId>
-            <version>${jackson.version}</version>
-         </dependency>
-         <dependency>
-            <groupId>com.fasterxml.jackson.jr</groupId>
-            <artifactId>jackson-jr-objects</artifactId>
-            <version>${jackson.version}</version>
-         </dependency>
-
-         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpcore</artifactId>
             <version>${apache.httpcore.version}</version>
@@ -925,6 +894,14 @@
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
             <version>${apache.httpclient.version}</version>
+         </dependency>
+
+         <dependency>
+            <groupId>com.fasterxml.jackson</groupId>
+            <artifactId>jackson-bom</artifactId>
+            <version>${jackson.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
          </dependency>
       </dependencies>
    </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -198,8 +198,7 @@
       <owasp.version>12.1.3</owasp.version>
       <spring.version>5.3.39</spring.version>
 
-      <jackson.version>2.19.2</jackson.version>
-      <jackson-databind.version>${jackson.version}</jackson-databind.version>
+      <jackson.version>2.20.0</jackson.version>
 
       <activemq.version.versionName>${project.version}</activemq.version.versionName>
       <activemq.version.majorVersion>1</activemq.version.majorVersion>


### PR DESCRIPTION
Update to jackson 2.20.0. Switches to using jackson-bom, fixes breakage from [change in versioning of jackson-annotations](https://github.com/FasterXML/jackson/wiki/Jackson-Release-2.20#compatibility-versioning) and ease future updates.

(Replaces both #5894 and #5897, which both failed due to the versioning change. The dual PRs happen because Dependabot doesnt understand the prior linked dual-property usage, meaning that should also go away with these changes.)