### PR TITLE
ARTEMIS-5578: Update Netty to 4.1.126 (inc tcnative test dep to 2.0.73)

### DIFF
--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -29,9 +29,6 @@
 	</feature>
 
 	<feature name="netty-core" version="${netty.version}" description="Netty libraries">
-		<!-- The wrap feature and svm dep can be removed once netty-common is fixed in 4.1.125 -->
-		<feature prerequisite="true">wrap</feature>
-		<bundle>wrap:mvn:org.graalvm.nativeimage/svm/19.3.6</bundle>
 		<bundle>mvn:io.netty/netty-common/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-resolver/${netty.version}</bundle>
 		<bundle>mvn:io.netty/netty-transport/${netty.version}</bundle>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
       <checkstyle.version>11.0.1</checkstyle.version>
       <mockito.version>5.19.0</mockito.version>
       <jctools.version>4.0.5</jctools.version>
-      <netty.version>4.1.124.Final</netty.version>
+      <netty.version>4.1.126.Final</netty.version>
       <hdrhistogram.version>2.2.2</hdrhistogram.version>
       <curator.version>5.9.0</curator.version>
       <zookeeper.version>3.9.4</zookeeper.version>
@@ -131,7 +131,7 @@
       <asciidoctorj.pdf.version>2.3.19</asciidoctorj.pdf.version>
 
       <!-- this is basically for tests -->
-      <netty-tcnative-version>2.0.72.Final</netty-tcnative-version>
+      <netty-tcnative-version>2.0.73.Final</netty-tcnative-version>
       <proton.version>0.34.1</proton.version>
       <protonj2.version>1.0.0</protonj2.version>
       <slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
Update to Netty to 4.1.126 and netty-tcnative test dep to 'matching' 2.0.73

Also unwinds workaround from #5876 / 19f8cc9c033dfd858f5648a38bff55fc392191fb now that the netty-common manifest fix was released (note 4.1.125 was quickly succeeded by 4.1.126 due to a cert related regression, hence skipping to it).

(This supplants PR #5898 and probably another later since Dependabot has already scheduled a 4.1.126 update PR to be created [EDIT: it since raised #5907], but it would miss the workaround removal so raised this PR instead).