### PR TITLE
ARTEMIS-5656 Prevent federation from creating self sustaining loops

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationLocalPolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationLocalPolicyManager.java
@@ -27,6 +27,7 @@ import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerBindingPlugi
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumer;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationReceiveFromResourcePolicy;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -104,10 +105,23 @@ public abstract class AMQPFederationLocalPolicyManager extends AMQPFederationPol
       // need to capture in the current configuration state.
       configuration = new AMQPFederationConsumerConfiguration(federation.getConfiguration(), getPolicy().getProperties());
 
+      updateStateAfterConnect(configuration, session);
+
       if (isActive()) {
          scanAllBindings();
       }
    }
+
+   /**
+    * Allows the policy manager implementation to update internal state after (re)connection and before the
+    * policy manager triggers a scan of all bindings to check for existing or new demand.
+    *
+    * @param configuration
+    *    The updated configuration based on the current connection.
+    * @param session
+    *    The session that matches the current connection.
+    */
+   protected abstract void updateStateAfterConnect(AMQPFederationConsumerConfiguration configuration, AMQPSessionContext session);
 
    /**
     * Scans all bindings and push them through the normal bindings checks that would be done on an add. This allows for

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueuePolicyManager.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/federation/AMQPFederationQueuePolicyManager.java
@@ -39,6 +39,7 @@ import org.apache.activemq.artemis.core.server.plugin.ActiveMQServerConsumerPlug
 import org.apache.activemq.artemis.core.transaction.Transaction;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationReceiveFromQueuePolicy;
+import org.apache.activemq.artemis.protocol.amqp.proton.AMQPSessionContext;
 import org.apache.activemq.artemis.protocol.amqp.federation.FederationConsumerInfo.Role;
 import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.slf4j.Logger;
@@ -146,6 +147,11 @@ public final class AMQPFederationQueuePolicyManager extends AMQPFederationLocalP
             .filter(b -> b instanceof QueueBinding)
             .map(b -> (QueueBinding) b)
             .forEach(b -> checkQueueForMatch(b.getQueue()));
+   }
+
+   @Override
+   protected void updateStateAfterConnect(AMQPFederationConsumerConfiguration configuration, AMQPSessionContext session) {
+      // No state needs updated currently on a per connection basis.
    }
 
    private void checkQueueForMatch(Queue queue) {


### PR DESCRIPTION
Prevent a federation source from considering bindings from its target to be demand that creates federation receivers in the opposite direction. This will prevent self sustaining local and remote federation links that route messages to the other side when there is no active consumer there to ever receive the messages sent which creates unnecessary traffic.