### PR TITLE
ARTEMIS-5669 AMQP bridge receivers prefer modified dispositions by de…

### DIFF
--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConfiguration.java
@@ -30,6 +30,9 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridg
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_LINK_QUIESCE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.AUTO_DELETE_DURABLE_SUBSCRIPTION;
@@ -55,6 +58,7 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridg
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_SEND_SETTLED;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DISABLE_RECEIVER_DEMAND_TRACKING;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_CONSUMER_FILTERS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.DEFAULT_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
@@ -376,6 +380,48 @@ public class AMQPBridgeConfiguration {
          return Boolean.parseBoolean((String) property);
       } else {
          return DEFAULT_PREFER_SHARED_DURABLE_SUBSCRIPTIONS;
+      }
+   }
+
+   /**
+    * (@return the use modified for transient delivery errors configuration}
+    */
+   public boolean isUseModifiedForTransientDeliveryErrors() {
+      final Object property = properties.get(USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return DEFAULT_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
+      }
+   }
+
+   /**
+    * (@return the drain link credit on transient delivery errors configuration}
+    */
+   public boolean isDrainOnTransientDeliveryErrors() {
+      final Object property = properties.get(RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return connection.getProtocolManager().isDrainOnTransientDeliveryErrors();
+      }
+   }
+
+   /**
+    * {@return the bridge receiver link quiesce timeout configuration}
+    */
+   public int getLinkQuiesceTimeout() {
+      final Object property = properties.get(RECEIVER_LINK_QUIESCE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return connection.getProtocolManager().getLinkQuiesceTimeout();
       }
    }
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConstants.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeConstants.java
@@ -271,7 +271,7 @@ public final class AMQPBridgeConstants {
    /**
     * Default value for the auto delete address sender durable subscription binding.
     */
-   public static boolean DEFAULT_AUTO_DELETE_DURABLE_SUBSCRIPTION = false;
+   public static final boolean DEFAULT_AUTO_DELETE_DURABLE_SUBSCRIPTION = false;
 
    /**
     * Encodes a boolean value that indicates if AMQP bridge senders should configure an auto delete option
@@ -284,7 +284,7 @@ public final class AMQPBridgeConstants {
    /**
     * Default value for the auto delete address sender message count for durable subscription bindings.
     */
-   public static long DEFAULT_AUTO_DELETE_DURABLE_SUBSCRIPTION_MSG_COUNT = 0;
+   public static final long DEFAULT_AUTO_DELETE_DURABLE_SUBSCRIPTION_MSG_COUNT = 0;
 
    /**
     * Encodes a signed long value that controls the delay before auto deletion if using durable address
@@ -295,12 +295,43 @@ public final class AMQPBridgeConstants {
    /**
     * Default value for the auto delete address sender message count for durable subscription bindings.
     */
-   public static long DEFAULT_AUTO_DELETE_DURABLE_SUBSCRIPTION_DELAY = 0;
+   public static final long DEFAULT_AUTO_DELETE_DURABLE_SUBSCRIPTION_DELAY = 0;
 
    /**
     * Encodes a signed long value that controls the message count value that allows for address auto delete
     * if using durable address subscriptions for bridge to address senders.
     */
    public static final String AUTO_DELETE_DURABLE_SUBSCRIPTION_DELAY = "auto-delete-durable-subscription-delay";
+
+   /**
+    * Configuration property for how a bridge receiver should respond to delivery errors indicating that an address is
+    * full and cannot accept messages at this time. By default we want to send Modified outcomes with the delivery failed
+    * value set to true such that the remote will deliver the message again after incrementing the delivery count of the
+    * message.
+    */
+   public static final String USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS = "amqpUseModifiedForTransientDeliveryErrors";
+
+   /**
+    * Default value for how a bridge receiver should respond to delivery errors indicating that an address is full
+    * and cannot accept messages at this time. By default we want to send Modified outcomes with the delivery failed
+    * value set to true such that the remote will deliver the message again after incrementing the delivery count of
+    * the message. This is an opinionated choice and the value set on the connector URI is not referenced by bridges
+    * as we want to maintain this behavior unless specifically set on bridge configuration explicitly.
+    */
+   public static final boolean DEFAULT_USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS = true;
+
+   /**
+    * Configuration property that defines the time in milliseconds that a receiver will wait before considering a pending
+    * quiesce timeout to have failed and should close the link. This option can be used to override the value specified on
+    * the connector URI to allow bridges to operate with a different default.
+    */
+   public static final String RECEIVER_LINK_QUIESCE_TIMEOUT = "amqpLinkQuiesceTimeout";
+
+   /**
+    * Configuration property that defines if a bridge receiver should drain the link credit when a transient delivery
+    * error such as the address being full occurs. This option can be used to override the value specified on the
+    * connector URI to allow bridges to operate with a different default.
+    */
+   public static final String RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS = "amqpDrainOnTransientDeliveryErrors";
 
 }

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromAddressReceiver.java
@@ -277,6 +277,21 @@ public class AMQPBridgeFromAddressReceiver extends AMQPBridgeReceiver {
       }
 
       @Override
+      protected boolean isUseModifiedForTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isUseModifiedForTransientDeliveryErrors();
+      }
+
+      @Override
+      protected boolean isDrainOnTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isDrainOnTransientDeliveryErrors();
+      }
+
+      @Override
+      protected int getLinkQuiesceTimeout(AMQPConnectionContext connection) {
+         return configuration.getLinkQuiesceTimeout();
+      }
+
+      @Override
       protected Runnable createCreditRunnable(AMQPConnectionContext connection) {
          // We defer to the configuration instance as opposed to the base class version that reads
          // from the connection this allows us to defer to configured policy properties that specify

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueueReceiver.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeFromQueueReceiver.java
@@ -236,6 +236,21 @@ public class AMQPBridgeFromQueueReceiver extends AMQPBridgeReceiver {
       }
 
       @Override
+      protected boolean isUseModifiedForTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isUseModifiedForTransientDeliveryErrors();
+      }
+
+      @Override
+      protected boolean isDrainOnTransientDeliveryErrors(AMQPConnectionContext connection) {
+         return configuration.isDrainOnTransientDeliveryErrors();
+      }
+
+      @Override
+      protected int getLinkQuiesceTimeout(AMQPConnectionContext connection) {
+         return configuration.getLinkQuiesceTimeout();
+      }
+
+      @Override
       public void close(boolean remoteLinkClose) throws ActiveMQAMQPException {
          super.close(remoteLinkClose);
 

--- a/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverConfiguration.java
+++ b/artemis-protocols/artemis-amqp-protocol/src/main/java/org/apache/activemq/artemis/protocol/amqp/connect/bridge/AMQPBridgeReceiverConfiguration.java
@@ -21,7 +21,10 @@ import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridg
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.IGNORE_QUEUE_FILTERS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_CREDITS_LOW;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_LINK_QUIESCE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.RECEIVER_QUIESCE_TIMEOUT;
+import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.PULL_RECEIVER_BATCH_SIZE;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.QUEUE_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.bridge.AMQPBridgeConstants.LARGE_MESSAGE_THRESHOLD;
@@ -208,6 +211,48 @@ public final class AMQPBridgeReceiverConfiguration extends AMQPBridgeLinkConfigu
          return Boolean.parseBoolean((String) property);
       } else {
          return configuration.isPreferSharedDurableSubscriptions();
+      }
+   }
+
+   /**
+    * (@return the use modified for transient delivery errors configuration}
+    */
+   public boolean isUseModifiedForTransientDeliveryErrors() {
+      final Object property = properties.get(USE_MODIFIED_FOR_TRANSIENT_DELIVERY_ERRORS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return configuration.isUseModifiedForTransientDeliveryErrors();
+      }
+   }
+
+   /**
+    * (@return the drain link credit on transient delivery errors configuration}
+    */
+   public boolean isDrainOnTransientDeliveryErrors() {
+      final Object property = properties.get(RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS);
+      if (property instanceof Boolean booleanValue) {
+         return booleanValue;
+      } else if (property instanceof String string) {
+         return Boolean.parseBoolean(string);
+      } else {
+         return configuration.isDrainOnTransientDeliveryErrors();
+      }
+   }
+
+   /**
+    * {@return the federation receiver link quiesce timeout configuration}
+    */
+   public int getLinkQuiesceTimeout() {
+      final Object property = properties.get(RECEIVER_LINK_QUIESCE_TIMEOUT);
+      if (property instanceof Number number) {
+         return number.intValue();
+      } else if (property instanceof String string) {
+         return Integer.parseInt(string);
+      } else {
+         return configuration.getLinkQuiesceTimeout();
       }
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/connect/AMQPFederationQueuePolicyTest.java
@@ -90,7 +90,6 @@ import org.slf4j.LoggerFactory;
 
 import static org.apache.activemq.artemis.core.config.WildcardConfiguration.DEFAULT_WILDCARD_CONFIGURATION;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConfiguration.DEFAULT_PULL_CREDIT_BATCH_SIZE;
-import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADDRESS_RECEIVER_IDLE_TIMEOUT;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.ADD_QUEUE_POLICY;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.EVENT_TYPE;
 import static org.apache.activemq.artemis.protocol.amqp.connect.federation.AMQPFederationConstants.FEDERATION_CONFIGURATION;
@@ -5458,7 +5457,6 @@ public class AMQPFederationQueuePolicyTest extends AmqpClientTestSupport {
          final AMQPFederatedBrokerConnectionElement element = new AMQPFederatedBrokerConnectionElement();
          element.setName(getTestName());
          element.addLocalQueuePolicy(receiveFromQueue);
-         element.addProperty(ADDRESS_RECEIVER_IDLE_TIMEOUT, 0);
          element.addProperty(RECEIVER_DRAIN_ON_TRANSIENT_DELIVERY_ERRORS, String.valueOf(drainOnFull));
          element.addProperty(RECEIVER_LINK_QUIESCE_TIMEOUT, 350);
          element.addProperty(QUEUE_RECEIVER_IDLE_TIMEOUT, 0);


### PR DESCRIPTION
…fault

AMQP Bridge receiver links configure themselves to a default of sending a modified disposition for address full errors to allow the remote sender to redeliver the message instead of the broker default which is to send rejected dispositions meaning the remote must discard or DLQ the message. Allows for configuration at the bridge policy level to override this and ignore the connector URI as this is an opinionated configuration for bridged resources. Also adds ability to configure the drain on address full and delivery is rejected at the bridge configuration level.