### PR TITLE
ARTEMIS-5672 fix AddressManager leaks

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/AddressMap.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/AddressMap.java
@@ -45,6 +45,10 @@ public class AddressMap<T> {
       return address.getPaths(DELIMITER);
    }
 
+   public AddressPartNode<T> getRootNode() {
+      return rootNode;
+   }
+
    /**
     * @param address a non wildcard to match against wildcards in the map
     */

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/SimpleAddressManager.java
@@ -417,7 +417,9 @@ public class SimpleAddressManager implements AddressManager {
 
    @Override
    public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
-      return addressInfoMap.remove(CompositeAddress.extractAddressName(address));
+      SimpleString realAddress = CompositeAddress.extractAddressName(address);
+      mappings.remove(realAddress);
+      return addressInfoMap.remove(realAddress);
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/WildcardAddressManager.java
@@ -22,8 +22,10 @@ import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.postoffice.Binding;
 import org.apache.activemq.artemis.core.postoffice.Bindings;
 import org.apache.activemq.artemis.core.postoffice.BindingsFactory;
+import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.server.metrics.MetricsManager;
 import org.apache.activemq.artemis.core.transaction.Transaction;
+import org.apache.activemq.artemis.utils.CompositeAddress;
 
 /**
  * extends the simple manager to allow wildcard addresses to be used.
@@ -146,5 +148,12 @@ public class WildcardAddressManager extends SimpleAddressManager {
 
    public AddressMap<Bindings> getAddressMap() {
       return addressMap;
+   }
+
+   @Override
+   public AddressInfo removeAddressInfo(SimpleString address) throws Exception {
+      SimpleString realAddress = CompositeAddress.extractAddressName(address);
+      addressMap.remove(realAddress, super.getBindingsForRoutingAddress(realAddress));
+      return super.removeAddressInfo(address);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/WildCardRoutingTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/WildCardRoutingTest.java
@@ -16,10 +16,6 @@
  */
 package org.apache.activemq.artemis.tests.integration.client;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
@@ -34,6 +30,10 @@ import org.apache.activemq.artemis.core.server.ActiveMQServers;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 public class WildCardRoutingTest extends ActiveMQTestBase {
 
@@ -215,9 +215,8 @@ public class WildCardRoutingTest extends ActiveMQTestBase {
       ClientConsumer clientConsumer = clientSession.createConsumer(queueName);
       clientSession.start();
       clientSession.deleteQueue(queueName1);
-      // the wildcard binding should still exist
-      assertEquals(1, server.getPostOffice().getBindingsForAddress(addressAB).getBindings().size());
       producer.send(createTextMessage(clientSession, "m1"));
+      assertEquals(1, server.getPostOffice().getBindingsForAddress(addressAB).getBindings().size());
       producer2.send(createTextMessage(clientSession, "m2"));
       ClientMessage m = clientConsumer.receive(500);
       assertNotNull(m);


### PR DESCRIPTION
I removed a test that was asserting the exact behavior that this commit fixes. Once an address is removed the broker should not keep track of any related address-to-binding mappings, etc.