### PR TITLE
ARTEMIS-5645 Drain the receiver link if address is rejecting messages

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/broker/ProtonProtocolManager.java
@@ -96,6 +96,8 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
 
    private boolean amqpUseModifiedForTransientDeliveryErrors = AmqpSupport.AMQP_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
 
+   private boolean amqpDrainOnTransientDeliveryErrors = AmqpSupport.AMQP_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS;
+
    // If set true, a reject disposition will be treated as if it were an unmodified disposition with the
    // delivery-failed flag set true.
    private boolean amqpTreatRejectAsUnmodifiedDeliveryFailed = AmqpSupport.AMQP_TREAT_REJECT_AS_UNMODIFIED_DELIVERY_FAILURE;
@@ -105,6 +107,8 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
    private String[] saslMechanisms = MechanismFinder.getDefaultMechanisms();
 
    private String saslLoginConfigScope = "amqp-sasl-gssapi";
+
+   private int amqpLinkQuiesceTimeout = AmqpSupport.AMQP_LINK_QUIESCE_TIMEOUT;
 
    private Long amqpIdleTimeout;
 
@@ -449,12 +453,53 @@ public class ProtonProtocolManager extends AbstractProtocolManager<AMQPMessage, 
       return this;
    }
 
-
    public void setAmqpTreatRejectAsUnmodifiedDeliveryFailed(final boolean amqpTreatRejectAsUnmodifiedDeliveryFailed) {
       this.amqpTreatRejectAsUnmodifiedDeliveryFailed = amqpTreatRejectAsUnmodifiedDeliveryFailed;
    }
 
    public boolean isAmqpTreatRejectAsUnmodifiedDeliveryFailed() {
       return this.amqpTreatRejectAsUnmodifiedDeliveryFailed;
+   }
+
+   /**
+    * {@return true if transient delivery errors should be handled by draining link credit from the remote sender}
+    */
+   public boolean isDrainOnTransientDeliveryErrors() {
+      return this.amqpDrainOnTransientDeliveryErrors;
+   }
+
+   /**
+    * Sets if transient delivery errors should be handled by draining link credit from the remote sender
+    *
+    * @param amqpDrainOnTransientDeliveryErrors
+    *    Set to <code>true</code> if senders should be drained on transient delivery errors.
+    *
+    * @return this protocol manager instance.
+    */
+   public ProtonProtocolManager setAmqpDrainOnTransientDeliveryErrors(boolean amqpDrainOnTransientDeliveryErrors) {
+      this.amqpDrainOnTransientDeliveryErrors = amqpDrainOnTransientDeliveryErrors;
+      return this;
+   }
+
+   /**
+    * {@return the time in milliseconds to wait for remote sender once a link quiesce is initiated by this peer}
+    */
+   public int getLinkQuiesceTimeout() {
+      return amqpLinkQuiesceTimeout;
+   }
+
+   /**
+    * Sets the time in milliseconds to wait before closing a remote sender link if the server has requested
+    * that the link drain all outstanding credit an complete pending settlements. A value less than or equal
+    * to zero disables drain timeouts.
+    *
+    * @param amqpLinkQuiesceTimeout
+    *    The time in milliseconds to wait for quiesce to complete.
+    *
+    * @return this protocol manager instance.
+    */
+   public ProtonProtocolManager setAmqpLinkQuiesceTimeout(int amqpLinkQuiesceTimeout) {
+      this.amqpLinkQuiesceTimeout = amqpLinkQuiesceTimeout;
+      return this;
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/proton/AmqpSupport.java
@@ -49,6 +49,12 @@ public class AmqpSupport {
    // Defaults for controlling the behaviour of AMQP dispositions
    public static final boolean AMQP_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS = false;
 
+   // Defaults for controlling the behaviour of AMQP credit draining on resource exhaustion
+   public static final boolean AMQP_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS = true;
+
+   // Default timeout (in milliseconds) before closing a link as failed if a quiesce is initiated from this peer
+   public static final int AMQP_LINK_QUIESCE_TIMEOUT = 600_000; // ten minutes
+
    // Identification values used to locating JMS selector types.
    public static final Symbol JMS_SELECTOR_KEY = Symbol.valueOf("jms-selector");
    public static final UnsignedLong JMS_SELECTOR_CODE = UnsignedLong.valueOf(0x0000468C00000004L);

--- a/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContextTest.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/test/java/org/apache/activemq/artemis/protocol/amqp/proton/ProtonServerReceiverContextTest.java
@@ -17,6 +17,9 @@
 package org.apache.activemq.artemis.protocol.amqp.proton;
 
 import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import io.netty.buffer.Unpooled;
@@ -24,6 +27,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQAddressFullException;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.RoutingContext;
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.protocol.amqp.broker.AMQPMessage;
@@ -34,11 +38,13 @@ import org.apache.activemq.artemis.protocol.amqp.converter.AMQPMessageSupport;
 import org.apache.activemq.artemis.protocol.amqp.exceptions.ActiveMQAMQPException;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyReadable;
 import org.apache.activemq.artemis.protocol.amqp.util.NettyWritable;
+import org.apache.activemq.artemis.utils.Wait;
 import org.apache.qpid.proton.amqp.Symbol;
 import org.apache.qpid.proton.amqp.messaging.Accepted;
 import org.apache.qpid.proton.amqp.messaging.Modified;
 import org.apache.qpid.proton.amqp.messaging.Outcome;
 import org.apache.qpid.proton.amqp.messaging.Rejected;
+import org.apache.qpid.proton.amqp.messaging.Released;
 import org.apache.qpid.proton.amqp.messaging.Source;
 import org.apache.qpid.proton.amqp.transport.DeliveryState;
 import org.apache.qpid.proton.codec.ReadableBuffer;
@@ -179,7 +185,10 @@ public class ProtonServerReceiverContextTest {
       verify(mockDelivery, times(1)).settle();
 
       verify(mockReceiver, times(1)).getDrain();
-      if (!drain) {
+      if (drain) {
+         verify(mockReceiver, times(1)).getQueued();
+         verify(mockReceiver, times(1)).getCredit();
+      } else {
          verify(mockReceiver, times(1)).flow(1);
       }
       verifyNoMoreInteractions(mockReceiver);
@@ -241,6 +250,116 @@ public class ProtonServerReceiverContextTest {
 
       assertEquals(1000, ProtonServerReceiverContext.calculatedUpdateRefill(2000, 1000, 0));
       assertEquals(900, ProtonServerReceiverContext.calculatedUpdateRefill(2000, 1000, 100));
+   }
+
+   @Test
+   public void testStopDrainsOffCredit() throws Exception {
+      final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+      try {
+         ActiveMQServer mockServer = mock(ActiveMQServer.class);
+         when(mockServer.getScheduledPool()).thenReturn(scheduler);
+
+         Receiver mockReceiver = mock(Receiver.class);
+         AMQPConnectionContext mockConnContext = mock(AMQPConnectionContext.class);
+
+         when(mockConnContext.getAmqpCredits()).thenReturn(100);
+         when(mockConnContext.getAmqpLowCredits()).thenReturn(30);
+
+         when(mockConnContext.getProtocolManager()).thenReturn(mock(ProtonProtocolManager.class));
+
+         AMQPSessionCallback mockSessionSpi = mock(AMQPSessionCallback.class);
+         when(mockSessionSpi.getStorageManager()).thenReturn(new NullStorageManager());
+         when(mockSessionSpi.createStandardMessage(any(), any())).thenAnswer((Answer<AMQPStandardMessage>) invocation -> new AMQPStandardMessage(0, createAMQPMessageBuffer(), null, null));
+
+         AMQPSessionContext mockProtonContext = mock(AMQPSessionContext.class);
+         when(mockProtonContext.getServer()).thenReturn(mockServer);
+         when(mockProtonContext.getSessionSPI()).thenReturn(mockSessionSpi);
+
+         ProtonServerReceiverContext rc = new ProtonServerReceiverContext(mockSessionSpi, mockConnContext, mockProtonContext, mockReceiver);
+
+         AtomicBoolean stopped = new AtomicBoolean();
+
+         when(mockReceiver.getCredit()).thenReturn(100);
+
+         rc.stop(10_000, (rcvr, didStop) -> stopped.set(true));
+
+         assertFalse(stopped.get());
+
+         verify(mockReceiver, times(1)).drain(0);
+         verify(mockReceiver, times(1)).draining();
+         verify(mockReceiver, times(2)).getCredit();
+         verify(mockReceiver, times(1)).getQueued();
+         verify(mockReceiver, times(1)).drain(0);
+      } finally {
+         scheduler.shutdown();
+      }
+   }
+
+   @Test
+   public void testDrainInitiatedWhenDeliveryMarkedFailed() throws Exception {
+      final ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+
+      try {
+         ActiveMQServer mockServer = mock(ActiveMQServer.class);
+         when(mockServer.getScheduledPool()).thenReturn(scheduler);
+
+         Source source = new Source();
+         source.setOutcomes(new Symbol[]{Accepted.DESCRIPTOR_SYMBOL, Rejected.DESCRIPTOR_SYMBOL,
+                                         Modified.DESCRIPTOR_SYMBOL, Released.DESCRIPTOR_SYMBOL});
+
+         Receiver mockReceiver = mock(Receiver.class);
+         when(mockReceiver.getSource()).thenReturn(source);
+
+         ProtonProtocolManager mockProtocolManager = mock(ProtonProtocolManager.class);
+         when(mockProtocolManager.getLinkQuiesceTimeout()).thenReturn(100);
+         when(mockProtocolManager.isDrainOnTransientDeliveryErrors()).thenReturn(true);
+
+         AMQPConnectionContext mockConnContext = mock(AMQPConnectionContext.class);
+         when(mockConnContext.getAmqpCredits()).thenReturn(100);
+         when(mockConnContext.getAmqpLowCredits()).thenReturn(30);
+         when(mockConnContext.getProtocolManager()).thenReturn(mockProtocolManager);
+
+         doAnswer(invocation -> {
+            final Runnable target = invocation.getArgument(0, Runnable.class);
+            target.run();
+            return null;
+         }).when(mockConnContext).runNow(any(Runnable.class));
+
+         doAnswer(invocation -> {
+            final Runnable target = invocation.getArgument(0, Runnable.class);
+            target.run();
+            return null;
+         }).when(mockConnContext).runLater(any(Runnable.class));
+
+         AMQPSessionCallback mockSessionSpi = mock(AMQPSessionCallback.class);
+         when(mockSessionSpi.getStorageManager()).thenReturn(new NullStorageManager());
+         when(mockSessionSpi.createStandardMessage(any(), any())).thenAnswer((Answer<AMQPStandardMessage>) invocation -> new AMQPStandardMessage(0, createAMQPMessageBuffer(), null, null));
+
+         AMQPSessionContext mockProtonContext = mock(AMQPSessionContext.class);
+         when(mockProtonContext.getServer()).thenReturn(mockServer);
+         when(mockProtonContext.getSessionSPI()).thenReturn(mockSessionSpi);
+
+         ProtonServerReceiverContext rc = new ProtonServerReceiverContext(mockSessionSpi, mockConnContext, mockProtonContext, mockReceiver);
+
+         when(mockReceiver.getCredit()).thenReturn(100);
+
+         Delivery mockDelivery = mock(Delivery.class);
+         when(mockDelivery.getLink()).thenReturn(mockReceiver);
+         when(mockReceiver.current()).thenReturn(mockDelivery);
+
+         rc.incrementSettle();
+         rc.deliveryFailed(mockDelivery, mockReceiver, new ActiveMQAddressFullException("full"));
+
+         Wait.assertTrue(() -> rc.isClosed(), 5000, 50);
+
+         verify(mockReceiver, times(1)).drain(0);
+         verify(mockReceiver, times(2)).getCredit();
+         verify(mockReceiver, times(1)).drain(0);
+         verify(mockReceiver, times(1)).getSource();
+      } finally {
+         scheduler.shutdown();
+      }
    }
 
    private ReadableBuffer createAMQPMessageBuffer() {

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpDrainOnNoSpaceForSendsTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/AmqpDrainOnNoSpaceForSendsTest.java
@@ -1,0 +1,1091 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.tests.integration.amqp;
+
+import java.util.concurrent.TimeUnit;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.TransportConfiguration;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.protocol.amqp.proton.AmqpSupport;
+import org.apache.activemq.artemis.utils.Wait;
+import org.apache.qpid.proton.amqp.transport.LinkError;
+import org.apache.qpid.protonj2.test.driver.ProtonTestClient;
+import org.junit.jupiter.api.Test;
+
+public class AmqpDrainOnNoSpaceForSendsTest extends AmqpClientTestSupport {
+
+   @Override
+   protected String getConfiguredProtocols() {
+      return "AMQP";
+   }
+
+   @Override
+   protected void configureAMQPAcceptorParameters(TransportConfiguration tc) {
+      tc.getParams().put("amqpCredits", "3");
+      tc.getParams().put("amqpLowCredits", "1");
+   }
+
+   @Override
+   protected void configureAddressPolicy(ActiveMQServer server) {
+      AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch("#");
+      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+      addressSettings.setMaxSizeBytes(500);
+      server.getAddressSettingsRepository().addMatch("#", addressSettings);
+   }
+
+   @Override
+   protected ActiveMQServer createServer() throws Exception {
+      // Creates the broker used to make the outgoing connection. The port passed is for
+      // that brokers acceptor. The test server connected to by the broker binds to a random port.
+      return createServer(AMQP_PORT, false);
+   }
+
+   @Test
+   public void testDrainCreditOnClientSendFailForMulticastAddress() throws Exception {
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("queue2").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue2")).isExists(), 5000, 100);
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().rejected();
+         peer.expectDetach();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "3").also()
+                              .withBody().withString("Third Message: ")
+                              .also()
+                              .withDeliveryId(3)
+                              .later(10);
+         peer.remoteDetach().later(15);
+
+         // Should be no new flow since the address remains full
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainCreditOnClientSendFailForAnyCastAddress() throws Exception {
+      server.start();
+      server.createQueue(QueueConfiguration.of(getTestName()).setRoutingType(RoutingType.ANYCAST)
+                                                             .setAddress(getTestName())
+                                                             .setAutoCreated(false));
+
+      Wait.assertTrue(() -> server.queueQuery(SimpleString.of(getTestName())).isExists(), 5000, 100);
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("queue").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().rejected();
+         peer.expectDetach();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "3").also()
+                              .withBody().withString("Third Message: ")
+                              .also()
+                              .withDeliveryId(3)
+                              .later(10);
+         peer.remoteDetach().later(15);
+
+         // Should be no new flow since the address remains full
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDoesDrainCreditOnClientSendFailForAnonymousRelaySenderForMatchedAddressPolicy() throws Exception {
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender")
+                          .withDesiredCapabilities(AmqpSupport.ANONYMOUS_RELAY.toString()).now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("queue2").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue2")).isExists(), 5000, 100);
+
+         final Queue queue1 = server.locateQueue(SimpleString.of("queue1"));
+         final Queue queue2 = server.locateQueue(SimpleString.of("queue2"));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "3").also()
+                              .withBody().withString("Third Message: ")
+                              .also()
+                              .withDeliveryId(3)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(3);
+
+         // Make capacity again which should now replenish credit.
+         queue1.deleteQueue();
+         queue2.deleteQueue();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().accepted();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "4").also()
+                              .withBody().withString("Fourth Message: ")
+                              .also()
+                              .withDeliveryId(4)
+                              .later(10);
+
+         // Should be no new flow since the address remains full
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainedAnonymousRelaySenderCanBurnCreditSendingToOtherAddresses() throws Exception {
+      final String queueNameA = getTestName() + "-A";
+      final String queueNameB = getTestName() + "-B";
+
+      AddressSettings addressSettings1 = server.getAddressSettingsRepository().getMatch(queueNameA);
+      addressSettings1.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+      addressSettings1.setMaxSizeBytes(500);
+      server.getAddressSettingsRepository().addMatch(queueNameA, addressSettings1);
+
+      AddressSettings addressSettings2 = server.getAddressSettingsRepository().getMatch(queueNameB);
+      addressSettings2.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+      addressSettings2.setMaxSizeBytes(500);
+      server.getAddressSettingsRepository().addMatch(queueNameB, addressSettings2);
+
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender")
+                          .withDesiredCapabilities(AmqpSupport.ANONYMOUS_RELAY.toString()).now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of(queueNameA).setRoutingType(RoutingType.ANYCAST)
+                                                             .setAddress(queueNameA)
+                                                             .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of(queueNameB).setRoutingType(RoutingType.MULTICAST)
+                                                             .setAddress(queueNameB)
+                                                             .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(queueNameA)).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(queueNameB)).isExists(), 5000, 100);
+
+         final Queue queue1 = server.locateQueue(SimpleString.of(queueNameA));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().accepted();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameB).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "3").also()
+                              .withBody().withString("Third Message: ")
+                              .also()
+                              .withDeliveryId(3)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(3);
+
+         // Make capacity again which should now replenish credit.
+         queue1.deleteQueue();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().accepted();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "4").also()
+                              .withBody().withString("Fourth Message: ")
+                              .also()
+                              .withDeliveryId(4)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainedAnonymousRelaySenderCreditNotReplenishedOnBurnOfExistingCredit() throws Exception {
+      final String queueNameA = getTestName() + "-A";
+      final String queueNameB = getTestName() + "-B";
+
+      AddressSettings addressSettings1 = server.getAddressSettingsRepository().getMatch(queueNameA);
+      addressSettings1.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+      addressSettings1.setMaxSizeBytes(500);
+      server.getAddressSettingsRepository().addMatch(queueNameA, addressSettings1);
+
+      AddressSettings addressSettings2 = server.getAddressSettingsRepository().getMatch(queueNameB);
+      addressSettings2.setAddressFullMessagePolicy(AddressFullMessagePolicy.FAIL);
+      addressSettings2.setMaxSizeBytes(500);
+      server.getAddressSettingsRepository().addMatch(queueNameB, addressSettings2);
+
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen().withOfferedCapability(AmqpSupport.ANONYMOUS_RELAY.toString());
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender")
+                          .withDesiredCapabilities(AmqpSupport.ANONYMOUS_RELAY.toString()).now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of(queueNameA).setRoutingType(RoutingType.ANYCAST)
+                                                             .setAddress(queueNameA)
+                                                             .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of(queueNameB).setRoutingType(RoutingType.MULTICAST)
+                                                             .setAddress(queueNameB)
+                                                             .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(queueNameA)).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(queueNameB)).isExists(), 5000, 100);
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().accepted();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameB).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "3").also()
+                              .withBody().withString("Third Message: ")
+                              .also()
+                              .withDeliveryId(3)
+                              .later(10);
+
+         // Create some traffic to ensure we don't see unexpected flow frames
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender().respond();
+         peer.remoteAttach().ofReceiver()
+                            .withName("receiving-peer")
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withTarget().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+         peer.remoteDetach().later(1);
+
+         // Should be no new flow since the address remains full
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainAnonymousRelayOnceBlockPolicyHitsRejectMaxSizeThreshold() throws Exception {
+      final String queueNameA = getTestName() + "A";
+      final String queueNameB = getTestName() + "B";
+
+      AddressSettings addressSettings1 = server.getAddressSettingsRepository().getMatch(queueNameA);
+      addressSettings1.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      addressSettings1.setMaxSizeBytes(500);
+      addressSettings1.setMaxSizeBytesRejectThreshold(1000);
+      server.getAddressSettingsRepository().addMatch(queueNameA, addressSettings1);
+
+      AddressSettings addressSettings2 = server.getAddressSettingsRepository().getMatch(queueNameB);
+      addressSettings2.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      addressSettings2.setMaxSizeBytes(500);
+      addressSettings2.setMaxSizeBytesRejectThreshold(1000);
+      server.getAddressSettingsRepository().addMatch(queueNameB, addressSettings2);
+
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen().withOfferedCapability(AmqpSupport.ANONYMOUS_RELAY.toString());
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender")
+                          .withDesiredCapabilities(AmqpSupport.ANONYMOUS_RELAY.toString()).now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of(queueNameA).setRoutingType(RoutingType.MULTICAST)
+                                                             .setAddress(queueNameA)
+                                                             .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of(queueNameB).setRoutingType(RoutingType.MULTICAST)
+                                                             .setAddress(queueNameB)
+                                                             .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(queueNameA)).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of(queueNameB)).isExists(), 5000, 100);
+
+         Queue queue1 = server.locateQueue(SimpleString.of(queueNameA));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(1024);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(queueNameA).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: " + payload)
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         // Make capacity again which should now replenish credit once remote send drain response.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender();
+         peer.expectDetach();
+         peer.remoteAttach().ofReceiver()
+                            .withName("receiving-peer")
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withTarget().also()
+                            .now();
+         peer.remoteDetach().later(1);
+
+         queue1.deleteQueue();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(3).withDeliveryCount(3);
+
+         // Respond drained with one credit outstanding, remote should then grant a new batch
+         peer.remoteFlow().withLinkCredit(0).withDeliveryCount(3).withDrain(true).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDoesNotDrainCreditOnClientSendFailIfAcceptorConfiguredNotTo() throws Exception {
+      server.getConfiguration().getAcceptorConfigurations().clear();
+      server.getConfiguration().addAcceptorConfiguration("server",
+         "tcp://localhost:" + AMQP_PORT + "?amqpCredits=3&amqpLowCredits=0&amqpDrainOnTransientDeliveryErrors=false");
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("queue2").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue2")).isExists(), 5000, 100);
+
+         final Queue queue1 = server.locateQueue(SimpleString.of("queue1"));
+         final Queue queue2 = server.locateQueue(SimpleString.of("queue2"));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "3").also()
+                              .withBody().withString("Third Message: ")
+                              .also()
+                              .withDeliveryId(3)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(3);
+
+         // Make capacity again which should now replenish credit.
+         queue1.deleteQueue();
+         queue2.deleteQueue();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDisposition().withState().accepted();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "4").also()
+                              .withBody().withString("Fourth Message: ")
+                              .also()
+                              .withDeliveryId(4)
+                              .later(10);
+
+         // Should be no new flow since the address remains full
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainCreditOnClientSendFailPeerAnsweresDrainedButFlowsOnlyAfterSpaceCleared() throws Exception {
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("queue2").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue2")).isExists(), 5000, 100);
+
+         final Queue queue1 = server.locateQueue(SimpleString.of("queue1"));
+         final Queue queue2 = server.locateQueue(SimpleString.of("queue2"));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.remoteFlow().withLinkCredit(0).withDeliveryCount(3).withDrain(true).now();
+
+         // The address should still be full so nothing expected until the queues are deleted
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(3).withDeliveryCount(3);
+
+         // Make capacity again which should now replenish credit.
+         queue1.deleteQueue();
+         queue2.deleteQueue();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainCreditOnClientSendFailNoNewCreditUntilPeerAnswersDrained() throws Exception {
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+
+         Queue queue1 = server.locateQueue(SimpleString.of("queue1"));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         // Make capacity again which should now replenish credit once remote send drain response.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         queue1.deleteQueue();
+
+         peer.expectFlow().withLinkCredit(3).withDeliveryCount(3);
+
+         // Respond drained with one credit outstanding, remote should then grant a new batch
+         peer.remoteFlow().withLinkCredit(0).withDeliveryCount(3).withDrain(true).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testSenderClosedIfRemoteTimesOutWaitingForDrainToComplete() throws Exception {
+      server.getConfiguration().getAcceptorConfigurations().clear();
+      server.getConfiguration().addAcceptorConfiguration("server",
+         "tcp://localhost:" + AMQP_PORT + "?amqpCredits=3&amqpLowCredits=0&amqpLinkQuiesceTimeout=1");
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+         server.createQueue(QueueConfiguration.of("queue2").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue2")).isExists(), 5000, 100);
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(100);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+         peer.expectDetach().withError(LinkError.DETACH_FORCED.toString());
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withProperties().withTo(getTestName()).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         // Create some traffic to ensure we don't see unexpected flow frames
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender().respond();
+         peer.remoteAttach().ofReceiver()
+                            .withName("receiving-peer")
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withTarget().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectDetach().respond();
+         peer.remoteDetach().later(1);
+
+         // Should be no new flow since the address remains full
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+
+   @Test
+   public void testDrainOnceBlockPolicyHitsRejectMaxSizeThreshold() throws Exception {
+      AddressSettings addressSettings = server.getAddressSettingsRepository().getMatch("#");
+      addressSettings.setAddressFullMessagePolicy(AddressFullMessagePolicy.BLOCK);
+      addressSettings.setMaxSizeBytes(500);
+      addressSettings.setMaxSizeBytesRejectThreshold(1000);
+      server.getAddressSettingsRepository().addMatch("#", addressSettings);
+      server.start();
+
+      try (ProtonTestClient peer = new ProtonTestClient()) {
+         peer.queueClientSaslAnonymousConnect();
+         peer.connect("localhost", AMQP_PORT);
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         peer.expectOpen();
+         peer.expectBegin();
+         peer.expectAttach().ofReceiver();
+         peer.expectFlow().withLinkCredit(3);
+
+         peer.remoteOpen().withContainerId("test-sender").now();
+         peer.remoteBegin().now();
+         peer.remoteAttach().ofSender()
+                            .withInitialDeliveryCount(0)
+                            .withName("sending-peer")
+                            .withTarget().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withSource().also()
+                            .now();
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+
+         server.createQueue(QueueConfiguration.of("queue1").setRoutingType(RoutingType.MULTICAST)
+                                                           .setAddress(getTestName())
+                                                           .setAutoCreated(false));
+
+         Wait.assertTrue(() -> server.queueQuery(SimpleString.of("queue1")).isExists(), 5000, 100);
+
+         Queue queue1 = server.locateQueue(SimpleString.of("queue1"));
+
+         peer.expectDisposition().withState().accepted();
+
+         final String payload = "A".repeat(1024);
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "1").also()
+                              .withBody().withString("First Message: " + payload)
+                              .also()
+                              .withDeliveryId(1)
+                              .now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(1).withDrain(true);
+         peer.expectDisposition().withState().rejected();
+
+         peer.remoteTransfer().withHeader().withDurability(true).also()
+                              .withApplicationProperties().withProperty("color", "red").also()
+                              .withMessageAnnotations().withAnnotation("x-opt-test", "2").also()
+                              .withBody().withString("Second Message: ")
+                              .also()
+                              .withDeliveryId(2)
+                              .later(10);
+
+         // Make capacity again which should now replenish credit once remote sends drain response.
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectAttach().ofSender();
+         peer.expectDetach();
+         peer.remoteAttach().ofReceiver()
+                            .withName("receiving-peer")
+                            .withSource().withAddress(getTestName())
+                                         .withCapabilities("topic").also()
+                            .withTarget().also()
+                            .now();
+         peer.remoteDetach().later(1);
+
+         queue1.deleteQueue();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectFlow().withLinkCredit(3).withDeliveryCount(3);
+
+         // Respond drained with one credit outstanding, remote should then grant a new batch
+         peer.remoteFlow().withLinkCredit(0).withDeliveryCount(3).withDrain(true).now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+         peer.expectClose();
+         peer.remoteClose().now();
+
+         peer.waitForScriptToComplete(5, TimeUnit.SECONDS);
+      }
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationAddressPolicyTest.java
@@ -6319,6 +6319,12 @@ public class AMQPFederationAddressPolicyTest extends AmqpClientTestSupport {
 
          peer.expectDisposition().withState().accepted(); // This should fill the address
 
+         // In either configuration we drain the link credit to avoid repeated sends of the failed
+         // deliveries where possible.
+         peer.expectFlow().withDrain(true).withLinkCredit(998)
+                          .respond()
+                          .withDrain(true).withLinkCredit(0).withDeliveryCount(998).afterDelay(5);
+
          // If sending modified the remote won't discard the message, it will send it again
          if (useModifiedForReject) {
             peer.expectDisposition().withState().modified(true);


### PR DESCRIPTION
When an address policy limits the incoming messages and starts to reject them the AMQP link should drain remote credit to limit the remote from sending new messages until the address has space again in which case new credit will be granted.