### PR TITLE
ARTEMIS-5650 AMQP Federation receivers prefer modified dispositions b…

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationAddressConsumer.java
@@ -332,6 +332,21 @@ public abstract class AMQPFederationAddressConsumer extends AMQPFederationConsum
       }
 
       @Override
+      protected boolean isUseModifiedForTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isUseModifiedForTransientDeliveryErrors();
+      }
+
+      @Override
+      protected boolean isDrainOnTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isDrainOnTransientDeliveryErrors();
+      }
+
+      @Override
+      protected int getLinkQuiesceTimeout(AMQPConnectionContext connection) {
+         return configuration.getLinkQuiesceTimeout();
+      }
+
+      @Override
       protected final Runnable createCreditRunnable(AMQPConnectionContext connection) {
          // We defer to the configuration instance as opposed to the base class version that reads
          // from the connection this allows us to defer to configured policy properties that specify

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConstants.java
@@ -175,6 +175,30 @@ public final class AMQPFederationConstants {
    public static final String IGNORE_QUEUE_CONSUMER_PRIORITIES = "ignoreQueueConsumerPriorities";
 
    /**
+    * Configuration property for how a federation receiver should respond to delivery errors indicating that an address is
+    * full and cannot accept messages at this time. By default we want to send Modified outcomes with the delivery failed
+    * value set to true such that the remote will deliver the message again after incrementing the delivery count of the
+    * message.
+    */
+   public static final String USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS = "amqpUseModifiedForTransientDeliveryErrors";
+
+   /**
+    * Configuration property that defines the time in milliseconds that a receiver will wait before considering a pending
+    * quiesce timeout to have failed and should close the link. This configuration can be sent to the remote peer so that
+    * dual federation configurations share the same configuration on both sides of the connection. This option can be used
+    * to override the value specified on the connector URI to allow federation to operate with a different default.
+    */
+   public static final String RECEIVER_LINK_QUIESCE_TIMEOUT = "amqpLinkQuiesceTimeout";
+
+   /**
+    * Configuration property that defines if a federation receiver should drain the link credit when a transient delivery
+    * error such as the address being full occurs. This configuration can be sent to the remote peer so that dual federation
+    * configurations share the same configuration on both sides of the connection. This option can be used to override the
+    * value specified on the connector URI to allow federation to operate with a different default.
+    */
+   public static final String RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS = "amqpDrainOnTransientDeliveryErrors";
+
+   /**
     * A desired capability added to the federation queue receiver link that must be offered in return for a federation
     * queue receiver to be successfully opened.  On the remote the presence of this capability indicates that the
     * matching queue should be present on the remote and its absence constitutes a failure that should result in the

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConsumerConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationConsumerConfiguration.java
@@ -27,7 +27,10 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_LINK_QUIESCE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
 
 import java.util.Collections;
 import java.util.HashMap;
@@ -227,6 +230,48 @@ public final class AMQPFederationConsumerConfiguration {
          return Boolean.parseBoolean(string);
       } else {
          return configuration.isIgnoreSubscriptionPriorities();
+      }
+   }
+
+   /**
+    * (@return the use modified for transient delivery errors configuration}
+    */
+   public boolean isUseModifiedForTransientDeliveryErrors() {
+      final Object property = properties.get(USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return configuration.isUseModifiedForTransientDeliveryErrors();
+      }
+   }
+
+   /**
+    * (@return the drain link credit on transient delivery errors configuration}
+    */
+   public boolean isDrainOnTransientDeliveryErrors() {
+      final Object property = properties.get(RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return configuration.isDrainOnTransientDeliveryErrors();
+      }
+   }
+
+   /**
+    * {@return the federation receiver link quiesce timeout configuration}
+    */
+   public int getLinkQuiesceTimeout() {
+      final Object property = properties.get(RECEIVER_LINK_QUIESCE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return configuration.getLinkQuiesceTimeout();
       }
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueueConsumer.java
@@ -356,6 +356,21 @@ public final class AMQPFederationQueueConsumer extends AMQPFederationConsumer {
       }
 
       @Override
+      protected boolean isUseModifiedForTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isUseModifiedForTransientDeliveryErrors();
+      }
+
+      @Override
+      protected boolean isDrainOnTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isDrainOnTransientDeliveryErrors();
+      }
+
+      @Override
+      protected int getLinkQuiesceTimeout(AMQPConnectionContext connection) {
+         return configuration.getLinkQuiesceTimeout();
+      }
+
+      @Override
       protected Runnable createCreditRunnable(AMQPConnectionContext connection) {
          // We defer to the configuration instance as opposed to the base class version that reads
          // from the connection this allows us to defer to configured policy properties that specify

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationConnectTest.java
@@ -55,7 +55,10 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPF
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_LINK_QUIESCE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
 import static org.hamcrest.CoreMatchers.allOf;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -256,6 +259,9 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       final boolean AMQP_INGNORE_CONSUMER_FILTERS = false;
       final boolean AMQP_INGNORE_CONSUMER_PRIORITIES = false;
       final boolean AMQP_INGNORE_ADDRESS_BINDING_FILTERS = false;
+      final boolean AMQP_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS = false;
+      final int AMQP_RECEIVER_LINK_QUIESCE_TIMEOUT = 250_000;
+      final boolean AMQP_RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS = false;
 
       final Map<String, Object> federationConfiguration = new HashMap<>();
       federationConfiguration.put(RECEIVER_CREDITS, AMQP_CREDITS);
@@ -270,6 +276,9 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
       federationConfiguration.put(IGNORE_QUEUE_CONSUMER_PRIORITIES, AMQP_INGNORE_CONSUMER_PRIORITIES);
       federationConfiguration.put(IGNORE_ADDRESS_BINDING_FILTERS, AMQP_INGNORE_ADDRESS_BINDING_FILTERS);
       federationConfiguration.put(AmqpSupport.TUNNEL_CORE_MESSAGES, AMQP_TUNNEL_CORE_MESSAGES);
+      federationConfiguration.put(USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS, AMQP_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS);
+      federationConfiguration.put(RECEIVER_LINK_QUIESCE_TIMEOUT, AMQP_RECEIVER_LINK_QUIESCE_TIMEOUT);
+      federationConfiguration.put(RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS, AMQP_RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS);
 
       final String controlLinkAddress = "test-control-address";
 
@@ -310,6 +319,9 @@ public class AMQPFederationConnectTest extends AmqpClientTestSupport {
          federation.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, AMQP_QUEUE_RECEIVER_IDLE_TIMEOUT);
          federation.addProperty(IGNORE_QUEUE_CONSUMER_PRIORITIES, Boolean.toString(AMQP_INGNORE_CONSUMER_PRIORITIES));
          federation.addProperty(IGNORE_ADDRESS_BINDING_FILTERS, Boolean.toString(AMQP_INGNORE_ADDRESS_BINDING_FILTERS));
+         federation.addProperty(USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS, Boolean.toString(AMQP_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS));
+         federation.addProperty(RECEIVER_LINK_QUIESCE_TIMEOUT, AMQP_RECEIVER_LINK_QUIESCE_TIMEOUT);
+         federation.addProperty(RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS, Boolean.toString(AMQP_RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS));
          amqpConnection.addElement(federation);
          server.getConfiguration().addAMQPConnection(amqpConnection);
          server.start();


### PR DESCRIPTION
…y default

AMQP Federation receiver links configure themselves to a default of sending a modified disposition for address full errors to allow the remote sender to redeliver the message instead of the broker default which is to send rejected dispositions meaning the remote must discard or DLQ the message. Allows for configuration at the federation policy level to override this and ignore the connector URI as this is an opinionated configuration for federation resources.