### PR TITLE
ARTEMIS-5725 parameterize project name in the docs

### DIFF
--- a/artemis-website/pom.xml
+++ b/artemis-website/pom.xml
@@ -381,6 +381,9 @@
 
                         <!-- Version substitution attributes -->
                         <project-version>${project.version}</project-version>
+                        <project-name-full>Apache ActiveMQ Artemis</project-name-full>
+                        <project-name-full-url>apache-activemq-artemis</project-name-full-url>
+                        <project-name-short>ActiveMQ Artemis</project-name-short>
                         <log4j-version>${log4j.version}</log4j-version>
                      </attributes>
                      <logHandler>

--- a/docs/hacking-guide/_building.adoc
+++ b/docs/hacking-guide/_building.adoc
@@ -64,11 +64,15 @@ $ mvn -o ...
 
 == Building the ASYNC IO library
 
-ActiveMQ Artemis provides the `ASYNCIO` `journal-type` which interacts with the Linux kernel libaio library. The ASYNCIO journal type should be used where possible as it is far superior in terms of performance.
+The `ASYNCIO` `journal-type` which interacts with the Linux kernel libaio library.
+The ASYNCIO journal type should be used where possible as it is far superior in terms of performance.
 
-ActiveMQ Artemis does not ship with the Artemis Native ASYNCIO library in the _source_ distribution. This need to be built prior to running `mvn install`, to ensure that the ASYNCIO journal type is available in the resulting build. Don't worry if you don't want to use ASYNCIO or your system does not support libaio, ActiveMQ Artemis will check at runtime to see if the required libraries and system dependencies are available, if not it will default to using NIO.
+The ASYNCIO native library is not included in the broker _source_ distribution.
+It needs to be built prior to running `mvn install` to ensure that the ASYNCIO journal type is available in the resulting build.
+Don't worry if you don't want to use ASYNCIO or your system does not support libaio.
+The broker will check at runtime to see if the required libraries and system dependencies are available and, if not, it will default to using NIO.
 
-To build the ActiveMQ Artemis ASYNCIO native libraries, please follow link:https://github.com/apache/activemq-artemis-native[these instructions].
+To build the ASYNCIO native libraries, please follow link:https://github.com/apache/activemq-artemis-native[these instructions].
 
 == Open Web Application Security Project (OWASP) Report
 

--- a/docs/hacking-guide/_code-coverage-report.adoc
+++ b/docs/hacking-guide/_code-coverage-report.adoc
@@ -19,9 +19,9 @@ $ mvn verify -Pjacoco-generate-report -DskipTests
 For generating JaCoCo reports only run the maven build with profile `jacoco-generate-report` as it is shown in the example above.
 After the command was executed, in directory `target/jacoco-report` you can find reports in HTML and XML formats.
 
-== Merge JaCoCo exec files to one
+== Merge JaCoCo exec files into one
 
-Since ActiveMQ Artemis is divided into several modules, exec files are generated for each module separately.
+JaCoCo exec files are generated for each module separately.
 If you need to merge them together to have all data in one place, you can do it by command below.
 [,console]
 ----

--- a/docs/hacking-guide/_code.adoc
+++ b/docs/hacking-guide/_code.adoc
@@ -1,6 +1,6 @@
 = Working with the Code
 
-While the canonical Apache ActiveMQ Artemis git repository is hosted on Apache hardware at https://gitbox.apache.org/repos/asf/activemq-artemis.git contributors are encouraged (but not required) to use a mirror on GitHub for collaboration and pull-request review functionality.
+While the canonical git repository is hosted on Apache hardware at https://gitbox.apache.org/repos/asf/activemq-artemis.git contributors are encouraged (but not required) to use a mirror on GitHub for collaboration and pull-request review functionality.
 Follow the steps below to get set up with GitHub, etc.
 
 If you do not wish to use GitHub for whatever reason you can follow the overall process outlined in the "Typical development cycle" section below but instead attach https://git-scm.com/docs/git-format-patch[a patch file] to the related JIRA or an email to the http://activemq.apache.org/mailing-lists.html[dev list].
@@ -86,7 +86,7 @@ $ git commit
 [#commitMessageDetails]
 When you commit your changes you will need to supply a commit message.
 We follow the  50/72 git commit message format as recommended in the https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project[official Git book].
-An ActiveMQ Artemis commit message should be formatted in the following manner:
+The commit message should be formatted in the following manner:
 
 .. Add the first line with the summary, using maximum 50 characters.
 Start the summary with the jira key (ARTEMIS-XXX) followed by a brief description of the change.
@@ -184,8 +184,8 @@ You might need to specify `-f` to force the changes.
 Due to incompatibilities between some open source licenses and the Apache v2.0 license (that this project is licensed under) care must be taken when adding new dependencies to the project.
 The Apache Software Foundation 3rd party licensing  policy has more information here: https://www.apache.org/legal/3party.html
 
-To keep track of all licenses in ActiveMQ Artemis, new dependencies must be added in either the top level `pom.xml` or in `test/pom.xml` (depending on whether this is a test only dependency or if it is used in the main code base).
-The dependency should be added under the dependency management section with version and labelled with a comment highlighting the license for the dependency version.
+To keep track of all licenses, new dependencies must be added in either the top level `pom.xml` or in `test/pom.xml` (depending on whether this is a test-only dependency or if it is used in the main code base).
+The dependency should be added under the dependency management section with version and labeled with a comment highlighting the license for the dependency version.
 See existing dependencies in the main `pom.xml` for examples.
-The dependency can then be added to individual ActiveMQ Artemis modules _without_ the version specified (the version is implied from the dependency management section of the top level pom).
-This allows ActiveMQ Artemis developers to keep track of all dependencies and licenses.
+The dependency can then be added to individual modules _without_ the version specified (the version is implied from the dependency management section of the top level pom).
+This allows developers to keep track of all dependencies and licenses.

--- a/docs/hacking-guide/_history.adoc
+++ b/docs/hacking-guide/_history.adoc
@@ -1,8 +1,7 @@
 = History
 
-The Apache ActiveMQ Artemis project was started in October 2014.
-The Artemis code base was seeded with a code donation granted by Red Hat, of the HornetQ project.
-The code donation process consisted of taking a snapshot of the latest HornetQ code base and contributing this snapshot as an https://issues.apache.org/jira/browse/ARTEMIS-1[initial git commit] into the Artemis git repository.
+In October 2014 the {project-name-full} code-base was seeded with a donation of the HornetQ project from Red Hat.
+The code donation process consisted of taking a snapshot of the latest HornetQ code base and contributing it as the https://issues.apache.org/jira/browse/ARTEMIS-1[initial commit] into the corresponding Git repository.
 
 The HornetQ commit history is preserved and can be accessed here: https://github.com/hornetq/hornetq/tree/apache-donation
 

--- a/docs/hacking-guide/_maintainers.adoc
+++ b/docs/hacking-guide/_maintainers.adoc
@@ -1,8 +1,8 @@
 = Notes for Maintainers
 
-ActiveMQ Artemis committers have write access to the Apache ActiveMQ Artemis repositories and will be responsible for acknowledging and pushing commits contributed via pull requests on GitHub.
+Committers have write access to all project repositories and will be responsible for acknowledging and pushing commits contributed via pull requests on GitHub.
 
-Core ActiveMQ Artemis members are also able to push their own commits directly to the canonical Apache repository.
+Core members are also able to push their own commits directly to the canonical Apache repository.
 However, the expectation here is that the developer has made a good effort to test their changes and is reasonably confident that the changes that are being committed will not break the build.
 
 What does it mean to be reasonably confident?

--- a/docs/hacking-guide/_validating-releases.adoc
+++ b/docs/hacking-guide/_validating-releases.adoc
@@ -60,7 +60,7 @@ After you configure this, all the maven objects will be available to your builds
 
 == Using the examples
 
-The Apache ActiveMQ Artemis examples will create servers and use most of the maven components as real application were supposed to do.
+The examples will create servers and use most of the maven components as real application were supposed to do.
 You can do this by running these examples after the `.m2` profile installations for the staged repository.
 
-Of course you can use your own applications after you have staged the maven repository.
+Of course, you can use your own applications after you have staged the maven repository.

--- a/docs/hacking-guide/index.adoc
+++ b/docs/hacking-guide/index.adoc
@@ -1,6 +1,6 @@
-= Apache ActiveMQ Artemis Hacking Guide
+= {project-name-full} Hacking Guide
 
-This hacking guide outlines how developers can get involved in contributing to the Apache ActiveMQ Artemis project.
+This hacking guide outlines how developers can get involved in contributing to the {project-name-full} project.
 
 include::_code.adoc[leveloffset=1]
 include::_building.adoc[leveloffset=1]

--- a/docs/migration-guide/_authentication.adoc
+++ b/docs/migration-guide/_authentication.adoc
@@ -1,12 +1,12 @@
 = Authentication
 
 Now that we have our acceptors and addresses ready, it's time to deal with broker security.
-Artemis inherited most of the security concepts from ActiveMQ.
-One of the most notable differences is that ActiveMQ _groups_ are now called _roles_ in Artemis.
+{project-name-short} inherited most of the security concepts from ActiveMQ.
+One of the most notable differences is that ActiveMQ _groups_ are now called _roles_ in {project-name-short}.
 Besides that things should be pretty familiar to existing ActiveMQ users.
 Let's start by looking into the authentication mechanisms and defining users and roles (groups).
 
-Both ActiveMQ and Artemis use JAAS to define authentication credentials.
+Both ActiveMQ and {project-name-short} use JAAS to define authentication credentials.
 In ActiveMQ, that's configured through the appropriate broker plugin in `conf/activemq.xml`
 
 [,xml]
@@ -18,7 +18,7 @@ In ActiveMQ, that's configured through the appropriate broker plugin in `conf/ac
 
 The name of the JAAS domain is specified as a configuration parameter.
 
-In Artemis, the same thing is achieved by defining `<jaas-security>` configuration in `etc/bootstrap.xml`
+In {project-name-short}, the same thing is achieved by defining `<jaas-security>` configuration in `etc/bootstrap.xml`
 
 [,xml]
 ----
@@ -26,10 +26,10 @@ In Artemis, the same thing is achieved by defining `<jaas-security>` configurati
 ----
 
 From this point on, you can go and define your users and their roles in appropriate files, like `conf/users.properties` and `conf/groups.properties` in ActiveMQ.
-Similarly, `etc/artemis-users.properties` and `etc/artemis-roles.properties` files are used in Artemis.
+Similarly, `etc/artemis-users.properties` and `etc/artemis-roles.properties` files are used in {project-name-short}.
 These files are interchangeable, so you should be able to just copy your existing configuration over to the new broker.
 
 If your deployment is more complicated than this and requires some advanced JAAS configuration, you'll need go and change the `etc/login.config` file.
-It's important to say that all custom JAAS modules and configuration you were using in ActiveMQ should be compatible with Artemis.
+It's important to say that all custom JAAS modules and configuration you were using in ActiveMQ should be compatible with {project-name-short}.
 
-Finally, in case you're still using ActiveMQ's _Simple Authentication Plugin_, which defines users and groups directly in the broker's xml configuration file, you'll need to migrate to JAAS as Artemis doesn't support the similar concept.
+Finally, in case you're still using ActiveMQ's _Simple Authentication Plugin_, which defines users and groups directly in the broker's xml configuration file, you'll need to migrate to JAAS as {project-name-short} doesn't support the similar concept.

--- a/docs/migration-guide/_authorization.adoc
+++ b/docs/migration-guide/_authorization.adoc
@@ -22,7 +22,7 @@ In ActiveMQ, authorization is specified using the appropriate broker plugin in `
 </authorizationPlugin>
 ----
 
-The equivalent Artemis configuration is specified in `etc/broker.xml` and should look like this
+The equivalent {project-name-short} configuration is specified in `etc/broker.xml` and should look like this
 
 [,xml]
 ----
@@ -60,24 +60,24 @@ The equivalent Artemis configuration is specified in `etc/broker.xml` and should
 ----
 
 As you can see, things are pretty comparable with some minor differences.
-The most important one is that policies in ActiveMQ are defined on destination names, while in Artemis they are applied to _core queues_ (refresh your knowledge about relation between queues and addresses in previous sections and Artemis user manual).
+The most important one is that policies in ActiveMQ are defined on destination names, while in {project-name-short} they are applied to _core queues_ (refresh your knowledge about relation between queues and addresses in previous sections and {project-name-short} user manual).
 
-The other notable difference is that policies are more fine-grained in Artemis.
-The following paragraphs and tables show Artemis policies that corresponds to ActiveMQ ones.
+The other notable difference is that policies are more fine-grained in {project-name-short}.
+The following paragraphs and tables show {project-name-short} policies that corresponds to ActiveMQ ones.
 
 If you wish to allow users to send messages, you need to define the following policies in the respective brokers.
 
 |===
-| ActiveMQ | Artemis
+| ActiveMQ | {project-name-short}
 
 | write
 | send
 |===
 
-In Artemis, policies for consuming and browsing are separated and you need to define them both in order to control `read` access to the destination.
+In {project-name-short}, policies for consuming and browsing are separated and you need to define them both in order to control `read` access to the destination.
 
 |===
-| ActiveMQ | Artemis
+| ActiveMQ | {project-name-short}
 
 | read
 | consume
@@ -90,7 +90,7 @@ It's the same story with `admin` privileges.
 You need to define separate create and delete policies for durable and non-durable core queues.
 
 |===
-| ActiveMQ | Artemis
+| ActiveMQ | {project-name-short}
 
 | admin
 | createNonDurableQueue
@@ -109,7 +109,7 @@ Finally, there's a topic of using wildcards to define policies.
 The following table shows the wildcard syntax difference.
 
 |===
-| Wildcard | Description | ActiveMQ | Artemis
+| Wildcard | Description | ActiveMQ | {project-name-short}
 
 | Delimiter
 | Separates words in the path
@@ -127,6 +127,6 @@ The following table shows the wildcard syntax difference.
 | #
 |===
 
-Basically, by default only the _any word_ character is different, so that's why we used `GUESTS.#` in Artemis example instead of ActiveMQ's `GUESTS.>` syntax.
+Basically, by default only the _any word_ character is different, so that's why we used `GUESTS.#` in {project-name-short} example instead of ActiveMQ's `GUESTS.>` syntax.
 
-Powered with this knowledge, you should be able to transform your current ActiveMQ authorization policies to Artemis.
+Powered with this knowledge, you should be able to transform your current ActiveMQ authorization policies to {project-name-short}.

--- a/docs/migration-guide/_configuration.adoc
+++ b/docs/migration-guide/_configuration.adoc
@@ -1,10 +1,10 @@
 = Configuration
 
 Once we download and install the broker we run into the first difference.
-With Artemis, you need to explicitly create a broker instance, while on ActiveMQ this step is optional.
+With {project-name-short}, you need to explicitly create a broker instance, while on ActiveMQ this step is optional.
 The whole idea of this step is to keep installation and configuration of the broker separate, which makes it easier to upgrade and maintain the broker in the future.
 
-So in order to start with Artemis you need execute something like this
+So in order to start with {project-name-short} you need execute something like this
 
 $ bin/artemis create --user admin --password admin --role admins --allow-anonymous true /opt/artemis
 
@@ -14,7 +14,7 @@ The content of this directory will be familiar to every ActiveMQ user:
 * `bin` - contains shell scripts for managing the broker(start, stop, etc.)
 * `data` - is where the broker state lives (message store)
 * `etc` - contains broker configuration file (it's what `conf` directory is in ActiveMQ)
-* `log` - Artemis stores logs in this separate directory, unlike ActiveMQ which keeps them in `data` directory
+* `log` - {project-name-short} stores logs in this separate directory, unlike ActiveMQ which keeps them in `data` directory
 * `tmp` - is utility directory for temporary files
 
 Let's take a look now at the configuration in more details.
@@ -34,7 +34,7 @@ The `etc/log4j2-utility.properties` file is where it's all configured for all CL
 
 Finally, we have JAAS configuration files (`login.config`, `artemis-users.properties` and `artemis-roles.properties`), which cover same roles as in ActiveMQ and we will go into more details on these in the article that covers security.
 
-After this brief walk through the location of different configuration aspects of Artemis, we're ready to start the broker.
+After this brief walk through the location of different configuration aspects of {project-name-short}, we're ready to start the broker.
 If you wish to start the broker in the foreground, you should execute
 
 [,sh]
@@ -51,7 +51,7 @@ $ bin/activemq console
 
 command in ActiveMQ.
 
-For running the broker as a service, Artemis provides a separate shell script `bin/artemis-service`.
+For running the broker as a service, {project-name-short} provides a separate shell script `bin/artemis-service`.
 So you can run the broker in the background like
 
 [,sh]
@@ -68,8 +68,8 @@ $ bin/activemq start
 
 After the start, you can check the broker status in `logs/artemis.log` file.
 
-Congratulations, you have your Artemis broker up and running.
-By default, Artemis starts _Openwire_ connector on the same port as ActiveMQ, so clients can connect.
+Congratulations, you have your {project-name-short} broker up and running.
+By default, {project-name-short} starts _Openwire_ connector on the same port as ActiveMQ, so clients can connect.
 To test this you can go to your existing ActiveMQ instance and run the following commands.
 
 [,sh]
@@ -86,5 +86,5 @@ Finally, we can stop the broker with
 $ bin/artemis-service stop
 ----
 
-With this, our orienteering session around Artemis is finished.
+With this, our orienteering session around {project-name-short} is finished.
 In the following articles we'll start digging deeper into the configuration details and differences between two brokers and see how that can affect your messaging applications.

--- a/docs/migration-guide/_connectors.adoc
+++ b/docs/migration-guide/_connectors.adoc
@@ -1,7 +1,7 @@
 = Connectors
 
 After broker is started, you'll want to connect your clients to it.
-So, let's start with comparing ActiveMQ and Artemis configurations in area of client connectors.
+So, let's start with comparing ActiveMQ and {project-name-short} configurations in area of client connectors.
 In ActiveMQ terminology, they are called _transport connectors_, and the default configuration looks something like this (in `conf/activemq.xml`).
 
 [,xml]
@@ -15,7 +15,7 @@ In ActiveMQ terminology, they are called _transport connectors_, and the default
 </transportConnectors>
 ----
 
-In Artemis, client connectors are called _acceptors_ and they are configured in `etc/broker.xml` like this
+In {project-name-short}, client connectors are called _acceptors_ and they are configured in `etc/broker.xml` like this
 
 [,xml]
 ----
@@ -29,22 +29,22 @@ In Artemis, client connectors are called _acceptors_ and they are configured in 
 ----
 
 As you can notice the syntax is very similar, but there are still some differences that we need to understand.
-First, as we said earlier, there's no notion of blocking	and non-blocking (nio) transport in Artemis, so you should treat everything as non-blocking.
-Also, in Artemis the low level transport is distinct from the actual messaging protocol (like AMQP or MQTT) used on top of it.
+First, as we said earlier, there's no notion of blocking	and non-blocking (nio) transport in {project-name-short}, so you should treat everything as non-blocking.
+Also, in {project-name-short} the low level transport is distinct from the actual messaging protocol (like AMQP or MQTT) used on top of it.
 One acceptor can handle multiple messaging protocols on the same port.
 By default, all protocols are accepted on the single port, but you can restrict this using the `protocols=X,Y` uri attribute pattern as shown in the example above.
 
-Besides _tcp_ network protocol, Artemis support _InVm_ and _Web Socket_ transports.
+Besides _tcp_ network protocol, {project-name-short} support _InVm_ and _Web Socket_ transports.
 The _InVm_ transport is similar to ActiveMQ's _vm_ transport and is used to connect clients to the embedded broker.
-The difference is that you can use any messaging protocol on top of _InVm_ transport in Artemis, while _vm_ transport in ActiveMQ is tied to OpenWire.
+The difference is that you can use any messaging protocol on top of _InVm_ transport in {project-name-short}, while _vm_ transport in ActiveMQ is tied to OpenWire.
 
-One of the advantages of using Netty for IO layer, is that Web Sockets are supported out of the box.
-So, there's no need for the separate _ws_ transport like in ActiveMQ, the _tcp_ (Netty) acceptor in Artemis will detect Web Socket clients and handle them accordingly.
+One of the advantages of using Netty for IO layer, is that WebSockets are supported out of the box.
+So, there's no need for the separate _ws_ transport like in ActiveMQ, the _tcp_ (Netty) acceptor in {project-name-short} will detect Web Socket clients and handle them accordingly.
 
-To summarize this topic, here's a table that shows you how to migrate your ActiveMQ transport connectors to the Artemis acceptors
+To summarize this topic, here's a table that shows you how to migrate your ActiveMQ transport connectors to the {project-name-short} acceptors
 
 |===
-| ActiveMQ | Artemis (options in the acceptor URL)
+| ActiveMQ | {project-name-short} (options in the acceptor URL)
 
 | OpenWire
 | protocols=OpenWire (version 10+)

--- a/docs/migration-guide/_destinations.adoc
+++ b/docs/migration-guide/_destinations.adoc
@@ -1,6 +1,6 @@
 = Destinations
 
-We already talked about addressing differences between ActiveMQ and Artemis in the xref:README.adoc[introduction].
+We already talked about addressing differences between ActiveMQ and {project-name-short} in the xref:README.adoc[introduction].
 Now let's dig into the details and see how to configure JMS queues and topics.
 It's important to note here that both brokers are configured by default to _auto-create_ destinations requested by clients, which is preferred behavior for many use cases.
 This is configured using authorization security policies, so we will cover this topic in the later sections of this manual.
@@ -16,13 +16,13 @@ In ActiveMQ, destinations are pre-defined in the `<destinations>` section of the
 </destinations>
 ----
 
-Things looks a bit different in Artemis.
+Things looks a bit different in {project-name-short}.
 We already explained that queues are `anycast` addresses and topics are `multicast` ones.
 We're not gonna go deep into the address settings details here and you're advised to look at the user manual for that.
 Let's just see what we need to do in order to replicate ActiveMQ configuration.
 
 Addresses are defined in `<addresses>` section of the `etc/broker.xml` configuration file.
-So the corresponding Artemis configuration for the ActiveMQ example above, looks like this:
+So the corresponding {project-name-short} configuration for the ActiveMQ example above, looks like this:
 
 [,xml]
 ----

--- a/docs/migration-guide/_key-differences.adoc
+++ b/docs/migration-guide/_key-differences.adoc
@@ -6,14 +6,14 @@ Although they are designed to do the same job, things are done differently inter
 Here are some of the most notable architectural differences you need to be aware of when you're planning the migration.
 
 In ActiveMQ, we have a few different implementations of the IO connectivity layer, like tcp (synchronous one) and nio (non-blocking one).
-In Artemis, the IO layer is implemented using Netty, which is a nio framework.
+In {project-name-short}, the IO layer is implemented using Netty, which is a nio framework.
 This means that there's no more need to choose between different implementations as the non-blocking one is used by default.
 
 The other important part of every broker is a message store.
 Most of the ActiveMQ users are familiar with KahaDB.
 It consists of a message journal for fast sequential storing of messages (and other command packets) and an index for retrieving messages when needed.
 
-Artemis has its own message store.
+{project-name-short} has its own message store.
 It consists only of the append-only message journal.
 Because of the differences in how paging is done, there's no need for the message index.
 We'll talk more about that in a minute.
@@ -29,7 +29,7 @@ When the space become available again, the broker will fill the cache again by p
 Because of this, we need to read the journal from time to time during a broker runtime.
 In order to do that, we need to maintain a journal index, so that messages' position can be tracked inside the journal.
 
-In Artemis, things work differently in this regard.
+In {project-name-short}, things work differently in this regard.
 The whole message journal is kept in memory and messages are dispatched directly from it.
 When we run out of memory, messages are paged _on the producer side_ (before they hit the broker).
 Theay are stored in sequential page files in the same order as they arrived.
@@ -37,7 +37,7 @@ Once the memory is freed, messages are moved from these page files into the jour
 With paging working like this, messages are read from the file journal only when the broker starts up, in order to recreate this in-memory version of the journal.
 In this case, the journal is only read sequentially, meaning that there's no need to keep an index of messages in the journal.
 
-This is one of the main differences between ActiveMQ Classic and Artemis.
+This is one of the main differences between ActiveMQ Classic and {project-name-short}.
 It's important to understand it early on as it affects a lot of destination policy settings and how we configure brokers in order to support these scenarios properly.
 
 == Addressing differences
@@ -47,7 +47,7 @@ ActiveMQ started as an open source JMS implementation, so at its core all JMS co
 It's all based on OpenWire protocol developed within the project and even KahaDB message store is OpenWire centric.
 This means that all other supported protocols, like MQTT and AMQP are translated internally into OpenWire.
 
-Artemis took a different approach.
+{project-name-short} took a different approach.
 It implements only queues internally and all other messaging concepts are achieved by routing messages to appropriate queue(s) using addresses.
 Messaging concepts like publish-subscribe (topics) and point-to-point (queues) are implemented using different type of routing mechanisms on addresses.
 _Multicast_ routing is used to implement _publish-subscribe_ semantics, where all subscribers to a certain address will get their own internal queue and messages will be routed to all of them.

--- a/docs/migration-guide/_message-store.adoc
+++ b/docs/migration-guide/_message-store.adoc
@@ -2,13 +2,13 @@
 
 == ActiveMQ Classic KahaDB or mKahaDB
 
-ActiveMQ Artemis supports an XML format for message store exchange.
+{project-name-short} supports an XML format for message store exchange.
 An existing store may be exported from a broker using the command line tools and subsequently imported to another broker.
 
-The https://github.com/apache/activemq-cli-tools[Apache ActiveMQ Command Line Tools] project provides an command line export tool for ActiveMQ Classic that will export a KahaDB (or mKahaDB) message store into the ActiveMQ Artemis XML format, for subsequent import by ActiveMQ Artemis.
+The https://github.com/apache/activemq-cli-tools[Apache ActiveMQ Command Line Tools] project provides an command line export tool for ActiveMQ Classic that will export a KahaDB (or mKahaDB) message store into the {project-name-short} XML format, for subsequent import by {project-name-short}.
 
 The export tool supports selective export using filters, useful if only some of your data needs to be migrated.
-From version 0.2.0, the export tool has support for virtual topic consumer queue mapping, which will allow existing Openwire virtual topic consumers to resume on an ActiveMQ Artemis broker with no message loss.
+From version 0.2.0, the export tool has support for virtual topic consumer queue mapping, which will allow existing Openwire virtual topic consumers to resume on an {project-name-short} broker with no message loss.
 Note the OpenWire acceptor `virtualTopicConsumerWildcards` option from xref:virtual-topics.adoc[virtual topics migration].
 
 Full details of tool can be found on the project website: https://github.com/apache/activemq-cli-tools

--- a/docs/migration-guide/_preface.adoc
+++ b/docs/migration-guide/_preface.adoc
@@ -1,16 +1,16 @@
 = Preface
 
-As more and more people start using Artemis, it's valuable to have a migration guide that will help experienced ActiveMQ users adapt to the new broker.
+As more and more people start using {project-name-short}, it's valuable to have a migration guide that will help experienced ActiveMQ users adapt to the new broker.
 From outside, two brokers might seem very similar, but there are subtle differences in their inner-workings that can lead to confusions.
 The goal of this guide is to explain these differences and help make a transition.
 
 Migration is a fairly broad term in systems like these, so what are we talking about here?
 This guide will be focused only on broker server migration.
 We'll assume that the current system is a working ActiveMQ Classic broker with OpenWire JMS clients.
-We'll see how we can replace the broker with Artemis and leave the clients intact.
+We'll see how we can replace the broker with {project-name-short} and leave the clients intact.
 
-This guide is aimed at experienced ActiveMQ users that want to learn more about what's different in Artemis.
+This guide is aimed at experienced ActiveMQ users that want to learn more about what's different in {project-name-short}.
 We will assume that you know the concepts that are covered in these articles.
-They will not be explained from the first principles, for that you're advised to see appropriate manuals of the ActiveMQ and Artemis brokers.
+They will not be explained from the first principles, for that you're advised to see appropriate manuals of the ActiveMQ and {project-name-short} brokers.
 
 Before we dig into more details on the migration, let's talk about basic conceptual differences between two brokers.

--- a/docs/migration-guide/_ssl.adoc
+++ b/docs/migration-guide/_ssl.adoc
@@ -1,7 +1,7 @@
 = SSL
 
 The next interesting security related topic is encrypting transport layer using SSL.
-Both ActiveMQ and Artemis leverage JDK's Java Secure Socket Extension (JSSE), so things should be easy to migrate.
+Both ActiveMQ and {project-name-short} leverage JDK's Java Secure Socket Extension (JSSE), so things should be easy to migrate.
 
 Let's recap quickly how SSL is used in ActiveMQ.
 First, you need to define the _SSL Context_.
@@ -26,7 +26,7 @@ After this, you set your transport connector with the `ssl` schema and  preferab
 
 These options are related to https://docs.oracle.com/javase/8/docs/api/javax/net/ssl/SSLServerSocket.html[SSLServerSocket] and are specified as URL parameters with the `transport.` prefix, like `needClientAuth` shown in the example above.
 
-In Artemis, Netty is responsible for all things related to the transport layer, so it handles SSL for us as well.
+In {project-name-short}, Netty is responsible for all things related to the transport layer, so it handles SSL for us as well.
 All configuration options are set directly on the acceptor, like
 
 [,xml]
@@ -41,7 +41,7 @@ Next, we can go ahead and define key and trust stores.
 There's a slight difference in parameter naming between two brokers, as shown in the table below.
 
 |===
-| ActiveMQ | Artemis
+| ActiveMQ | {project-name-short}
 
 | keyStore
 | keyStorePath
@@ -57,6 +57,6 @@ There's a slight difference in parameter naming between two brokers, as shown in
 |===
 
 Finally, you can go and set all other `SSLServerSocket` parameters you need (like `needClientAuth` in this example).
-There's no extra prefix needed for this in Artemis.
+There's no extra prefix needed for this in {project-name-short}.
 
 It's important to note that you should be able to reuse your existing key and trust stores and just copy them to the new broker.

--- a/docs/migration-guide/_virtual-topics.adoc
+++ b/docs/migration-guide/_virtual-topics.adoc
@@ -11,15 +11,15 @@ This means that the subscription is exclusive.
 It is not possible to load balance the stream of messages across consumers and quick failover is difficult because the existing connection state on the broker needs to be first disposed.
 With virtual topics, each subscription's stream of messages is redirected to a queue.
 
-In Artemis there are two alternatives, the new JMS 2.0 api or direct access to a subscription queue via the FQQN.
+In {project-name-short} there are two alternatives, the new JMS 2.0 api or direct access to a subscription queue via the FQQN.
 
 == JMS 2.0 shared subscriptions
 
-JMS 2.0 adds the possibility of shared subscriptions with new API's that are fully supported in Artemis.
+JMS 2.0 adds the possibility of shared subscriptions with new API's that are fully supported in {project-name-short}.
 
 == Fully Qualified Queue name (FQQN)
 
-Secondly, Artemis uses a queue per topic subscriber model internally, and it is possibly to directly address the subscription queue using its Fully Qualified Queue name (FQQN).
+Secondly, {project-name-short} uses a queue per topic subscriber model internally, and it is possibly to directly address the subscription queue using its Fully Qualified Queue name (FQQN).
 
 For example, a default Classic consumer destination for topic `VirtualTopic.Orders` subscription `A`:
 
@@ -29,7 +29,7 @@ For example, a default Classic consumer destination for topic `VirtualTopic.Orde
     session.createConsumer(subscriptionQueue);
 ----
 
-would be replaced with an Artemis FQQN comprised of the address and queue.
+would be replaced with an {project-name-short} FQQN comprised of the address and queue.
 
 ----
     ...
@@ -38,7 +38,7 @@ would be replaced with an Artemis FQQN comprised of the address and queue.
 ----
 
 This does require modification to the destination name used by consumers which is not ideal.
-If OpenWire clients cannot be modified, Artemis supports a virtual topic wildcard filter mechanism on the OpenWire protocol handler that will automatically convert the consumer destination into the corresponding FQQN.
+If OpenWire clients cannot be modified, {project-name-short} supports a virtual topic wildcard filter mechanism on the OpenWire protocol handler that will automatically convert the consumer destination into the corresponding FQQN.
 The format is a comma separated list of strings pairs, delimited with a ';'.
 Each pair identifies a filter to match the virtual topic consumer destination, and an int that specifies the number of path matches that terminate the consumer queue identity.
 
@@ -55,4 +55,4 @@ As demand migrates across a network, duplicate durable subs get created on each 
 The end result can result in duplicate message storage and ultimately duplicate delivery, which is not good.
 When durable subscribers map to virtual topic subscriber queues, the queues can migrate, and the problem can be avoided.
 
-In Artemis, because a durable sub is modeled as a queue, this problem does not arise.
+In {project-name-short}, because a durable sub is modeled as a queue, this problem does not arise.

--- a/docs/migration-guide/index.adoc
+++ b/docs/migration-guide/index.adoc
@@ -1,6 +1,6 @@
-= Apache ActiveMQ Artemis Migration Guide
+= {project-name-full} Migration Guide
 
-The migration guide outlines how users can migrate an existing ActiveMQ Classic broker installation to ActiveMQ Artemis.
+The migration guide outlines how users can migrate an existing ActiveMQ broker installation to {project-name-short}.
 
 include::_preface.adoc[leveloffset=1]
 include::_key-differences.adoc[leveloffset=1]

--- a/docs/user-manual/_book.adoc
+++ b/docs/user-manual/_book.adoc
@@ -5,7 +5,7 @@ It *aggregates* all chapters into a single document following the same pattern a
 image::images/activemq-logo.png[align="center"]
 
 [.text-center]
-*An in-depth manual on all aspects of Apache ActiveMQ Artemis {project-version}*
+*An in-depth manual on all aspects of {project-name-full} {project-version}*
 
 //== Overview
 

--- a/docs/user-manual/activation-tools.adoc
+++ b/docs/user-manual/activation-tools.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-You can use the Artemis CLI to execute activation sequence maintenance/recovery tools for xref:ha.adoc#replication[Replication] with Pluggable Lock Manager.
+You can use the CLI to execute activation sequence maintenance/recovery tools for xref:ha.adoc#replication[Replication] with Pluggable Lock Manager.
 
 The 2 main commands are `activation list` and `activation set`, that can be used together to recover some disaster happened to local/coordinated activation sequences.
 

--- a/docs/user-manual/address-model.adoc
+++ b/docs/user-manual/address-model.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Every messaging protocol and API that Apache ActiveMQ Artemis supports defines a different set of messaging resources.
+Every supported messaging protocol and API defines a different set of messaging resources.
 
 * JMS uses _queues_ and _topics_
 * STOMP uses generic _destinations_
@@ -48,7 +48,7 @@ WARNING: It is possible to define queues with a different routing type for the s
 
 == Automatic Configuration
 
-By default Apache ActiveMQ Artemis will automatically create addresses and queues to support the semantics of whatever protocol you're using.
+By default, the broker will automatically create addresses and queues to support the semantics of whatever protocol you're using.
 The broker understands how to support each protocol's functionality with the core resources so that in most cases no manual configuration is required.
 This saves you from having to preconfigure each address and queue before a client can connect to it.
 
@@ -357,7 +357,7 @@ Each of the following advanced configurations have their own chapter so their de
 
 == How to filter messages
 
-Apache ActiveMQ Artemis supports the ability to filter messages using xref:filter-expressions.adoc#filter-expressions[Filter Expressions].
+Messages can be filtered using xref:filter-expressions.adoc#filter-expressions[Filter Expressions].
 
 Filters can be applied in two places - on a queue and on a consumer.
 

--- a/docs/user-manual/address-settings.adoc
+++ b/docs/user-manual/address-settings.adoc
@@ -264,8 +264,8 @@ Whether or not the broker should automatically create a queue when a message is 
 Queues which are auto-created are durable, non-temporary, and non-transient.
 Default is `true`.
 +
-NOTE: Automatic queue creation does _not_ work for the core client.
-The core API is a low-level API and is not meant to have such automation.
+NOTE: Automatic queue creation does _not_ work for the Core client.
+The Core API is a low-level API and is not meant to have such automation.
 
 include::_auto-queue-creation-note.adoc[]
 
@@ -315,8 +315,8 @@ auto-create-addresses::
 Whether or not the broker should automatically create an address when a message is sent to or a consumer tries to consume from a queue which is mapped to an address whose name fits the address `match`.
 Default is `true`.
 +
-NOTE: automatic address creation does _not_ work for the core client.
-The core API is a low-level API and is not meant to have such automation.
+NOTE: automatic address creation does _not_ work for the Core client.
+The Core API is a low-level API and is not meant to have such automation.
 
 auto-delete-addresses::
 Whether or not the broker should automatically delete auto-created addresses once the address no longer has any queues.

--- a/docs/user-manual/amqp-broker-connections.adoc
+++ b/docs/user-manual/amqp-broker-connections.adoc
@@ -16,8 +16,8 @@ Broker connections are configured by the `<broker-connections>` XML element in t
 
 == AMQP Server Connections
 
-An ActiveMQ Artemis broker can initiate connections using the AMQP protocol.
-This means that the broker can connect to another AMQP server (not necessarily ActiveMQ Artemis) and create elements on that connection.
+The broker can initiate connections using the AMQP protocol.
+This means that the broker can connect to another AMQP server (not necessarily {project-name-short}) and create elements on that connection.
 
 To define an AMQP broker connection, add an `<amqp-connection>` element within the `<broker-connections>` element in the `broker.xml` configuration file.
 For example:
@@ -48,7 +48,7 @@ auto-start::
 Should the broker connection start automatically with the broker. Default is `true`.
 If `false` it is necessary to call a management operation to start it.
 
-NOTE: The connection URI options for transport settings, such as enabling and configuring TLS, are common with other Artemis connector URIs.
+NOTE: The connection URI options for transport settings, such as enabling and configuring TLS, are common with other broker connector URIs.
 See xref:configuring-transports.adoc#configuring-netty-ssl[the transport doc] for more.
 An example configuration for a TLS AMQP broker-connection can be found in the broker xref:examples.adoc[examples] at _./examples/features/broker-connection/amqp-sending-overssl_.
 
@@ -221,7 +221,7 @@ Previously existing messages will not be forwarded to other brokers.
 
 == Dual Mirror (Disaster Recovery)
 
-ActiveMQ Artemis supports automatic fallback mirroring.
+Automatic fallback mirroring is supported.
 Every sent message and every acknowledgement is asynchronously replicated to the mirrored broker.
 
 On the following diagram there will be two servers called _DataCenter1_, and _DataCenter2_.
@@ -270,7 +270,7 @@ On the provided example above, two brokers are configured to mirror each other a
 
 == Senders and Receivers
 
-It is possible to connect an ActiveMQ Artemis broker to another AMQP endpoint simply by creating a sender or receiver broker connection element.
+It is possible to connect a broker to another AMQP endpoint simply by creating a `sender` or `receiver` element.
 
 For a `sender`, the broker creates a message consumer on a queue that sends messages to another AMQP endpoint.
 
@@ -278,7 +278,7 @@ For a `receiver`, the broker creates a message producer on an address that recei
 
 Both elements function as a message bridge.
 However, there is no additional overhead required to process messages.
-Senders and receivers behave just like any other consumer or producer in ActiveMQ Artemis.
+Senders and receivers behave just like any other consumer or producer.
 
 Specific queues can be configured by senders or receivers.
 Wildcard expressions can be used to match senders and receivers to specific addresses or _sets_ of addresses.
@@ -354,10 +354,10 @@ This creates an infinite loop of sends and receives.
 The broker can be configured as a peer which connects to the https://qpid.apache.org/components/dispatch-router/[Apache Qpid Dispatch Router] and instructs it that the broker will act as a store-and-forward queue for a given AMQP waypoint address configured on the router.
 In this scenario, clients connect to a router to send and receive messages using a waypointed address, and the router routes these messages to or from the queue on the broker.
 
-The peer configuration causes ActiveMQ Artemis to create a sender and receiver pair for each destination matched in the broker-connection configuration, with these carrying special configuration to let Qpid Dispatch know to collaborate with the broker.
+The `peer` configuration causes the broker to create a sender and receiver pair for each destination matched in the broker-connection configuration, with these carrying special configuration to let Qpid Dispatch know to collaborate with the broker.
 This replaces the traditional need of a router-initiated connection and auto-links.
 
-Qpid Dispatch Router offers a lot of advanced networking options that be used together with ActiveMQ Artemis.
+Qpid Dispatch Router offers a lot of advanced networking options that be used together with the broker.
 
 With a peer configuration, the same properties are present as when there are senders and receivers.
 For example, a configuration where queues with names beginning `queue.` act as storage for the matching router waypoint address would be:

--- a/docs/user-manual/amqp.adoc
+++ b/docs/user-manual/amqp.adoc
@@ -3,8 +3,8 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis supports the https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=amqp[AMQP 1.0] specification.
-By default there are `acceptor` elements configured to accept AMQP connections on ports `61616` and `5672`.
+The https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=amqp[AMQP 1.0] specification is supported.
+By default, there are `acceptor` elements configured to accept AMQP connections on ports `61616` and `5672`.
 
 See the general xref:protocols-interoperability.adoc#protocols-and-interoperability[Protocols and Interoperability] chapter for details on configuring an `acceptor` for AMQP.
 
@@ -21,7 +21,7 @@ and many others.
 
 == Examples
 
-We have a few examples as part of the xref:examples.adoc[Artemis examples]:
+We have a project with xref:examples.adoc[a few examples]:
 
 * .NET:
  ** ./examples/protocols/amqp/dotnet
@@ -67,7 +67,7 @@ If regardless these recommendations you still need and want to intercept and cha
 
 == AMQP and security
 
-The Apache ActiveMQ Artemis Server accepts the PLAIN, ANONYMOUS, and GSSAPI SASL mechanism.
+The PLAIN, ANONYMOUS, and GSSAPI SASL mechanisms are accepted.
 These are implemented on the broker's xref:security.adoc#authentication-authorization[security] infrastructure.
 
 == AMQP and destinations
@@ -91,7 +91,7 @@ If a coordinator is used then the underlying server session will be transacted a
 
 [NOTE]
 ====
-AMQP allows the use of multiple transactions per session, `amqp:multi-txns-per-ssn`, however in this version of Apache ActiveMQ Artemis will only support single transactions per session.
+AMQP allows the use of multiple transactions per session, `amqp:multi-txns-per-ssn`, however, only a single transaction per session is supported by the broker.
 ====
 
 == AMQP scheduling message delivery
@@ -193,17 +193,17 @@ This contains a real example for configuring amqpIdleTimeout:
 <acceptor name="amqp">tcp://0.0.0.0:5672?amqpIdleTimeout=0;tcpSendBufferSize=1048576;tcpReceiveBufferSize=1048576;protocols=AMQP;useEpoll=true;amqpCredits=1000;amqpLowCredits=300;directDeliver=false;batchDelay=10</acceptor>
 ----
 
-== Web Sockets
+== WebSockets
 
-Apache ActiveMQ Artemis also supports AMQP over https://html.spec.whatwg.org/multipage/web-sockets.html[Web Sockets].
-Modern web browsers which support Web Sockets can send and receive AMQP messages.
+AMQP over https://html.spec.whatwg.org/multipage/web-sockets.html[WebSockets] is also supported.
+Modern web browsers which support WebSockets can send and receive AMQP messages.
 
-AMQP over Web Sockets is supported via a normal AMQP acceptor:
+AMQP over WebSockets is supported via a normal AMQP acceptor:
 
 [,xml]
 ----
 <acceptor name="amqp-ws-acceptor">tcp://localhost:5672?protocols=AMQP</acceptor>
 ----
 
-With this configuration, Apache ActiveMQ Artemis will accept AMQP connections over Web Sockets on the port `5672`.
+With this configuration, the broker will accept AMQP connections over WebSockets on the port `5672`.
 Web browsers can then connect to `ws://<server>:5672` using a Web Socket to send and receive AMQP messages.

--- a/docs/user-manual/architecture.adoc
+++ b/docs/user-manual/architecture.adoc
@@ -3,43 +3,43 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis core is designed simply as set of Plain Old Java Objects (POJOs) - we hope you like its clean-cut design.
+The broker is designed simply as set of Plain Old Java Objects (POJOs) - we hope you like its clean-cut design.
 
-Each Apache ActiveMQ Artemis server has its own ultra high performance persistent journal, which it uses for message and other persistence.
+Each broker has its own ultra high performance persistent journal, which it uses for message and other persistence.
 
 Using a high performance journal allows outrageous persistence message performance, something not achievable when using a relational database for persistence (although JDBC is still an option if necessary).
 
-Apache ActiveMQ Artemis clients, potentially on different physical machines, interact with the Apache ActiveMQ Artemis broker.
-Apache ActiveMQ Artemis currently ships three API implementations for messaging at the client side:
+Clients, potentially on different physical machines, interact with the broker.
+Three API implementations for messaging at the client side are provided with the broker:
 
 . Core client API.
-This is a simple intuitive Java API that is aligned with the Artemis internal Core.
-Allowing more control of broker objects (e.g direct creation of addresses and queues).
+This is a simple, intuitive Java API that is aligned with the broker's internal Core.
+It allows more control of broker objects (e.g. direct creation of addresses and queues).
 The Core API also offers a full set of messaging functionality without some of the complexities of JMS.
 . JMS 2.0 client API.
 The standard JMS API is available at the client side.
 This client is also compliant with the Jakarta Messaging 2.0 specification.
-. Jakarta Messaging 3.0 client API.
+. Jakarta Messaging 3.1 client API.
 This is essentially the same as the JMS 2.0 API.
-The only difference is the package names use `jakarta` insead of `javax`.
+The main difference is the package names use `jakarta` instead of `javax`.
 This difference was introduced due to the move from Oracle's Java EE to Eclipse's Jakarta EE.
 
-Apache ActiveMQ Artemis also provides different protocol implementations on the server so you can use respective clients for these protocols:
+Other messaging protocols are also supported:
 
-* AMQP
+* AMQP 1.0
 * OpenWire
-* MQTT
-* STOMP
-* HornetQ (for use with HornetQ clients).
-* Core (Artemis CORE protocol)
+* MQTT 3.x & 5.0
+* STOMP 1.x
+* HornetQ (for use with HornetQ clients)
 
 JMS semantics are implemented by a JMS facade layer on the client side.
 
-The Apache ActiveMQ Artemis broker does not speak JMS and in fact does not know anything about JMS, it is a protocol agnostic messaging server designed to be used with multiple different protocols.
+The broker does not "speak" JMS and, in fact, does not know anything about JMS, per se.
+It is protocol agnostic, designed to be used with multiple different protocols.
 
-When a user uses the JMS API on the client side, all JMS interactions are translated into operations on the Apache ActiveMQ Artemis core client API before being transferred over the wire using the core protocol.
+When a client application uses the JMS API all JMS interactions are translated into operations on the Core client API before being transferred over the wire using the Core protocol.
 
-The broker always just deals with core API interactions.
+The broker always just deals with Core API interactions.
 
 == Standalone Broker
 
@@ -51,13 +51,14 @@ For more information on server configuration files see xref:configuration-index.
 
 == Embedded Broker
 
-Apache ActiveMQ Artemis core is designed as a set of simple POJOs so if you have an application that requires messaging functionality internally but you don't want to expose that as an Apache ActiveMQ Artemis broker you can directly instantiate and embed brokers in your own application.
+The broker is designed as a set of simple POJOs so if you have an application that requires messaging functionality internally, but you don't want to expose that as an independent, standalone broker, you can directly instantiate and embed a broker in your own application.
 
-Read more about xref:embedding-activemq.adoc#embedding-apache-activemq-artemis[embedding Apache ActiveMQ Artemis].
+Read more about xref:embedding-activemq.adoc#embedding-{project-name-full-url}[embedding a broker].
 
 == Integrated with a Java/Jakarta EE application server
 
-Apache ActiveMQ Artemis provides its own fully functional Java Connector Architecture (JCA) adaptor which enables it to be integrated easily into any Java/Jakarta EE (henceforth just "EE") compliant application server or servlet engine.
+A fully functional Java Connector Architecture (JCA) adaptor is provided.
+This enables easy integration with any Java/Jakarta EE (henceforth just "EE") compliant application server or servlet engine.
 
 EE application servers provide Message Driven Beans (MDBs), which are a special type of Enterprise Java Beans (EJBs) that can process messages from sources such as JMS systems or mail systems.
 
@@ -73,7 +74,7 @@ In fact, communicating with a JMS messaging system directly, without using JCA w
 The application server's JCA service provides extra functionality such as connection pooling and automatic transaction enlistment, which are desirable when using messaging, say, from inside an EJB.
 It is possible to talk to a JMS messaging system directly from an EJB, MDB or servlet without going through a JCA adapter, but this is not recommended since you will not be able to take advantage of the JCA features, such as caching of JMS sessions, which can result in poor performance.
 
-Note that all communication between EJB sessions or entity beans and Message Driven beans go through the adaptor and not directly to Apache ActiveMQ Artemis.
+Note that all communication between EJB sessions or entity beans and Message Driven beans go through the adaptor and not directly to the broker.
 
-The large arrow with the prohibited sign shows an EJB session bean talking directly to the Apache ActiveMQ Artemis server.
+The large arrow with the prohibited sign shows an EJB session bean talking directly to the the broker.
 This is not recommended as you'll most likely end up creating a new connection and session every time you want to interact from the EJB, which is an anti-pattern.

--- a/docs/user-manual/broker-plugins.adoc
+++ b/docs/user-manual/broker-plugins.adoc
@@ -3,8 +3,8 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis is designed to allow extra functionality to be added by creating a plugin.
-Multiple plugins can be registered at the same time and they will be chained together and executed in the order they are registered (i.e. the first plugin registered is always executed first).
+Extra functionality can be added by creating a plugin.
+Multiple plugins can be registered at the same time, and they will be chained together and executed in the order they are registered (i.e. the first plugin registered is always executed first).
 
 Creating a plugin is very simple.
 It requires:

--- a/docs/user-manual/cdi-integration.adoc
+++ b/docs/user-manual/cdi-integration.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis provides a simple CDI integration.
+{project-name-full} provides a simple CDI integration.
 It can either use an embedded broker or connect to a remote broker.
 
 == Configuring a connection

--- a/docs/user-manual/client-failover.adoc
+++ b/docs/user-manual/client-failover.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis clients can be configured to automatically <<reconnect-to-the-same-server,reconnect to the same server>>, <<reconnect-to-the-backup-server,reconnect to the backup server>> or <<reconnect-to-other-active-servers,reconnect to other active servers>> in the event that a failure is detected in the connection between the client and the server.
+Clients using the Core protocol can be configured to automatically <<reconnect-to-the-same-server,reconnect to the same server>>, <<reconnect-to-the-backup-server,reconnect to the backup server>> or <<reconnect-to-other-active-servers,reconnect to other active servers>> in the event that a failure is detected in the connection between the client and the server.
 The clients detect connection failure when they have not received any packets from the server within the time given by `client-failure-check-period` as explained in section xref:connection-ttl.adoc#detecting-dead-connections[Detecting Dead Connections].
 
 == Reconnect to the same server
@@ -17,7 +17,7 @@ This is done 100% transparently and the client can continue exactly as if nothin
 
 The way this works is as follows:
 
-As Apache ActiveMQ Artemis clients send commands to their servers they store each sent command in an in-memory buffer.
+As Core clients send commands to their servers they store each sent command in an in-memory buffer.
 In the case that connection failure occurs and the client subsequently reattaches to the same server, as part of the reattachment protocol the server informs the client during reattachment with the id of the last command it successfully received from that client.
 
 If the client has sent more commands than were received before failover it can replay any sent commands from its buffer so that the client and server can reconcile their states.Ac
@@ -112,4 +112,4 @@ If your client does manage to reconnect but the session is no longer available o
 
 == ExceptionListeners and SessionFailureListeners
 
-Please note, that when a client reconnects or re-attaches, any registered JMS `ExceptionListener` or core API `SessionFailureListener` will be called.
+Please note, that when a client reconnects or re-attaches, any registered JMS `ExceptionListener` or Core API `SessionFailureListener` will be called.

--- a/docs/user-manual/clusters.adoc
+++ b/docs/user-manual/clusters.adoc
@@ -5,8 +5,8 @@
 
 == Overview
 
-Apache ActiveMQ Artemis clusters allow groups of Apache ActiveMQ Artemis servers to be grouped together in order to share message processing load.
-Each active node in the cluster is an active Apache ActiveMQ Artemis server which manages its own messages and handles its own connections.
+Clusters allow groups of brokers to be grouped together in order to share message processing load.
+Each active node in the cluster manages its own messages and handles its own connections.
 
 The cluster is formed by each node declaring _cluster connections_ to other nodes in the core configuration file `broker.xml`.
 When a node forms a cluster connection to another node, internally it creates a _core bridge_ (as described in xref:core-bridges.adoc#core-bridges[Core Bridges]) connection between it and the other node, this is done transparently behind the scenes - you don't have to declare an explicit bridge for each node.
@@ -14,7 +14,7 @@ These cluster connections allow messages to flow between the nodes of the cluste
 
 Nodes can be connected together to form a cluster in many different topologies, we will discuss a couple of the more common topologies later in this chapter.
 
-We'll also discuss client side load balancing, where we can balance client connections across the nodes of the cluster, and we'll consider message redistribution where Apache ActiveMQ Artemis will redistribute messages between nodes to avoid starvation.
+We'll also discuss client side load balancing, where we can balance client connections across the nodes of the cluster, and we'll consider message redistribution where the broker will redistribute messages between nodes to avoid starvation.
 
 Another important part of clustering is _server discovery_ where servers can broadcast their connection details so clients or other servers can connect to them with the minimum of configuration.
 
@@ -22,8 +22,8 @@ Another important part of clustering is _server discovery_ where servers can bro
 ====
 [#copy-warning]
 Once a cluster node has been configured it is common to simply copy that configuration to other nodes to produce a symmetric cluster.
-However, care must be taken when copying the Apache ActiveMQ Artemis files.
-Do not copy the Apache ActiveMQ Artemis _data_ (i.e. the `bindings`, `journal`, `paging`, and `large-messages` directories) from one node to another.
+However, care must be taken when copying the files.
+Do not copy the _data_ (i.e. the `bindings`, `journal`, `paging`, and `large-messages` directories) from one node to another.
 When a node is started for the first time and initializes its journal files it also persists a special identifier to the `journal` directory.
 This id _must_ be unique among nodes in the cluster or the cluster will not form properly.
 ====
@@ -59,8 +59,8 @@ A messaging client wants to be able to connect to the servers of the cluster wit
 * Other servers.
 Servers in a cluster want to be able to create cluster connections to each other without having prior knowledge of all the other servers in the cluster.
 
-This information, let's call it the Cluster Topology, is actually sent around normal Apache ActiveMQ Artemis connections to clients and to other servers over cluster connections.
-This being the case we need a way of establishing the initial first connection.
+This information, let's call it the Cluster Topology, is actually sent around normal connections to clients and to other servers over cluster connections.
+This being the case, we need a way of establishing the initial first connection.
 This can be done using dynamic discovery techniques like https://en.wikipedia.org/wiki/User_Datagram_Protocol[UDP] and http://www.jgroups.org/[JGroups], or by providing a list of initial connectors.
 
 === Dynamic Discovery
@@ -77,7 +77,7 @@ The broadcast group takes a connector and broadcasts it on the network.
 Depending on which broadcasting technique you configure, it uses either UDP or JGroups to broadcast connector information.
 
 Broadcast groups are defined in the server configuration file `broker.xml`.
-There can be many broadcast groups per Apache ActiveMQ Artemis server.
+There can be many broadcast groups per broker.
 All broadcast groups must be defined in a `broadcast-groups` element.
 
 Let's take a look at an example broadcast group from `broker.xml` that defines a UDP broadcast group:
@@ -151,13 +151,12 @@ Here is another example broadcast group that defines a JGroups broadcast group:
 To be able to use JGroups to broadcast, one must specify two attributes, i.e. `jgroups-file` and `jgroups-channel`, as discussed in details as following:
 
 jgroups-file::
- attribute.
 This is the name of JGroups configuration file.
 It will be used to initialize JGroups channels.
-Make sure the file is in the java resource path so that Apache ActiveMQ Artemis can load it.
+Make sure the file is in the Java resource path so that the broker can load it.
 The typical location for the file is the `etc` directory from the broker instance.
+
 jgroups-channel::
- attribute.
 The name that JGroups channels connect to for broadcasting.
 
 [NOTE]
@@ -208,13 +207,13 @@ The following is an example of a JGroups file
 </config>
 ----
 
-As it shows, the file content defines a jgroups protocol stacks.
-If you want Apache ActiveMQ Artemis to use this stacks for channel creation, you have to make sure the value of `jgroups-file` in your broadcast-group/discovery-group configuration to be the name of this jgroups configuration file.
-For example if the above stacks configuration is stored in a file named "jgroups-stacks.xml" then your `jgroups-file` should be like
+As it shows, the file content defines a JGroups protocol stack.
+If you want the broker to use this stack for channel creation, you have to make sure the value of `jgroups-file` in your broadcast-group/discovery-group configuration to be the name of this JGroups configuration file.
+For example, if the above configuration is stored in a file named "jgroups-stack.xml" then your `jgroups-file` should be like:
 
 [,xml]
 ----
-<jgroups-file>jgroups-stacks.xml</jgroups-file>
+<jgroups-file>jgroups-stack.xml</jgroups-file>
 ----
 
 ==== Discovery Groups
@@ -226,12 +225,12 @@ As it receives broadcasts on the broadcast endpoint from a particular server it 
 
 If it has not received a broadcast from a particular server for a length of time it will remove that server's entry from its list.
 
-Discovery groups are used in two places in Apache ActiveMQ Artemis:
+Discovery groups are used in two places:
 
 * By cluster connections so they know how to obtain an initial connection to download the topology
 * By messaging clients so they know how to obtain an initial connection to download the topology
 
-Although a discovery group will always accept broadcasts, its current list of available primary and backup servers is only ever used when an initial connection is made, from then server discovery is done over the normal Apache ActiveMQ Artemis connections.
+Although a discovery group will always accept broadcasts, its current list of available primary and backup servers is only ever used when an initial connection is made, from then server discovery is done over the normal connections.
 
 [NOTE]
 ====
@@ -243,7 +242,7 @@ For example, if broadcast is configured using UDP, the discovery group must also
 
 For cluster connections, discovery groups are defined in the server side configuration file `broker.xml`.
 All discovery groups must be defined inside a `discovery-groups` element.
-There can be many discovery groups defined by Apache ActiveMQ Artemis server.
+There can be many discovery groups defined.
 Let's look at an example:
 
 [,xml]
@@ -303,18 +302,15 @@ Here is another example that defines a JGroups discovery group:
 To receive broadcast from JGroups channels, one must specify two attributes, `jgroups-file` and `jgroups-channel`, as discussed in details as following:
 
 jgroups-file::
- attribute.
-This is the name of JGroups configuration file.
+This is the name of the JGroups configuration file.
 It will be used to initialize JGroups channels.
-Make sure the file is in the java resource path so that Apache ActiveMQ Artemis can load it.
+Make sure the file is in the java resource path so that the broker can load it.
+
 jgroups-channel::
- attribute.
 The name that JGroups channels connect to for receiving broadcasts.
 
 [NOTE]
 ====
-
-
 The JGroups attributes (`jgroups-file` and `jgroups-channel`) and UDP specific attributes described above are exclusive of each other.
 Only one set can be specified in a discovery group configuration.
 Don't mix them!
@@ -322,8 +318,8 @@ Don't mix them!
 
 ==== Discovery Groups on the Client Side
 
-Let's discuss how to configure an Apache ActiveMQ Artemis client to use discovery to discover a list of servers to which it can connect.
-The way to do this differs depending on whether you're using JMS or the core API.
+Let's discuss how to configure a Core client to use discovery to discover a list of servers to which it can connect.
+The way to do this differs depending on whether you're using JMS or the Core API.
 
 ===== Configuring client discovery
 
@@ -372,7 +368,7 @@ The brackets are expanded so the same query can be appended after the last brack
 
 == Server-Side Message Load Balancing
 
-If cluster connections are defined between nodes of a cluster, then Apache ActiveMQ Artemis will load balance messages arriving at a particular node from a client.
+If cluster connections are defined between nodes of a cluster, then the broker will load balance messages arriving at a particular node from a client.
 
 Let's take a simple example of a cluster of four nodes A, B, C, and D arranged in a _symmetric cluster_ (described in Symmetrical Clusters section).
 We have a queue called `OrderQueue` deployed on each node of the cluster.
@@ -386,9 +382,9 @@ The messages are forwarded from the receiving node to other nodes of the cluster
 This is all done on the server side, the client maintains a single connection to node A.
 
 For example, messages arriving on node A might be distributed in the following order between the nodes: B, D, C, A, B, D, C, A, B, D.
-The exact order depends on the order the nodes started up, but the algorithm used is round robin.
+The exact order depends on the order the nodes started up, but the algorithm used is round-robin.
 
-Apache ActiveMQ Artemis cluster connections can be configured to always blindly load balance messages in a round robin fashion irrespective of whether there are any matching consumers on other nodes, but they can be a bit cleverer than that and also be configured to only distribute to other nodes if they have matching consumers.
+Cluster connections can be configured to always blindly load balance messages in a round-robin fashion irrespective of whether there are any matching consumers on other nodes, but they can be a bit cleverer than that and also be configured to only distribute to other nodes if they have matching consumers.
 We'll look at both these cases in turn with some examples, but first we'll discuss configuring cluster connections in general.
 
 === Configuring Cluster Connections
@@ -396,7 +392,7 @@ We'll look at both these cases in turn with some examples, but first we'll discu
 Cluster connections group servers into clusters so that messages can be load balanced between the nodes of the cluster.
 Let's take a look at a typical cluster connection.
 Cluster connections are always defined in `broker.xml` inside a `cluster-connection` element.
-There can be zero or more cluster connections defined per Apache ActiveMQ Artemis server.
+There can be zero or more cluster connections defined per broker.
 
 [,xml]
 ----
@@ -438,7 +434,7 @@ To prevent an address from being matched on this cluster connection, prepend a c
 In the case shown above the cluster connection will load balance messages sent to all addresses (since it's empty).
 +
 The address can be any value and you can have many cluster connections with different values of `address`, simultaneously balancing messages for those addresses, potentially to different clusters of servers.
-By having multiple cluster connections on different addresses a single Apache ActiveMQ Artemis Server can effectively take part in multiple clusters simultaneously.
+By having multiple cluster connections on different addresses, a single broker can effectively take part in multiple clusters simultaneously.
 +
 Be careful not to have multiple cluster connections with overlapping values of `address`, e.g. "europe" and "europe.news" since this could result in the same messages being distributed between more than one cluster connection, possibly resulting in duplicate deliveries.
 +
@@ -519,10 +515,10 @@ This parameter replaces the deprecated `forward-when-no-consumers` parameter.
 If this is set to `OFF` then messages will never be forwarded to another node in the cluster
 +
 If this is set to `STRICT` then each incoming message will be round robin'd even though the same queues on the other nodes of the cluster may have no consumers at all, or they may have consumers that have non matching message filters (selectors).
-Note that Apache ActiveMQ Artemis will _not_ forward messages to other nodes if there are no _queues_ of the same name on the other nodes, even if this parameter is set to `STRICT`.
+Note that the broker will _not_ forward messages to other nodes if there are no _queues_ of the same name on the other nodes, even if this parameter is set to `STRICT`.
 Using `STRICT` is like setting the legacy `forward-when-no-consumers` parameter to `true`.
 +
-If this is set to `ON_DEMAND` then Apache ActiveMQ Artemis will only forward messages to other nodes of the cluster if the address to which they are being forwarded has queues which have consumers, and if those consumers have message filters (selectors) at least one of those selectors must match the message.
+If this is set to `ON_DEMAND` then the broker will only forward messages to other nodes of the cluster if the address to which they are being forwarded has queues which have consumers, and if those consumers have message filters (selectors) at least one of those selectors must match the message.
 Using `ON_DEMAND` is like setting the legacy `forward-when-no-consumers` parameter to `false`.
 +
 If this is set to `OFF_WITH_REDISTRIBUTION` then like with 'OFF' messages won't be initially routed to other nodes in the cluster.
@@ -535,12 +531,12 @@ Default is `ON_DEMAND`.
 
 max-hops::
 When a cluster connection decides the set of nodes to which it might load balance a message, those nodes do not have to be directly connected to it via a cluster connection.
-Apache ActiveMQ Artemis can be configured to also load balance messages to nodes which might be connected to it only indirectly with other Apache ActiveMQ Artemis servers as intermediates in a chain.
+The broker can be configured to also load balance messages to nodes which might be connected to it only indirectly with other brokers as intermediates in a chain.
 +
-This allows Apache ActiveMQ Artemis to be configured in more complex topologies and still provide message load balancing.
+This allows the broker to be configured in more complex topologies and still provide message load balancing.
 We'll discuss this more later in this chapter.
 +
-The default value for this parameter is `1`, which means messages are only load balanced to other Apache ActiveMQ Artemis serves which are directly connected to this server.
+The default value for this parameter is `1`, which means messages are only load balanced to other brokers which are directly connected to this server.
 This parameter is optional.
 
 confirmation-window-size::
@@ -598,7 +594,7 @@ Default is 30.
 
 === Cluster User Credentials
 
-When creating connections between nodes of a cluster to form a cluster connection, Apache ActiveMQ Artemis uses a cluster user and cluster password which is defined in `broker.xml`:
+When creating connections between nodes of a cluster to form a cluster connection, the broker uses a cluster user and cluster password which is defined in `broker.xml`:
 
 [,xml]
 ----
@@ -609,16 +605,16 @@ When creating connections between nodes of a cluster to form a cluster connectio
 [WARNING]
 ====
 It is imperative that these values are changed from their default, or remote clients will be able to make connections to the server using the default values.
-If they are not changed from the default, Apache ActiveMQ Artemis will detect this and pester you with a warning on every start-up.
+If they are not changed from the default, the broker will detect this and pester you with a warning on every start-up.
 ====
 
 == Client-Side Load balancing
 
-With Apache ActiveMQ Artemis client-side load balancing, subsequent sessions created using a single session factory can be connected to different nodes of the cluster.
+With client-side load balancing, subsequent sessions created using a single session factory can be connected to different nodes of the cluster.
 This allows sessions to spread smoothly across the nodes of a cluster and not be "clumped" on any particular node.
 
 The load balancing policy to be used by the client factory is configurable.
-Apache ActiveMQ Artemis provides four out-of-the-box load balancing policies, and you can also implement your own and use that.
+Four out-of-the-box load balancing policies are available, and you can also implement your own.
 
 The out-of-the-box policies are
 
@@ -646,7 +642,7 @@ Use `org.apache.activemq.artemis.api.core.client.loadbalance.FirstElementConnect
 
 You can also implement your own policy by implementing the interface `org.apache.activemq.artemis.api.core.client.loadbalance.ConnectionLoadBalancingPolicy`
 
-Specifying which load balancing policy to use differs whether you are using JMS or the core API.
+Specifying which load balancing policy to use differs whether you are using JMS or the Core API.
 If you don't specify a policy then the default will be used which is `org.apache.activemq.artemis.api.core.client.loadbalance.RoundRobinConnectionLoadBalancingPolicy`.
 
 The parameter `connectionLoadBalancingPolicyClassName` can be set on the URI to configure what load balancing policy to use:
@@ -696,7 +692,7 @@ However, there is a situation it doesn't solve: What happens if the consumers on
 If there are no consumers on the queue the message won't get consumed and we have a _starvation_ situation.
 
 This is where message redistribution comes in.
-With message redistribution Apache ActiveMQ Artemis can be configured to automatically _redistribute_ messages from queues which have no consumers or consumers with filters that don't match messages.
+With message redistribution the broker can be configured to automatically _redistribute_ messages from queues which have no consumers or consumers with filters that don't match messages.
 The messages are re-routed to other nodes in the cluster which do have matching consumers.
 To enable this functionality `message-load-balancing` must be `ON_DEMAND` or `OFF_WITH_REDISTRIBUTION`
 
@@ -720,7 +716,7 @@ Here's an address settings snippet from `broker.xml` showing how message redistr
 The above `address-settings` block would set a `redistribution-delay` of `0` for any queue which is bound to any address.
 So the above would enable instant (no delay) redistribution for all addresses.
 
-The attribute `match` can be an exact match or it can be a string that conforms to the Apache ActiveMQ Artemis wildcard syntax (described in xref:wildcard-syntax.adoc#wildcard-syntax[Wildcard Syntax]).
+The attribute `match` can be an exact match, or it can be a string that conforms to the xref:wildcard-syntax.adoc#wildcard-syntax[wildcard syntax].
 
 The element `redistribution-delay` defines the delay in milliseconds between detecting the need for redistribution and actually attempting redistribution.
 A delay of zero means the messages will be immediately redistributed.
@@ -746,7 +742,7 @@ This configuration will not impact the internal processes which manage the store
 
 == Cluster topologies
 
-Apache ActiveMQ Artemis clusters can be connected together in many different topologies, let's consider the two most common ones here
+Clusters can be connected together in many different topologies, let's consider the two most common ones here
 
 === Symmetric cluster
 
@@ -783,10 +779,10 @@ Node A would then know to distribute messages to node B when they arrive, even t
 
 === Scaling Down
 
-Apache ActiveMQ Artemis supports scaling down a cluster with no message loss (even for non-durable messages).
+The broker supports scaling down a cluster with no message loss (even for non-durable messages).
 This is especially useful in certain environments (e.g. the cloud) where the size of a cluster may change relatively frequently.
 When scaling up a cluster (i.e. adding nodes) there is no risk of message loss, but when scaling down a cluster (i.e. removing nodes) the messages on those nodes would be lost unless the broker sent them to another node in the cluster.
-Apache ActiveMQ Artemis can be configured to do just that.
+The broker can be configured to do just that.
 
 To enable this behavior configure `scale-down` in the `live-only` `ha-policy`, e.g.:
 

--- a/docs/user-manual/configuration-index.adoc
+++ b/docs/user-manual/configuration-index.adoc
@@ -362,7 +362,7 @@ The system will create as many files as needed however when reclaiming files it 
 | -1
 
 | xref:persistence.adoc#configuring-the-message-journal[journal-sync-non-transactional]
-| if true wait for non transaction data to be synced to the journal before returning response to client.
+| if true wait for non-transaction data to be synced to the journal before returning response to client.
 | `true`
 
 | xref:persistence.adoc#configuring-the-message-journal[journal-sync-transactional]

--- a/docs/user-manual/configuring-transports.adoc
+++ b/docs/user-manual/configuring-transports.adoc
@@ -3,12 +3,12 @@
 :idseparator: -
 :docinfo: shared
 
-In this chapter we'll describe the concepts required for understanding Apache ActiveMQ Artemis transports and where and how they're configured.
+In this chapter we'll describe the concepts required for understanding transports and where and how they're configured.
 
 == Acceptors
 
-One of the most important concepts in Apache ActiveMQ Artemis transports is the _acceptor_.
-Let's dive straight in and take a look at an acceptor defined in xml in the configuration file `broker.xml`.
+One of the most important concepts in transports is the _acceptor_.
+Let's dive straight in and take a look at an acceptor defined in `broker.xml`.
 
 [,xml]
 ----
@@ -19,7 +19,7 @@ Acceptors are always defined inside an `acceptors` element.
 There can be one or more acceptors defined in the `acceptors` element.
 There's no upper limit to the number of acceptors per server.
 
-Each acceptor defines a way in which connections can be made to the Apache ActiveMQ Artemis server.
+Each acceptor defines a way in which connections can be made to the broker.
 
 In the above example we're defining an acceptor that uses https://netty.io/[Netty] to listen for connections at port `61617`.
 
@@ -88,7 +88,7 @@ Connection jmsConnection = connectionFactory.createConnection();
 
 == Configuring the Netty transport
 
-Out of the box, Apache ActiveMQ Artemis currently uses https://netty.io/[Netty], a high performance low level network library.
+Out of the box, the broker currently uses https://netty.io/[Netty], a high performance low level network library.
 
 Our Netty transport can be configured in several different ways;
 to use straightforward TCP sockets, SSL, or to tunnel over HTTP or HTTPS..
@@ -97,9 +97,10 @@ We believe this caters for the vast majority of transport requirements.
 
 === Single Port Support
 
-Apache ActiveMQ Artemis supports using a single port for all protocols, Apache ActiveMQ Artemis will automatically detect which protocol is being used CORE, AMQP, STOMP, MQTT or OPENWIRE and use the appropriate Apache ActiveMQ Artemis handler.
-It will also detect whether protocols such as HTTP or Web Sockets are being used and also use the appropriate decoders.
-Web Sockets are supported for AMQP, STOMP, and MQTT.
+The broker supports using a single port for all protocols.
+It will automatically detect which protocol is being used (i.e. Core, AMQP, STOMP, MQTT, or OpenWire) and use the appropriate handler.
+It will also detect whether protocols such as HTTP or WebSockets are being used and also use the appropriate decoders.
+WebSockets are supported for AMQP, STOMP, and MQTT.
 
 It is possible to limit which protocols are supported by using the `protocols` parameter on the Acceptor like so:
 
@@ -123,7 +124,7 @@ The following parameters can be used to configure Netty for simple TCP:
 
 [NOTE]
 ====
-The `host` and `port` parameters are only used in the core API, in XML configuration these are set in the URI host and port.
+The `host` and `port` parameters are only used in the Core API, in XML configuration these are set in the URI host and port.
 ====
 
 host::
@@ -178,12 +179,12 @@ Once the number of bytes queued in the write buffer exceeded the high water mark
 The default value for this property is `32768` bytes (32KiB).
 
 writeBufferHighWaterMark::
-This parameter determines the high water mark of the Netty write buffer.
+This parameter determines the high watermark of the Netty write buffer.
 If the number of bytes queued in the write buffer exceeds this value, Netty's channel will start to be not writable.
 The default value for this property is `131072` bytes (128KiB).
 
 batchDelay::
-Before writing packets to the transport, Apache ActiveMQ Artemis can be configured to batch up writes for a maximum of `batchDelay` milliseconds.
+Before writing packets to the transport, writes can be batched up for a maximum of `batchDelay` milliseconds.
 This can increase overall throughput for very small messages.
 It does so at the expense of an increase in average latency for message transfer.
 The default value for this property is `0` ms.
@@ -191,7 +192,7 @@ The default value for this property is `0` ms.
 directDeliver::
 When a message arrives on the server and is delivered to waiting consumers, by default, the delivery is done on the same thread as that on which the message arrived.
 This gives good latency in environments with relatively small messages and a small number of consumers, but at the cost of overall throughput and scalability - especially on multi-core machines.
-If you want the lowest latency and a possible reduction in throughput then you can use the default value for `directDeliver` (i.e. `true`).
+If you want the lowest latency and a possible reduction in throughput, then you can use the default value for `directDeliver` (i.e. `true`).
 If you are willing to take some small extra hit on latency but want the highest throughput set `directDeliver` to `false`.
 
 nioRemotingThreads::
@@ -199,8 +200,8 @@ This is deprecated.
 It is replaced by `remotingThreads`, if you are using this please update your configuration.
 
 remotingThreads::
-Apache ActiveMQ Artemis will, by default, use a number of threads equal to three times the number of cores (or hyper-threads) as reported by `Runtime.getRuntime().availableProcessors()` for processing incoming packets.
-If you want to override this value, you can set the number of threads by specifying this parameter.
+An acceptor will, by default, use a number of threads equal to three times the number of cores (or hyper-threads) as reported by `Runtime.getRuntime().availableProcessors()` for processing incoming packets.
+To override this value, set the number of threads by specifying this parameter.
 The default value for this parameter is `-1` which means use the value from `Runtime.getRuntime().availableProcessors()` * 3.
 
 localAddress::
@@ -237,10 +238,9 @@ Default value is `true`.
 
 === Configuring Netty Native Transport
 
-Netty Native Transport support exists for selected OS platforms.
-This allows Apache ActiveMQ Artemis to use native sockets/io instead of Java NIO.
+Netty Native Transport support exists for selected OS platforms in order to use native sockets/io instead of Java NIO.
 
-These Native transports add features specific to a particular platform, generate less garbage, and generally improve performance when compared to Java NIO based transport.
+These Native transports add features specific to a particular platform, generate less garbage, and generally improve performance when compared to Java NIO-based transport.
 
 Both Clients and Server can benefit from this.
 
@@ -249,9 +249,9 @@ Current Supported Platforms.
 * Linux running 64bit JVM
 * MacOS running 64bit JVM
 
-Apache ActiveMQ Artemis will by default enable the corresponding native transport if a supported platform is detected.
+The broker will by default enable the corresponding native transport if a supported platform is detected.
 
-If running on an unsupported platform or any issues loading native libs, Apache ActiveMQ Artemis will fallback onto Java NIO.
+If running on an unsupported platform or if there are any issues loading native libs, Java NIO will be used.
 
 ==== Linux Native Transport
 
@@ -484,25 +484,25 @@ Please see the examples for a full working example of using Netty HTTP.
 Netty HTTP uses the same properties as Netty TCP but adds the following additional properties:
 
 httpEnabled::
-Activates http on the client.
+Activates HTTP on the client.
 This is not needed on the broker.
-With single port support Apache ActiveMQ Artemis will now automatically detect if http is being used and configure itself.
+With single port support the broker will now automatically detect if HTTP is being used and configure itself.
 
 httpClientIdleTime::
-How long a client can be idle before sending an empty http request to keep the connection alive
+How long a client can be idle before sending an empty HTTP request to keep the connection alive
 
 httpClientIdleScanPeriod::
 How often, in milliseconds, to scan for idle clients
 
 httpResponseTime::
-How long the server can wait before sending an empty http response to keep the connection alive
+How long the server can wait before sending an empty HTTP response to keep the connection alive
 
 httpServerScanPeriod::
 How often, in milliseconds, to scan for clients needing responses
 
 httpRequiresSessionId::
 If `true` the client will wait after the first call to receive a session id.
-Used the http connector is connecting to servlet acceptor (not recommended)
+Used the HTTP connector is connecting to servlet acceptor (not recommended)
 
 === Configuring Netty SOCKS Proxy
 

--- a/docs/user-manual/connection-routers.adoc
+++ b/docs/user-manual/connection-routers.adoc
@@ -3,8 +3,8 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis connection routers allow incoming client connections to be distributed across multiple <<target-broker,target brokers>>.
-The target brokers are grouped in <<pools,pools>> and the connection routers use a <<keys,key>> to select a target broker from a pool of brokers according to a <<policies,policy>>.
+Connection routers allow incoming client connections to be distributed across multiple <<target-broker,target brokers>>.
+The target brokers are grouped in <<pools,pools>>, and the connection routers use a <<keys,key>> to select a target broker from a pool of brokers according to a <<policies,policy>>.
 
 == Target Broker
 
@@ -251,7 +251,7 @@ With the 'data gravity' mindset, operators are less concerned with numbers of co
 
 == Redirection
 
-Apache ActiveMQ Artemis provides a protocol-native redirection as well as a management API for other clients using a messaging protocol which doesn't support redirection.
+A protocol-native redirection is provided as well as a management API for other clients using a messaging protocol which doesn't support redirection.
 
 === Native Redirection
 

--- a/docs/user-manual/connection-ttl.adoc
+++ b/docs/user-manual/connection-ttl.adoc
@@ -3,13 +3,13 @@
 :idseparator: -
 :docinfo: shared
 
-In this section we will discuss connection time-to-live (TTL) and explain how Apache ActiveMQ Artemis deals with crashed clients and clients which have exited without cleanly closing their resources.
+In this section we will discuss connection time-to-live (TTL) and explain how the broker deals with crashed clients and clients which have exited without cleanly closing their resources.
 
 == Cleaning up Resources on the Server
 
-Before an Apache ActiveMQ Artemis client application exits it is considered good practice that it should close its resources in a controlled manner, using a `finally` block.
+Before a client application exits it is considered good practice that it should close its resources in a controlled manner, using a `finally` block.
 
-Here's an example of a well behaved core client application closing its session and session factory in a finally block:
+Here's an example of a well-behaved Core client application closing its session and session factory in a `finally` block:
 
 [,java]
 ----
@@ -76,9 +76,9 @@ If this occurs then it can leave server side resources, like sessions, hanging o
 If these were not removed they would cause a resource leak on the server and over time this result in the server running out of memory or other resources.
 
 We have to balance the requirement for cleaning up dead client resources with the fact that sometimes the network between the client and the server can fail and then come back, allowing the client to reconnect.
-Apache ActiveMQ Artemis supports client reconnection, so we don't want to clean up "dead" server side resources too soon or this will prevent any client from reconnecting, as it won't be able to find its old sessions on the server.
+The Core protocol supports client reconnection, so we don't want to clean up "dead" server side resources too soon or this will prevent any client from reconnecting, as it won't be able to find its old sessions on the server.
 
-Apache ActiveMQ Artemis makes all of this configurable via a _connection TTL_.
+The broker makes all of this configurable via a _connection TTL_.
 Basically, the TTL determines how long the server will keep a connection alive in the absence of any data arriving from the client.
 The client will automatically send "ping" packets periodically to prevent the server from closing it down.
 If the server doesn't receive any packets on a connection for the connection TTL time, then it will automatically close all the sessions on the server that relate to that connection.
@@ -99,11 +99,9 @@ However, this can be changed if necessary by using the  `connection-ttl-check-in
 
 == Closing Forgotten Resources
 
-As previously discussed, it's important that all core client sessions and JMS connections are always closed explicitly in a `finally` block when you are finished using them.
-
-If you fail to do so, Apache ActiveMQ Artemis will detect this at garbage collection time, and log a warning (If you are using JMS the warning will involve a JMS connection).
-
-Apache ActiveMQ Artemis will then close the connection / client session for you.
+As previously discussed, it's important that all Core client sessions and JMS connections are always closed explicitly in a `finally` block when you are finished using them.
+If you fail to do so, the Core client will detect this at garbage collection time, and log a warning (If you are using JMS the warning will involve a JMS connection).
+It will then close the connection / client session for you.
 
 Note that the log will also tell you the exact line of your user code where you created the JMS connection / client session that you later did not close.
 This will enable you to pinpoint the error in your code and correct it appropriately.

--- a/docs/user-manual/core-bridges.adoc
+++ b/docs/user-manual/core-bridges.adoc
@@ -3,26 +3,26 @@
 :idseparator: -
 :docinfo: shared
 
-The function of a bridge is to consume messages from a source queue, and forward them to a target address, typically on a different Apache ActiveMQ Artemis server.
+The function of a bridge is to consume messages from a source queue, and forward them to a target address, typically on a different broker.
 
-The source and target servers do not have to be in the same cluster which makes bridging suitable for reliably sending messages from one cluster to another, for instance across a WAN, or internet and where the connection may be unreliable.
+The source and target brokers do not have to be in the same cluster which makes bridging suitable for reliably sending messages from one cluster to another, for instance across a WAN, or internet and where the connection may be unreliable.
 
 The bridge has built in resilience to failure so if the target server connection is lost, e.g. due to network failure, the bridge will retry connecting to the target until it comes back online.
 When it comes back online it will resume operation as normal.
 
-In summary, bridges are a way to reliably connect two separate Apache ActiveMQ Artemis servers together.
-With a core bridge both source and target servers must be Apache ActiveMQ Artemis servers.
+In summary, bridges are a way to reliably connect two separate brokers together.
+With a core bridge both source and target servers must be brokers.
 
-Bridges can be configured to provide _once and only once_ delivery guarantees even in the event of the failure of the source or the target server.
+Bridges can be configured to provide _once and only once_ delivery guarantees even in the event of the failure of the source or the target broker.
 They do this by using duplicate detection (described in xref:duplicate-detection.adoc#duplicate-message-detection[Duplicate Detection]).
 
 [NOTE]
 ====
 Although they have similar function, don't confuse core bridges with JMS bridges!
 
-Core bridges are for linking an Apache ActiveMQ Artemis node with another Apache ActiveMQ Artemis node and do not use the JMS API.
+Core bridges are for linking one broker with another broker and do not use the JMS API.
 A JMS Bridge is used for linking any two JMS 1.1 compliant JMS providers.
-So, a JMS Bridge could be used for bridging to or from different JMS compliant messaging system.
+So, a JMS Bridge could be used for bridging to or from a different JMS-compliant messaging system.
 It's always preferable to use a core bridge if you can.
 Core bridges use duplicate detection to provide _once and only once_ guarantees.
 To provide the same guarantee using a JMS bridge you would have to use XA which has a higher overhead and is more complex to configure.
@@ -94,7 +94,7 @@ The default value is `false`.
 filter-string::
 An optional filter string can be supplied.
 If specified then only messages which match the filter expression specified in the filter string will be forwarded.
-The filter string follows the ActiveMQ Artemis filter expression syntax described in xref:filter-expressions.adoc#filter-expressions[Filter Expressions].
+The filter string follows the expression syntax described in xref:filter-expressions.adoc#filter-expressions[Filter Expressions].
 
 transformer-class-name::
 An _optional_ transformer can be specified.

--- a/docs/user-manual/core.adoc
+++ b/docs/user-manual/core.adoc
@@ -3,18 +3,18 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis core is a messaging system with its own API.
-We call this the _core API_.
+Core is a messaging system with its own API.
+We call this the _Core API_.
 
-If you don't want to use the JMS API or any of the other supported protocols you can use the core API directly.
-The core API provides all the functionality of JMS but without much of the complexity.
+If you don't want to use the JMS API or any of the other supported protocols, you can use the Core API directly.
+The Core API provides all the functionality of JMS but without much of the complexity.
 It also provides features that are not available using JMS.
 
 == Core Messaging Concepts
 
-Some of the core messaging concepts are similar to JMS concepts, but core messaging concepts are also different in some ways as well.
-In general the core API is simpler than the JMS API, since we remove distinctions between queues, topics and subscriptions.
-We'll discuss each of the major core messaging concepts in turn, but to see the API in detail please consult the Javadoc.
+Some of the Core messaging concepts are similar to JMS concepts, but Core messaging concepts are different in some ways as well.
+In general, the Core API is simpler than the JMS API since we remove distinctions between queues, topics, and subscriptions.
+We'll discuss each of the major Core messaging concepts in turn, but to see the API in detail, please consult the Javadoc.
 
 Also refer to the xref:address-model.adoc#address-model[address model] chapter for a high-level overview of these concepts as well as configuration details.
 
@@ -23,7 +23,7 @@ Also refer to the xref:address-model.adoc#address-model[address model] chapter f
 * A message is the unit of data which is sent between clients and servers.
 * A message has a body which is a buffer containing convenient methods for reading and writing data into it.
 * A message has a set of properties which are key-value pairs.
-Each property key is a string and property values can be of type integer, long, short, byte, byte[], String, double, float or boolean.
+Each property key is a string and property values can be of type integer, long, short, byte, byte[], String, double, float, or boolean.
 * A message has an _address_ it is being sent to.
 When the message arrives on the server it is routed to any queues that are bound to the address.
 The routing semantics (i.e. anycast or multicast) are determined by the "routing type" of the address and queue.
@@ -39,7 +39,7 @@ The broker will attempt to deliver higher priority messages before lower priorit
 * Messages can be specified with an optional expiry time.
 The broker will not deliver messages after its expiry time has been exceeded.
 * Messages also have an optional timestamp which represents the time the message was sent.
-* Apache ActiveMQ Artemis also supports the sending/consuming of very large messages much larger than can fit in available RAM at any one time.
+* Very large messages (i.e. much larger than can fit in available RAM at any one time) can be sent & consumed.
 
 == Core API
 
@@ -64,20 +64,20 @@ In JMS terms think of them as JMS Connections.
 === ClientSession
 
 A client uses a ``ClientSession``for consuming and producing messages and for grouping them in transactions.
-`ClientSession` instances can support both transactional and non transactional semantics and also provide an `XAResource` interface so messaging operations can be performed as part of a http://www.oracle.com/technetwork/java/javaee/tech/jta-138684.html[JTA] transaction.
+`ClientSession` instances can support both transactional and non-transactional semantics and also provide an `XAResource` interface so messaging operations can be performed as part of a http://www.oracle.com/technetwork/java/javaee/tech/jta-138684.html[JTA] transaction.
 
 `ClientSession` instances group `ClientConsumer` instances and `ClientProducer` instances.
 
 `ClientSession` instances can be registered with an optional `SendAcknowledgementHandler`.
 This allows your client code to be notified asynchronously when sent messages have successfully reached the server.
-This unique Apache ActiveMQ Artemis feature, allows you to have full guarantees that sent messages have reached the server without having to block on each message sent until a response is received.
-Blocking on each messages sent is costly since it requires a network round trip for each message sent.
-By not blocking and receiving send acknowledgements asynchronously you can create true end to end asynchronous systems which is not possible using the standard JMS API.
-For more information on this advanced feature please see the section xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits].
+This unique feature allows you to have full guarantees that sent messages have reached the server without having to block on each message sent until a response is received.
+Blocking on each message sent is costly since it requires a network round trip for each message sent.
+By not blocking and receiving send acknowledgements asynchronously, you can create true end-to-end asynchronous systems that are not possible using the standard JMS API.
+For more information on this advanced feature, please see the section xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits].
 
 ==== Identifying your client application for management and debugging
 
-Assigning IDs to your core session can help you with monitoring and debugging using the xref:management-console.adoc#management-console[management console], e.g.:
+Assigning IDs to your Core session can help you with monitoring and debugging using the xref:management-console.adoc#management-console[management console], e.g.:
 
 [,java]
 ----
@@ -112,7 +112,7 @@ This is  discussed further in the section on performance tuning xref:perf-tuning
 
 == A simple example of using Core
 
-Here's a very simple program using the core messaging API to send and receive a message.
+Here's a very simple program using the Core messaging API to send and receive a message.
 Logically it's comprised of two sections: firstly setting up the producer to write a message to an _address_, and secondly, creating a _queue_ for the consumer using anycast routing, creating the consumer, and _starting_ it.
 
 [,java]

--- a/docs/user-manual/critical-analysis.adoc
+++ b/docs/user-manual/critical-analysis.adoc
@@ -40,8 +40,8 @@ You can use these following configuration options on broker.xml to configure how
 | Should the server log, be halted or shutdown upon failures (default `LOG`)
 |===
 
-The default for critical-analyzer-policy is `LOG`, however the generated broker.xml will have it set to `HALT`.
-That is because we cannot halt the VM if you are embedding ActiveMQ Artemis into an application server or on a multi tenant environment.
+The default for critical-analyzer-policy is `LOG`, however the generated `broker.xml` will have it set to `HALT`.
+That is because we cannot halt the VM if you are embedding a broker or operating in a multi-tenant environment.
 
 The broker on the distribution will then have it set to `HALT`, but if you use it in any other way the default will be `LOG`.
 

--- a/docs/user-manual/data-retention.adoc
+++ b/docs/user-manual/data-retention.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-If you enable `journal-retention-directory` on broker.xml, ActiveMQ Artemis will keep copy of every data that has passed through the broker on this folder.
+If you enable `journal-retention-directory` in `broker.xml` a copy of every journal file used by the broker will be kept in this folder.
 
 [,xml]
 ----
@@ -16,13 +16,13 @@ If you enable `journal-retention-directory` on broker.xml, ActiveMQ Artemis will
 </configuration>
 ----
 
-ActiveMQ Artemis will keep a copy of each generated journal file, up to the configured retention period, at the unit chose.
-On the example above the system would keep all the journal files up to 365 days.
+The broker will keep a copy of each generated journal file, up to the configured retention period at the unit chosen.
+In the example above, the system would keep all the journal files up to 365 days.
 
-It is also possible to limit the number of files kept on the retention directory.
-You can keep a storage-limit, and the system will start removing older files when you have more files than the configured storage limit.
+It is also possible to limit the number of files kept in the retention directory.
+You can define `storage-limit` and older files will be removed when this limit is exceeded.
 
-Notice the storage limit is optional however you need to be careful to not run out of disk space at the retention folder or the broker might be shutdown because of a critical IO failure.
+Notice `storage-limit` is optional, but you need to be careful to not run out of disk space in the retention folder or the broker might be shutdown because of a critical IO failure.
 
 You can use the CLI tools to inspect and recover data from the history, by just passing the journal folder being the retention directory.
 

--- a/docs/user-manual/data-tools.adoc
+++ b/docs/user-manual/data-tools.adoc
@@ -3,32 +3,32 @@
 :idseparator: -
 :docinfo: shared
 
-You can use the Artemis CLI to execute data maintenance tools:
+You can use the CLI to execute data maintenance tools.
 
-The following sub-commands are available when running the CLI data command from a particular broker instance that has already been installed using the create command:
+The following sub-commands are available when running the CLI `data` command from a particular broker instance that has already been installed using the `create` command:
 
 |===
 | Name | Description
 
-| print
+| `print`
 | Prints a report about journal records of a non-running server
 
-| exp
+| `exp`
 | Export the message data using a special and independent XML format
 
-| imp
+| `imp`
 | Imports the journal to a running broker using the output from expt
 
-| encode
+| `encode`
 | shows an internal format of the journal encoded to String
 
-| decode
+| `decode`
 | imports the internal journal format from encode
 
-| compact
+| `compact`
 | Compacts the journal of a non running server
 
-| recover
+| `recover`
 | Recover (undelete) messages from an existing journal and create a new one.
 |===
 
@@ -124,7 +124,7 @@ OPTIONS
             'xml:${ARTEMIS_INSTANCE}/etc/bootstrap.xml'
 ----
 
-For a full list of data tools commands available use:
+For a full list of `data` commands available use:
 
 [,console]
 ----

--- a/docs/user-manual/diverts.adoc
+++ b/docs/user-manual/diverts.adoc
@@ -3,7 +3,6 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis allows you to configure objects called _diverts_ with some simple server configuration.
 Diverts allow you to transparently divert messages routed to one address to one or more other addresses, without making any changes to any client application logic.
 
 Diverts can be _exclusive_ or _non-exclusive_.
@@ -11,7 +10,7 @@ Diverts can be _exclusive_ or _non-exclusive_.
 An xref:#exclusive-divert[_exclusive_] divert routes messages the new address(es) only.
 Messages are not routed to the old address at all.
 
-A xref:#non-exclusive-divert[_non-exclusive_] divert routes messags to the old address and a _copy_ of the messages are also sent to the new address(es).
+A xref:#non-exclusive-divert[_non-exclusive_] divert routes messages to the old address and a _copy_ of the messages are also sent to the new address(es).
 Think of non-exclusive divert as _splitting_ message flow, e.g. there may be a requirement to monitor every order sent to an order queue.
 
 Multiple diverts can be configured for a single address.
@@ -82,18 +81,18 @@ This allows you to change the messages body or properties before it is diverted.
 In this example the transformer simply adds a header that records the time the divert happened.
 See the xref:transformers.adoc#transformers[transformer chapter] for more details about transformer-specific configuration.
 
-This example is actually diverting messages to a local store and forward queue, which is configured with a bridge which forwards the message to an address on another ActiveMQ Artemis server.
+This example is actually diverting messages to a local store and forward queue, which is configured with a bridge which forwards the message to an address on another broker.
 Please see the example for more details.
 
 == Non-exclusive Divert
 
 Now we'll take a look at a non-exclusive divert.
-Non exclusive diverts are the same as exclusive diverts, but they only forward a _copy_ of the message to the new address.
+Non-exclusive diverts are the same as exclusive diverts, but they only forward a _copy_ of the message to the new address.
 The original message continues to the old address
 
 You can therefore think of non-exclusive diverts as _splitting_ a message flow.
 
-Non exclusive diverts can be configured in the same way as exclusive diverts with an optional filter and transformer, here's an example non-exclusive divert, again from the divert example:
+Non-exclusive diverts can be configured in the same way as exclusive diverts with an optional filter and transformer, here's an example non-exclusive divert, again from the divert example:
 
 [,xml]
 ----

--- a/docs/user-manual/docker.adoc
+++ b/docs/user-manual/docker.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-One of the simplest ways to get started with ActiveMQ Artemis is by using one of our Docker images.
+One of the simplest ways to get started is by using one of our Docker images.
 
 == Official Images
 
@@ -45,7 +45,7 @@ Read on for more details.
 
 == Build your own Image
 
-In order to build an image you need an ActiveMQ Artemis binary distribution.
+In order to build an image you need a binary distribution.
 This can be sourced *locally* (in which case you need to build the project first) or *remotely* based on an official Apache release.
 
 === Using a Local Release
@@ -131,7 +131,7 @@ be saved and reused on each run.
 
 ==== Overriding files in `etc` folder
 
-You can use customized configuration for the ActiveMQ Artemis instance by replacing the files residing in the `etc` folder with the custom ones, e.g. `broker.xml` or `artemis.profile`.
+You can use customized configuration for the broker instance by replacing the files residing in the `etc` folder with the custom ones, e.g. `broker.xml` or `artemis.profile`.
 Put the replacement files inside a folder and map it as a volume to:
 ----
 /var/lib/artemis-instance/etc-override

--- a/docs/user-manual/duplicate-detection.adoc
+++ b/docs/user-manual/duplicate-detection.adoc
@@ -3,24 +3,24 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis includes powerful automatic duplicate message detection, filtering out duplicate messages without you having to code your own fiddly duplicate detection logic at the application level.
-This chapter will explain what duplicate detection is, how Apache ActiveMQ Artemis uses it, and how to configure it.
+The broker includes powerful automatic duplicate message detection, filtering out duplicate messages without you having to code your own fiddly duplicate detection logic at the application level.
+This chapter will explain what duplicate detection is, how the broker uses it, and how to configure it.
 
-When sending messages from a client to a server, or indeed from a server to another server, if the target server or connection fails sometime after sending the message, but before the sender receives a response that the send (or commit) was processed successfully then the sender cannot know for sure if the message was sent successfully to the address.
+When sending messages from a client to a server, or indeed from a server to another server, if the target server or connection fails sometime after sending the message, but before the sender receives a response that the send (or commit) was processed successfully, then the sender cannot know for sure if the message was sent successfully to the address.
 
-If the target server or connection failed after the send was received and processed but before the response was sent back then the message will have been sent to the address successfully, but if the target server or connection failed before the send was received and finished processing then it will not have been sent to the address successfully.
-From the senders point of view it's not possible to distinguish these two cases.
+If the target server or connection failed after the send was received and processed, but before the response was sent back then the message will have been sent to the address successfully, but if the target server or connection failed before the send was received and finished processing, then it will not have been sent to the address successfully.
+From the senders' point of view, it's not possible to distinguish these two cases.
 
-When the server recovers this leaves the client in a difficult situation.
+When the server recovers, this leaves the client in a difficult situation.
 It knows the target server failed, but it does not know if the last message reached its destination successfully.
 If it decides to resend the last message then that could result in a duplicate message being sent to the address.
-If each message was an order or a trade then this could result in the order being fulfilled twice or the trade being double booked.
+If each message was an order or a trade then this could result in the order being fulfilled twice or the trade being double-booked.
 This is clearly not a desirable situation.
 
 Sending the message(s) in a transaction does not help either.
-If the server or connection fails while the transaction commit is being processed it is also indeterminate whether the transaction was successfully committed or not!
+If the server or connection fails while the transaction commit is being processed, it is also indeterminate whether the transaction was successfully committed or not!
 
-To solve these issues Apache ActiveMQ Artemis provides automatic duplicate messages detection for messages sent to addresses.
+Automatic duplicate messages detection solves these problems.
 
 == Using Duplicate Detection for Message Sending
 
@@ -51,7 +51,7 @@ String myUniqueID = "This is my unique id";   // Could use a UUID for this
 message.setStringProperty(HDR_DUPLICATE_DETECTION_ID.toString(), myUniqueID);
 ----
 
-If using the Artemis Core client the value of the property can be of type `String`, `SimpleString`, or `byte[]`.
+If using the Core client the value of the property can be of type `String`, `SimpleString`, or `byte[]`.
 
 Here's an example of setting the property using the Core API:
 

--- a/docs/user-manual/embedding-activemq.adoc
+++ b/docs/user-manual/embedding-activemq.adoc
@@ -1,21 +1,21 @@
-= Embedding Apache ActiveMQ Artemis
+= Embedding {project-name-full}
 :idprefix:
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis is designed as set of simple Plain Old Java Objects (POJOs).
-This means Apache ActiveMQ Artemis can be instantiated and run in any dependency injection framework such as Spring or Google Guice.
-It also means that if you have an application that could use messaging functionality internally then it can _directly instantiate_ Apache ActiveMQ Artemis clients and servers in its own application code to perform that functionality.
-We call this _embedding_ Apache ActiveMQ Artemis.
+The broker is designed as a set of simple Plain Old Java Objects (POJOs).
+This means it can be instantiated and run in any dependency injection framework such as Spring or Google Guice.
+It also means that if you have an application that could use messaging functionality internally, then it can _directly instantiate_ clients and servers in its own application code to perform that functionality.
+We call this _embedding_ a broker.
 
 Examples of applications that might want to do this include any application that needs very high performance, transactional, persistent messaging but doesn't want the hassle of writing it all from scratch.
 
-Embedding Apache ActiveMQ Artemis can be done in very few easy steps - supply a `broker.xml` on the classpath or instantiate the configuration object, instantiate the server, start it, and you have a Apache ActiveMQ Artemis running in your JVM.
+Embedding can be done in very few easy steps - supply a `broker.xml` on the classpath or instantiate the configuration object, instantiate the server, start it, and you have a broker running in your JVM.
 It's as simple and easy as that.
 
 == Embedding with XML configuration
 
-The simplest way to embed Apache ActiveMQ Artemis is to use the embedded wrapper class and configure Apache ActiveMQ Artemis through `broker.xml`.
+The simplest way to embed a broker is to use the embedded wrapper class and configure it through `broker.xml`.
 
 Here's a simple example `broker.xml`:
 
@@ -70,7 +70,7 @@ See the javadocs for this class for more details.
 You can follow this step-by-step guide to programmatically embed a broker instance.
 
 Create the `Configuration` object.
-This contains configuration information for an Apache ActiveMQ Artemis instance.
+This contains configuration information for a broker instance.
 The setter methods of this class allow you to programmatically set configuration options as described in the xref:configuration-index.adoc#configuration-reference[Server Configuration] section.
 
 The acceptors are configured through `Configuration`.

--- a/docs/user-manual/examples.adoc
+++ b/docs/user-manual/examples.adoc
@@ -3,9 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-The Apache ActiveMQ Artemis Examples repository contains over 90 examples demonstrating many of the client and broker features.
-
-The examples can be found at: https://github.com/apache/activemq-artemis-examples[https://github.com/apache/activemq-artemis-examples^]
+https://github.com/apache/activemq-artemis-examples[The Examples repository^] contains over 90 examples demonstrating many of the client and broker features.
 
 The individual examples are available under the `examples` directory, and are grouped within the following sub tree:
 
@@ -167,13 +165,14 @@ server-out:Server stopped!
 [INFO] ------------------------------------------------------------------------
 ----
 
-This list includes a preview of some examples that exist for Artemis in the https://github.com/apache/activemq-artemis-examples[Examples Repository^], see the repository for more.
+This list includes a preview of some examples in the https://github.com/apache/activemq-artemis-examples[Examples Repository^].
+See the repository for more.
 
 == Application-Layer Failover
 
-Apache ActiveMQ Artemis also supports Application-Layer failover, useful in the case that replication is not enabled on the server side.
+The broker also supports Application-Layer failover, useful in the case that replication is not enabled on the server side.
 
-With Application-Layer failover, it's up to the application to register a JMS `ExceptionListener` with Apache ActiveMQ Artemis which will be called by Apache ActiveMQ Artemis in the event that connection failure is detected.
+With Application-Layer failover, it's up to the application to register a JMS `ExceptionListener` with the broker which will be called in the event that connection failure is detected.
 
 The code in the `ExceptionListener` then recreates the JMS connection, session, etc on another node and the application can continue.
 
@@ -185,12 +184,12 @@ Also, with Application-layer failover, since the old session object dies and a n
 
 The `bridge` example demonstrates a core bridge deployed on one server, which consumes messages from a local queue and forwards them to an address on a second server.
 
-Core bridges are used to create message flows between any two Apache ActiveMQ Artemis servers which are remotely separated.
+Core bridges are used to create message flows between any two remote brokers.
 Core bridges are resilient and will cope with temporary connection failure allowing them to be an ideal choice for forwarding over unreliable connections, e.g. a WAN.
 
 == Browser
 
-The `browser` example shows you how to use a JMS `QueueBrowser` with Apache ActiveMQ Artemis.
+The `browser` example shows you how to use a JMS `QueueBrowser`.
 
 Queues are a standard part of JMS, please consult the JMS 2.0 specification for full details.
 
@@ -212,7 +211,7 @@ The `client-side-failoverlistener` example shows how to register a listener to m
 == Client-Side Load-Balancing
 
 The `client-side-load-balancing` example demonstrates how sessions created from a single JMS `Connection` can be created to different nodes of the cluster.
-In other words it demonstrates how Apache ActiveMQ Artemis does client-side load-balancing of sessions across the cluster.
+In other words it demonstrates client-side load-balancing of sessions across the cluster.
 
 == Clustered Durable Subscription
 
@@ -259,10 +258,10 @@ We then send some messages via the producer, and we verify that both subscribers
 
 == Message Consumer Rate Limiting
 
-With Apache ActiveMQ Artemis you can specify a maximum consume rate at which a JMS MessageConsumer will consume messages.
+You can specify a maximum rate at which a JMS `MessageConsumer` will consume messages.
 This can be specified when creating or deploying the connection factory.
 
-If this value is specified then Apache ActiveMQ Artemis will ensure that messages are never consumed at a rate higher than the specified rate.
+If this value is specified, then the broker will ensure that messages are never consumed at a rate higher than the specified rate.
 This is a form of consumer throttling.
 
 == Dead Letter
@@ -277,18 +276,18 @@ To prevent this, messaging systems define dead letter messages: after a specifie
 
 == Delayed Redelivery
 
-The `delayed-redelivery` example demonstrates how Apache ActiveMQ Artemis can be configured to provide a delayed redelivery in the case a message needs to be redelivered.
+The `delayed-redelivery` example demonstrates how the broker can be configured to provide a delayed redelivery in the case a message needs to be redelivered.
 
 Delaying redelivery can often be useful in the case that clients regularly fail or roll-back.
 Without a delayed redelivery, the system can get into a "thrashing" state, with delivery being attempted, the client rolling back, and delivery being re-attempted in quick succession, using up valuable CPU and network resources.
 
 == Divert
 
-Apache ActiveMQ Artemis diverts allow messages to be transparently "diverted" or copied from one address to another with just some simple configuration defined on the server side.
+Diverts allow messages to be transparently "diverted" or copied from one address to another with just some simple configuration defined on the server side.
 
 == Durable Subscription
 
-The `durable-subscription` example shows you how to use a durable subscription with Apache ActiveMQ Artemis.
+The `durable-subscription` example shows you how to use a durable subscription.
 Durable subscriptions are a standard part of JMS, please consult the JMS 1.1 specification for full details.
 
 Unlike non-durable subscriptions, the key function of durable subscriptions is that the messages contained in them persist longer than the lifetime of the subscriber - i.e. they will accumulate messages sent to the topic even if there is no active subscriber on them.
@@ -301,7 +300,7 @@ The `embedded` example shows how to embed a broker within your own code using PO
 
 == Embedded Simple
 
-The `embedded-simple` example shows how to embed a broker within your own code using regular Apache ActiveMQ Artemis XML files.
+The `embedded-simple` example shows how to embed a broker within your own code using regular XML files.
 
 == Exclusive Queue
 
@@ -313,29 +312,28 @@ The `expiry` example shows you how to define and deal with message expiration.
 Messages can be retained in the messaging system for a limited period of time before being removed.
 JMS specification states that clients should not receive messages that have been expired (but it does not guarantee this will not happen).
 
-Apache ActiveMQ Artemis can assign an expiry address to a given queue so that when messages are expired, they are removed from the queue and sent to the expiry address.
+the broker can assign an expiry address to a given queue so that when messages are expired, they are removed from the queue and sent to the expiry address.
 These "expired" messages can later be consumed from the expiry address for further inspection.
 
-== Apache ActiveMQ Artemis Resource Adapter example
+== Resource Adapter example
 
 This examples shows how to build the activemq resource adapters a rar for deployment in other Application Server's
 
 == HTTP Transport
 
-The `http-transport` example shows you how to configure Apache ActiveMQ Artemis to use the HTTP protocol as its transport layer.
+The `http-transport` example shows you how to configure the broker to use the HTTP protocol as its transport layer.
 
 == Instantiate JMS Objects Directly
 
 Usually, JMS Objects such as `ConnectionFactory`, `Queue` and `Topic` instances are looked up from JNDI before being used by the client code.
-This objects are called "administered objects" in JMS terminology.
+These objects are called "administered objects" in JMS terminology.
 
 However, in some cases a JNDI server may not be available or desired.
-To come to the rescue Apache ActiveMQ Artemis also supports the direct instantiation of these administered objects on the client side so you don't have to use JNDI for JMS.
+To come to the rescue the Core JMS client also supports the direct instantiation of these administered objects on the client side, so you don't have to use JNDI for JMS.
 
 == Interceptor
 
-Apache ActiveMQ Artemis allows an application to use an interceptor to hook into the messaging system.
-Interceptors allow you to handle various message events in Apache ActiveMQ Artemis.
+Interceptors allow an application to hook into the messaging system to handle various events.
 
 == Interceptor AMQP
 
@@ -351,8 +349,8 @@ Similar to the <<#interceptor,Interceptor>> example, but using MQTT interceptors
 
 == JAAS
 
-The `jaas` example shows you how to configure Apache ActiveMQ Artemis to use JAAS for security.
-Apache ActiveMQ Artemis can leverage JAAS to delegate user authentication and authorization to existing security infrastructure.
+The `jaas` example shows you how to configure the broker to use JAAS for security.
+JAAS is leveraged to delegate user authentication and authorization to existing security infrastructure.
 
 == JMS Auto Closable
 
@@ -360,15 +358,15 @@ The `jms-auto-closeable` example shows how JMS resources, such as connections, s
 
 == JMS Completion Listener
 
-The `jms-completion-listener` example shows how to send a message asynchronously to Apache ActiveMQ Artemis and use a CompletionListener to be notified of the Broker receiving it.
+The `jms-completion-listener` example shows how to send a message asynchronously and use a `CompletionListener` to be notified of the Broker receiving it.
 
 == JMS Bridge
 
-The `jms-bridge` example shows how to setup a bridge between two standalone Apache ActiveMQ Artemis servers.
+The `jms-bridge` example shows how to setup a bridge between two standalone brokers.
 
 == JMS Context
 
-The `jms-context` example shows how to send and receive a message to/from an address/queue using Apache ActiveMQ Artemis by using a JMS Context.
+The `jms-context` example shows how to send and receive a message to/from an address/queue using a `JMSContext`.
 
 A JMSContext is part of JMS 2.0 and combines the JMS Connection and Session Objects into a simple Interface.
 
@@ -380,33 +378,33 @@ In JMS 2 this restriction has been lifted so you can share the load across diffe
 
 == JMX Management
 
-The `jmx` example shows how to manage Apache ActiveMQ Artemis using JMX.
+The `jmx` example shows how to manage a broker using JMX.
 
 == Large Message
 
-The `large-message` example shows you how to send and receive very large messages with Apache ActiveMQ Artemis.
-Apache ActiveMQ Artemis supports the sending and receiving of huge messages, much larger than can fit in available RAM on the client or server.
-Effectively the only limit to message size is the amount of disk space you have on the server.
+The `large-message` example shows you how to send and receive very large messages.
+The Core client supports the sending and receiving of huge messages, much larger than can fit in available RAM on the client or server.
+Effectively, the only limit to message size is the amount of disk space you have on the server.
 
 Large messages are persisted on the server so they can survive a server restart.
-In other words Apache ActiveMQ Artemis doesn't just do a simple socket stream from the sender to the consumer.
+In other words, the broker doesn't just do a simple socket stream from the sender to the consumer.
 
 == Last-Value Queue
 
 The `last-value-queue` example shows you how to define and deal with last-value queues.
-Last-value queues are special queues which discard any messages when a newer message with the same value for a well-defined last-value property is put in the queue.
+Last-value queues are special queues that discard any messages when a newer message with the same value for a well-defined last-value property is put in the queue.
 In other words, a last-value queue only retains the last value.
 
 A typical example for last-value queue is for stock prices, where you are only interested by the latest price for a particular stock.
 
 == Management
 
-The `management` example shows how to manage Apache ActiveMQ Artemis using JMS Messages to invoke management operations on the server.
+The `management` example shows how to manage the broker using JMS Messages to invoke management operations.
 
 == Management Notification
 
-The `management-notification` example shows how to receive management notifications from Apache ActiveMQ Artemis using JMS messages.
-Apache ActiveMQ Artemis servers emit management notifications when events of interest occur (consumers are created or closed, addresses are created or deleted, security authentication fails, etc.).
+The `management-notification` example shows how to receive management notifications from the broker using JMS messages.
+The broker emits management notifications when events of interest occur (e.g. consumers are created or closed, addresses are created or deleted, security authentication fails, etc.).
 
 == Message Counter
 
@@ -414,7 +412,7 @@ The `message-counters` example shows you how to use message counters to obtain m
 
 == Message Group
 
-The `message-group` example shows you how to configure and use message groups with Apache ActiveMQ Artemis.
+The `message-group` example shows you how to configure and use message groups.
 Message groups allow you to pin messages so they are only consumed by a single consumer.
 Message groups are sets of messages that has the following characteristics:
 
@@ -423,7 +421,7 @@ Message groups are sets of messages that has the following characteristics:
 
 == Message Group
 
-The `message-group2` example shows you how to configure and use message groups with Apache ActiveMQ Artemis via a connection factory.
+The `message-group2` example shows you how to configure and use message groups via a connection factory.
 
 == Message Priority
 
@@ -448,34 +446,34 @@ This example demonstrates how to set up a primary server with multiple backups b
 
 == No Consumer Buffering
 
-By default, Apache ActiveMQ Artemis consumers buffer messages from the server in a client side buffer before you actually receive them on the client side.
-This improves performance since otherwise every time you called receive() or had processed the last message in a `MessageListener onMessage()` method, the Apache ActiveMQ Artemis client would have to go the server to request the next message, which would then get sent to the client side, if one was available.
+By default, consumers buffer messages from the server in a client side buffer before you actually receive them on the client side.
+This improves performance since otherwise every time you called receive() or had processed the last message in a `MessageListener onMessage()` method, the Core client would have to go the server to request the next message, which would then get sent to the client side, if one was available.
 
 This would involve a network round trip for every message and reduce performance.
-Therefore, by default, Apache ActiveMQ Artemis pre-fetches messages into a buffer on each consumer.
+Therefore, by default, the Core client pre-fetches messages into a buffer on each consumer.
 
-In some case buffering is not desirable, and Apache ActiveMQ Artemis allows it to be switched off.
+In some cases buffering is not desirable, and it can be switched off.
 This example demonstrates that.
 
 == Non-Transaction Failover With Server Data Replication
 
-The `non-transaction-failover` example demonstrates two servers coupled as a live-backup pair for high availability (HA), and a client using a _non-transacted_ JMS session failing over from primary to backup when the primary server is crashed.
+The `non-transaction-failover` example demonstrates two servers coupled as a live-backup pair for high-availability (HA), and a client using a _non-transacted_ JMS session failing over from primary to backup when the primary server is crashed.
 
-Apache ActiveMQ Artemis implements failover of client connections between primary and backup servers.
+Client connections can failover between primary and backup servers.
 This is implemented by the replication of state between primary and backup nodes.
 When replication is configured and a primary node crashes, the client connections can carry on and continue to send and consume messages.
 When non-transacted sessions are used, once and only once message delivery is not guaranteed and it is possible that some messages will be lost or delivered twice.
 
 == OpenWire
 
-The `Openwire` example shows how to configure an Apache ActiveMQ Artemis server to communicate with an Apache ActiveMQ Artemis JMS client that uses open-wire protocol.
+The `Openwire` example shows how to configure a broker to communicate with a JMS client that uses the OpenWire protocol.
 
-You will find the queue example for open wire, and the chat example.
-The virtual-topic-mapping examples shows how to map the ActiveMQ Classic Virtual Topic naming convention to work with the Artemis Address model.
+You will find the `queue` example for OpenWire, and the `chat` example.
+The `virtual-topic-mapping` example shows how to map the ActiveMQ Virtual Topic naming convention to work with the xref:address-model.adoc[address model].
 
 == Paging
 
-The `paging` example shows how Apache ActiveMQ Artemis can support huge queues even when the server is running in limited RAM.
+The `paging` example shows how to support huge queues even when running in limited RAM.
 It does this by transparently _paging_ messages to disk, and _depaging_ them when they are required.
 
 == Pre-Acknowledge
@@ -485,11 +483,11 @@ For a full description on these modes please consult the JMS specification, or a
 
 All of these standard modes involve sending acknowledgements from the client to the server.
 However in some cases, you really don't mind losing messages in event of failure, so it would make sense to acknowledge the message on the server before delivering it to the client.
-This example demonstrates how Apache ActiveMQ Artemis allows this with an extra acknowledgement mode.
+This example demonstrates this extra acknowledgement mode.
 
 == Message Producer Rate Limiting
 
-The `producer-rte-limit` example demonstrates how, with Apache ActiveMQ Artemis, you can specify a maximum send rate at which a JMS message producer will send messages.
+The `producer-rte-limit` example demonstrates how to specify a maximum send rate at which a JMS message producer will send messages.
 
 == Queue
 
@@ -510,7 +508,7 @@ The `queue-selector` example shows you how to selectively consume messages using
 == Reattach Node example
 
 The `Reattach Node` example shows how a client can try to reconnect to the same server instead of failing the connection immediately and notifying any user ExceptionListener objects.
-Apache ActiveMQ Artemis can be configured to automatically retry the connection, and reattach to the server when it becomes available again across the network.
+The broker can be configured to automatically retry the connection and reattach to the server when it becomes available again across the network.
 
 == Replicated Failback example
 
@@ -535,67 +533,67 @@ A simple example showing the JMS request-response pattern.
 
 == Scheduled Message
 
-The `scheduled-message` example shows you how to send a scheduled message to an address/queue with Apache ActiveMQ Artemis.
+The `scheduled-message` example shows you how to send a scheduled message to an address/queue.
 Scheduled messages won't get delivered until a specified time in the future.
 
 == Security
 
-The `security` example shows you how configure and use role based security with Apache ActiveMQ Artemis.
+The `security` example shows you how configure and use role based security.
 
 == Security LDAP
 
-The `security-ldap` example shows you how configure and use role based security with Apache ActiveMQ Artemis & an embedded instance of the Apache DS LDAP server.
+The `security-ldap` example shows you how configure and use role based security & an embedded instance of the Apache DS LDAP server.
 
 == Security keycloak
 
-The `security-keycloak` example shows you how to delegate security with Apache ActiveMQ Artemis & an external Keycloak.
+The `security-keycloak` example shows you how to delegate security with & an external Keycloak.
 Using OAuth of the web console and direct access for JMS clients.
 
 == Send Acknowledgements
 
-The `send-acknowledgements` example shows you how to use Apache ActiveMQ Artemis's advanced _asynchronous send acknowledgements_ feature to obtain acknowledgement from the server that sends have been received and processed in a separate stream to the sent messages.
+The `send-acknowledgements` example shows you how to use the Core client's advanced _asynchronous send acknowledgements_ feature to obtain acknowledgement from the server that sends have been received and processed in a separate stream to the sent messages.
 
 == Slow Consumer
 
-The `slow-consumer` example shows you how to detect slow consumers and configure a slow consumer policy in Apache ActiveMQ Artemis's
+The `slow-consumer` example shows you how to detect slow consumers and configure a slow consumer policy.
 
 == Spring Integration
 
-This example shows how to use embedded JMS using Apache ActiveMQ Artemis's Spring integration.
+This example shows how to embed a JMS broker into a Spring application.
 
 == SSL Transport
 
-The `ssl-enabled` shows you how to configure SSL with Apache ActiveMQ Artemis to send and receive message.
+The `ssl-enabled` shows you how to configure SSL when sending and receiving messages.
 
 == Static Message Selector
 
-The `static-selector` example shows you how to configure an Apache ActiveMQ Artemis core queue with static message selectors (filters).
+The `static-selector` example shows you how to configure a queue with static message selectors (filters).
 
 == Static Message Selector Using JMS
 
-The `static-selector-jms` example shows you how to configure an Apache ActiveMQ Artemis queue with static message selectors (filters) using JMS.
+The `static-selector-jms` example shows you how to configure a queue with static message selectors (filters) using JMS.
 
 == Stomp
 
-The `stomp` example shows you how to configure an Apache ActiveMQ Artemis server to send and receive Stomp messages.
+The `stomp` example shows you how to send and receive Stomp messages.
 
 == Stomp1.1
 
-The `stomp` example shows you how to configure an Apache ActiveMQ Artemis server to send and receive Stomp messages via a Stomp 1.1 connection.
+The `stomp` example shows you how to send and receive Stomp messages via a Stomp 1.1 connection.
 
 == Stomp1.2
 
-The `stomp` example shows you how to configure an Apache ActiveMQ Artemis server to send and receive Stomp messages via a Stomp 1.2 connection.
+The `stomp` example shows you how to send and receive Stomp messages via a Stomp 1.2 connection.
 
-== Stomp Over Web Sockets
+== Stomp Over WebSockets
 
-The `stomp-websockets` example shows you how to configure an Apache ActiveMQ Artemis server to send and receive Stomp messages directly from Web browsers (provided they support Web Sockets).
+The `stomp-websockets` example shows you how to send and receive Stomp messages directly from Web browsers (provided they support WebSockets).
 
 == Symmetric Cluster
 
-The `symmetric-cluster` example demonstrates a symmetric cluster set-up with Apache ActiveMQ Artemis.
+The `symmetric-cluster` example demonstrates a symmetric cluster set-up.
 
-Apache ActiveMQ Artemis has extremely flexible clustering which allows you to set-up servers in many different topologies.
+Clusters can b set up in many different topologies.
 The most common topology that you'll perhaps be familiar with if you are used to application server clustering is a symmetric cluster.
 
 With a symmetric cluster, the cluster is homogeneous, i.e. each node is configured the same as every other node, and every node is connected to every other node in the cluster.
@@ -610,12 +608,11 @@ A simple example demonstrating a JMS topic.
 
 == Topic Hierarchy
 
-Apache ActiveMQ Artemis supports topic hierarchies.
-With a topic hierarchy you can register a subscriber with a wild-card and that subscriber will receive any messages sent to an address that matches the wild card.
+With a topic hierarchy you can register a subscriber with a wild-card, and that subscriber will receive any messages sent to an address that matches the wild card.
 
 == Topic Selector 1
 
-The `topic-selector-example1` example shows you how to send message to a JMS Topic, and subscribe them using selectors with Apache ActiveMQ Artemis.
+The `topic-selector-example1` example shows you how to send a message to a JMS Topic, and subscribe them using selectors.
 
 == Topic Selector 2
 
@@ -625,7 +622,7 @@ The `topic-selector-example2` example shows you how to selectively consume messa
 
 The `transaction-failover` example demonstrates two servers coupled as a live-backup pair for high availability (HA), and a client using a transacted JMS session failing over from primary to backup when the primary server is crashed.
 
-Apache ActiveMQ Artemis implements failover of client connections between primary and backup servers.
+The broker implements failover of client connections between primary and backup servers.
 This is implemented by the sharing of a journal between the servers.
 When a primary node crashes, the client connections can carry and continue to send and consume messages.
 When transacted sessions are used, once and only once message delivery is guaranteed.
@@ -636,17 +633,17 @@ The `stop-server-failover` example demonstrates failover of the JMS connection f
 
 == Transactional Session
 
-The `transactional` example shows you how to use a transactional Session with Apache ActiveMQ Artemis.
+The `transactional` example shows you how to use a transactional Session.
 
 == XA Heuristic
 
-The `xa-heuristic` example shows you how to make an XA heuristic decision through Apache ActiveMQ Artemis Management Interface.
+The `xa-heuristic` example shows you how to make an XA heuristic decision through the broker's management interface.
 A heuristic decision is a unilateral decision to commit or rollback an XA transaction branch after it has been prepared.
 
 == XA Receive
 
-The `xa-receive` example shows you how message receiving behaves in an XA transaction in Apache ActiveMQ Artemis.
+The `xa-receive` example shows you how message receiving behaves in an XA transaction.
 
 == XA Send
 
-The `xa-send` example shows you how message sending behaves in an XA transaction in Apache ActiveMQ Artemis.
+The `xa-send` example shows you how message sending behaves in an XA transaction.

--- a/docs/user-manual/exclusive-queues.adoc
+++ b/docs/user-manual/exclusive-queues.adoc
@@ -25,7 +25,7 @@ Exclusive queues can be statically configured using the `exclusive` boolean  pro
 </address>
 ----
 
-Specified on creating a Queue by using the CORE api specifying the parameter  `exclusive` to `true`.
+Specified on creating a Queue by using the Core API specifying the parameter  `exclusive` to `true`.
 
 Or on auto-create when using the JMS Client by using address parameters when  creating the destination used by the consumer.
 

--- a/docs/user-manual/federation.adoc
+++ b/docs/user-manual/federation.adoc
@@ -26,8 +26,8 @@ When it comes back online it will resume operation as normal.
 
 Federation can transmit messages between brokers (or clusters) in different administrative domains:
 
-* they may have different configuration, users and setup;
-* they may run on different versions of ActiveMQ Artemis
+* they may have different configurations, users, and setups
+* they may run on different versions of the broker
 
 === Dynamic and Selective
 

--- a/docs/user-manual/filter-expressions.adoc
+++ b/docs/user-manual/filter-expressions.adoc
@@ -3,23 +3,23 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis provides a powerful filter language based on a subset of the SQL 92 expression syntax.
+{project-name-full} provides a powerful filter language based on a subset of the SQL 92 expression syntax.
 
 It is the same as the syntax used for JMS & Jakarta Messaging selectors, but the predefined identifiers are different.
-For documentation on JMS selector syntax please the JavaDoc for https://docs.oracle.com/javaee/7/api/javax/jms/Message.html[`javax.jms.Message`].
-For the corresponding Jakarta Messaging JavaDoc see https://jakarta.ee/specifications/messaging/3.0/apidocs/jakarta/jms/message[`jakarta.jms.Message`]
+For documentation on JMS selector syntax please see the JavaDoc for https://docs.oracle.com/javaee/7/api/javax/jms/Message.html[`javax.jms.Message`].
+For the corresponding Jakarta Messaging JavaDoc see https://jakarta.ee/specifications/messaging/3.0/apidocs/jakarta/jms/message[`jakarta.jms.Message`].
 
-Filter expressions are used in several places in Apache ActiveMQ Artemis
+Filter expressions are used in several places:
 
 * Predefined Queues.
 When pre-defining a queue, in `broker.xml` in either the core or jms configuration a filter expression can be defined for a queue.
 Only messages that match the filter expression will enter the queue.
 * Core bridges can be defined with an optional filter expression, only matching messages will be bridged (see xref:core-bridges.adoc#core-bridges[Core Bridges]).
 * Diverts can be defined with an optional filter expression, only matching messages will be diverted (see xref:diverts.adoc#diverting-and-splitting-message-flows[Diverts]).
-* Filter are also used programmatically when creating consumers, queues and in several places as described in xref:management.adoc#management[management].
+* Filters are also used programmatically when creating consumers, queues and in several places as described in xref:management.adoc#management[management].
 
-There are some differences between JMS selector expressions and Apache ActiveMQ Artemis core filter expressions.
-Whereas JMS selector expressions operate on a JMS message, Apache ActiveMQ Artemis core filter expressions operate on a core message.
+There are some differences between JMS selector expressions and Core filter expressions.
+Whereas JMS selector expressions operate on a JMS message, Core filter expressions operate on a core message.
 
 The following identifiers can be used in a core filter expressions to refer to attributes of the core message in an expression:
 
@@ -59,7 +59,7 @@ Any other identifiers used in core filter expressions will be assumed to be prop
 
 The JMS and Jakarta Messaging specs state that a String property should not get converted to a numeric when used in a selector.
 So for example, if a message has the `age` property set to `String` `21` then the following selector should not match it: `age > 18`.
-Since Apache ActiveMQ Artemis supports STOMP clients which can only send messages with string properties, that restriction is a bit limiting.
+STOMP clients, for example, can only send messages with string properties, which is a bit limiting.
 Therefore, if you want your filter expressions to auto-convert `String` properties to the appropriate number type, just prefix it with `convert_string_expressions:`.
 If you changed the filter expression in the previous example to be `convert_string_expressions:age > 18`, then it would  match the aforementioned message.
 
@@ -78,7 +78,7 @@ For example, if a message had the `foo-bar` property set to `0` then the filter 
 
 == XPath
 
-Apache ActiveMQ Artemis also supports special https://en.wikipedia.org/wiki/XPath[XPath] filters which operate on the _body_ of a message.
+Special https://en.wikipedia.org/wiki/XPath[XPath] filters which operate on the _body_ of a message are also available.
 The body must be XML.
 To use an XPath filter use this syntax:
 

--- a/docs/user-manual/flow-control.adoc
+++ b/docs/user-manual/flow-control.adoc
@@ -9,17 +9,18 @@ Flow control is used to limit the flow of data between a client and server, or a
 
 This controls the flow of data between the server and the client as the client consumes messages.
 For performance reasons clients normally buffer messages before delivering to the consumer via the `receive()` method or asynchronously via a message listener.
-If the consumer cannot process messages as fast as they are being delivered and stored in the internal buffer, then you could end up with a situation where messages would keep building up possibly causing out of memory on the client if they cannot be processed in time.
+If the consumer cannot process messages as fast as they are being delivered and stored in the internal buffer.
+Ultimately, you could end up with a situation where messages would keep building up, possibly causing out of memory on the client if they cannot be processed in time.
 
 === Window-Based Flow Control
 
-By default, Apache ActiveMQ Artemis consumers buffer messages from the server in a client side buffer before the client consumes them.
-This improves performance: otherwise every time the client consumes a message, Apache ActiveMQ Artemis would have to go the server to request the next message.
-In turn, this message would then get sent to the client side, if one was available.
+By default, Core consumers buffer messages from the broker in a client side buffer before the client consumes them.
+This improves performance: otherwise every time the client consumes a message, the client would have to request the next message from the queue on the broker.
+In turn, this message would then get sent to the client side if one was available.
 
 A network round trip would be involved for _every_ message and considerably reduce performance.
 
-To prevent this, Apache ActiveMQ Artemis pre-fetches messages into a buffer on each consumer.
+To prevent this, the Core client pre-fetches messages into a buffer on each consumer.
 The total maximum size of messages (in bytes) that will be buffered on each consumer is determined by the `consumerWindowSize` parameter.
 
 By default, the `consumerWindowSize` is set to 1 MiB (1024 * 1024 bytes) unless overridden via (xref:address-settings.adoc#address-settings[Address Settings])
@@ -61,7 +62,7 @@ Setting this to 0 can give deterministic distribution between multiple consumers
 Most of the consumers cannot be clearly identified as fast or slow consumers but are in-between.
 In that case, setting the value of `consumerWindowSize` to optimize performance depends on the messaging use case and requires benchmarks to find the optimal value, but a value of 1MiB is fine in most cases.
 
-Please see xref:examples.adoc#examples[the examples chapter] for an example which shows how to configure ActiveMQ Artemis to prevent consumer buffering when dealing with slow consumers.
+Please see xref:examples.adoc#examples[the examples chapter] for an example which shows how to configure the broker to prevent consumer buffering when dealing with slow consumers.
 
 === Rate limited flow control
 
@@ -77,31 +78,31 @@ Please see xref:examples.adoc#examples[the examples chapter] for a working examp
 
 [NOTE]
 ====
-Rate limited flow control can be used in conjunction with window based flow control.
-Rate limited flow control only effects how many messages a client can consume in a second and not how many messages are in its buffer.
-So if you had a slow rate limit and a high window based limit the clients internal buffer would soon fill up with messages.
+Rate-limited flow control can be used in conjunction with window-based flow control.
+Rate-limited flow control only effects how many messages a client can consume in a second and not how many messages are in its buffer.
+So if you had a slow rate limit and a high window-based limit, the clients internal buffer would soon fill up with messages.
 ====
 
 == Producer flow control
 
-Apache ActiveMQ Artemis also can limit the amount of data sent from a client to a server to prevent the server being overwhelmed.
+The Core client also can limit the amount of data sent to a server to prevent the server from being overwhelmed.
 
-=== Window based flow control
+=== Window-based flow control
 
-In a similar way to consumer window based flow control, Apache ActiveMQ Artemis producers, by default, can only send messages to an address as long as they have sufficient credits to do so.
-The amount of credits required to send a message is given by the size of the message.
+Similarly to consumer window-based flow control, Core producers, by default, can only send messages to an address as long as they have enough credits to do so.
+The number of credits required to send a message is given by the size of the message.
 
-As producers run low on credits they request more from the server, when the server sends them more credits they can send more messages.
+As producers run low on credits, they request more from the server; when the server sends them more credits, they can send more messages.
 
 The amount of credits a producer requests in one go is known as the _window size_ and it is controlled by the `producerWindowSize` URI parameter.
 
 The window size therefore determines the amount of bytes that can be in-flight at any one time before more need to be requested - this prevents the remoting connection from getting overloaded.
 
-==== Blocking CORE Producers
+==== Blocking Core Producers
 
-When using the CORE protocol (used by both the Artemis Core Client and Artemis JMS Client) the server will always aim give the same number of credits as have been requested.
+When using the Core protocol (used by both the broker's Core client and JMS client) the server will always aim to give the same number of credits as have been requested.
 However, it is also possible to set a maximum size on any address, and the server will never send more credits to any one producer than what is available according to the address's upper memory limit.
-Although a single producer will be issued more credits than available (at the time of issue) it is possible that more than 1 producer be associated with the same address and so it is theoretically possible that more credits are allocated across total producers than what is available.
+Although a single producer will be issued more credits than available (at the time of issue) it is possible that more than 1 producer will be associated with the same address and so it is theoretically possible that more credits are allocated across total producers than what is available.
 It is therefore possible to go over the address limit by approximately:
 
 ----
@@ -155,27 +156,26 @@ It is also possible for a misbehaving client to ignore the flow control credits 
 
 ==== Blocking AMQP Producers
 
-Apache ActiveMQ Artemis ships with out of the box with 2 protocols that support flow control.
-Artemis CORE protocol and AMQP.
+The broker supports flow control for two protocols - Core and AMQP.
 Both protocols implement flow control slightly differently and therefore address full BLOCK policy behaves slightly different for clients that use each protocol respectively.
 
-As explained earlier in this chapter the CORE protocol uses a producer window size flow control system.
+As explained earlier in this chapter the Core protocol uses a producer window size flow control system.
 Where credits (representing bytes) are allocated to producers, if a producer wants to send a message it should wait until it has enough byte credits available for it to send.
 AMQP flow control credits are not representative of bytes but instead represent the number of messages a producer is permitted to send (regardless of the message size).
 
 BLOCK for AMQP works mostly in the same way as the producer window size mechanism above.
-Artemis will issue 100 credits to a client at a time and refresh them when the clients credits reaches 30.
+The broker will issue 100 credits to a client at a time and refresh them when the clients credits reaches 30.
 The broker will stop issuing credits once an address is full.
 However, since AMQP credits represent whole messages and not bytes, it would be possible in some scenarios for an AMQP client to significantly exceed an address upper bound should the broker continue accepting messages until the clients credits are exhausted.
 For this reason there is an additional parameter available on address settings that specifies an upper bound on an address size in bytes.
-Once this upper bound is reach Artemis will start rejecting AMQP messages.
+Once this upper bound is reached the broker will start rejecting AMQP messages.
 This limit is the max-size-bytes-reject-threshold and is by default set to -1 (or no limit).
-This is additional parameter allows a kind of soft and hard limit, in normal circumstances the broker will utilize the max-size-bytes parameter using flow control to put back pressure on the client, but will protect the broker by rejecting messages once the address size is reached.
+This additional parameter allows a kind of soft and hard limit, in normal circumstances the broker will utilize the max-size-bytes parameter using flow control to put back pressure on the client, but will protect the broker by rejecting messages once the address size is reached.
 
 === Rate limited flow control
 
-Apache ActiveMQ Artemis also allows the rate a producer can emit message to be limited, in units of messages per second.
-By specifying such a rate, Apache ActiveMQ Artemis will ensure that producer never produces messages at a rate higher than that specified.
+The broker can also limit the rate at which a producer can send messages (measured in messages per second).
+Specifying such a rate will ensure that a producer never produces messages at a rate higher than that specified.
 This is controlled by the `producerMaxRate` URL parameter.
 
 The `producerMaxRate` must be a positive integer to enable this functionality and is the maximum desired message production rate specified in units of messages per second.

--- a/docs/user-manual/ha.adoc
+++ b/docs/user-manual/ha.adoc
@@ -49,7 +49,7 @@ It is waiting for the primary to fail before it activates and begins accepting r
 
 == HA Policies
 
-Apache ActiveMQ Artemis supports two main policies for backing up a server:
+Two main policies are available for backing up a server:
 
 * *shared store*
 * *replication*
@@ -173,8 +173,8 @@ Specifies that if the NFS server is unavailable the error should be reported rat
 +
 [TIP]
 ====
-The https://linux.die.net/man/5/nfs[NFS documentation] notes the potential for "silent data corruption" when using `soft`. 
-This can be safely ignored in the case of ActiveMQ Artemis.
+The https://linux.die.net/man/5/nfs[NFS documentation] notes the potential for "silent data corruption" when using `soft`.
+This can be safely ignored.
 ====
 lookupcache=none::
 Disables lookup caching.
@@ -922,17 +922,17 @@ The normal reconnect settings apply when the client is reconnecting so these sho
 
 == Client Failover
 
-Apache ActiveMQ Artemis clients can be configured to receive knowledge of all primary and backup servers, so that in event of connection failure the client will detect this and reconnect to the backup server.
+Core clients can be configured to receive knowledge of all primary and backup servers, so that in event of connection failure the client will detect this and reconnect to the backup server.
 The backup server will then automatically recreate any sessions and consumers that existed on each connection before failover, thus saving the user from having to hand-code manual reconnection logic.
 For further details see xref:client-failover.adoc#core-client-failover[Client Failover]
 
 .A Note on Seamless Failover
 ****
-Apache ActiveMQ Artemis does not reproduce _full_ server state between active and passive servers.
-When a core client automatically creates a new session on the backup that session won't contain any information about messages already sent or acknowledged in the previous session.
+The broker does not reproduce _full_ server state between active and passive servers.
+When a Core client automatically creates a new session on the backup, that session won't contain any information about messages already sent or acknowledged in the previous session.
 Any in-flight sends or acknowledgements at the time of failover will also be lost if they weren't written to storage.
 
-Theoretically we could provide a 100% transparent, seamless failover which would avoid any lost messages or acknowledgements.
+Theoretically, we could provide a 100% transparent, seamless failover which would avoid any lost messages or acknowledgements.
 However, this comes at a great cost: reproducing the full server state (including the queues, session, etc.).
 This would require every operation on the primary server to be reproduced on the backup server in the exact same global order to ensure a consistent state.
 This is extremely hard to do in a performant and scalable way, especially when one considers that multiple threads are changing the active server's state concurrently.
@@ -949,25 +949,25 @@ However, this is not 100% transparent to the client code.
 === Handling Blocking Calls During Failover
 
 If the client code is in a blocking call to the server, waiting for a response to continue its execution, when failover occurs, the new session will not have any knowledge of the call that was in progress.
-This call might otherwise hang for ever, waiting for a response that will never come.
+This call might otherwise hang forever, waiting for a response that will never come.
 
-To prevent this, Apache ActiveMQ Artemis will unblock any blocking calls that were in progress at the time of failover by making them throw a `javax.jms.JMSException` (if using JMS), or a `ActiveMQException` with error code `ActiveMQException.UNBLOCKED`.
+To prevent this, the broker will unblock any blocking calls that were in progress at the time of failover by making them throw a `javax.jms.JMSException` (if using JMS), or a `ActiveMQException` with error code `ActiveMQException.UNBLOCKED`.
 It is up to the client code to catch this exception and retry any operations if desired.
 
-If the method being unblocked is a call to commit(), or prepare(), then the transaction will be automatically rolled back and Apache ActiveMQ Artemis will throw a `javax.jms.TransactionRolledBackException` (if using JMS), or a `ActiveMQException` with error code `ActiveMQException.TRANSACTION_ROLLED_BACK` if using the core API.
+If the method being unblocked is a call to `commit()`, or `prepare()`, then the transaction will be automatically rolled back and will throw a `javax.jms.TransactionRolledBackException` (if using JMS), or a `ActiveMQException` with error code `ActiveMQException.TRANSACTION_ROLLED_BACK` if using the Core API.
 
 === Handling Failover With Transactions
 
 If the session is transactional and messages have already been sent or acknowledged in the current transaction, then the server cannot be sure that messages sent or acknowledgements have not been lost during the failover.
 
-Consequently the transaction will be marked as rollback-only, and any subsequent attempt to commit it will throw a `javax.jms.TransactionRolledBackException` (if using JMS), or a `ActiveMQException` with error code `ActiveMQException.TRANSACTION_ROLLED_BACK` if using the core API.
+Consequently, the transaction will be marked as rollback-only, and any subsequent attempt to commit it will throw a `javax.jms.TransactionRolledBackException` (if using JMS), or a `ActiveMQException` with error code `ActiveMQException.TRANSACTION_ROLLED_BACK` if using the Core API.
 
 [WARNING]
 ====
-The caveat to this rule is when XA is used either via JMS or through the core API.
+The caveat to this rule is when XA is used either via JMS or through the Core API.
 If 2 phase commit is used and prepare has already been called then rolling back could cause a `HeuristicMixedException`.
 Because of this the commit will throw a `XAException.XA_RETRY` exception.
-This informs the Transaction Manager that it should retry the commit at some later point in time, a side effect of this is that any non persistent messages will be lost.
+This informs the Transaction Manager that it should retry the commit at some later point in time, a side effect of this is that any non-persistent messages will be lost.
 To avoid this use persistent messages when using XA.
 With acknowledgements this is not an issue since they are flushed to the server before prepare gets called.
 ====
@@ -976,14 +976,15 @@ It is up to the user to catch the exception, and perform any client side local r
 There is no need to manually rollback the session - it is already rolled back.
 The user can then just retry the transactional operations again on the same session.
 
-Apache ActiveMQ Artemis ships with a fully functioning example demonstrating how to do this, please see xref:examples.adoc#examples[the examples] chapter.
+A fully functioning example demonstrating how to do this is available.
+Please see xref:examples.adoc#examples[the examples] chapter.
 
 If failover occurs when a commit call is being executed, the server, as previously described, will unblock the call to prevent a hang, since no response will come back.
 In this case it is not easy for the client to determine whether the transaction commit was actually processed before failure occurred.
 
 [NOTE]
 ====
-If XA is being used either via JMS or through the core API then an `XAException.XA_RETRY` is thrown.
+If XA is being used either via JMS or through the Core API then an `XAException.XA_RETRY` is thrown.
 This is to inform Transaction Managers that a retry should occur at some point.
 At some later point in time the Transaction Manager will retry the commit.
 If the original commit has not occurred then it will still exist and be committed, if it does not exist then it is assumed to have been committed although the transaction manager may log a warning.
@@ -997,15 +998,15 @@ If the transaction had indeed been committed successfully before failover, then 
 By catching the rollback exceptions and retrying, catching unblocked calls and enabling duplicate detection, _once and only once_ delivery guarantees can be provided for messages in the case of failure, guaranteeing 100% no loss or duplication of messages.
 ====
 
-==== Handling Failover With Non Transactional Sessions
+==== Handling Failover With Non-Transactional Sessions
 
-If the session is non transactional, messages or acknowledgements can be lost in the event of a failover.
+If the session is non-transactional, messages or acknowledgements can be lost in the event of a failover.
 
-If you wish to provide _once and only once_ delivery guarantees for non transacted sessions too, enable duplicate detection, and catch unblock exceptions as described in <<handling-blocking-calls-during-failover,Handling Blocking Calls During Failover>>
+If you wish to provide _once and only once_ delivery guarantees for non-transacted sessions too, enable duplicate detection, and catch unblock exceptions as described in <<handling-blocking-calls-during-failover,Handling Blocking Calls During Failover>>
 
 ==== Use client connectors to fail over
 
-Apache ActiveMQ Artemis clients retrieve the backup connector from the topology updates that the cluster brokers send.
+Core clients retrieve the backup connector from the topology updates that the cluster brokers send.
 If the connection options of the clients don't match the options of the cluster brokers the clients can define a client connector that will be used in place of the connector in the topology.
 To define a client connector it must have a name that matches the name of the connector defined in the `cluster-connection` of the broker, i.e. supposing to have a primary broker with the cluster connector name `node-0` and a backup broker with the `cluster-connector` name `node-1` the client connection url must define 2 connectors with the names `node-0` and `node-1`:
 
@@ -1050,30 +1051,31 @@ Client connection url
 
 === Getting Notified of Connection Failure
 
-JMS provides a standard mechanism for getting notified asynchronously of connection failure: `java.jms.ExceptionListener`.
-Please consult the JMS javadoc or any good JMS tutorial for more information on how to use this.
+JMS provides a standard mechanism for getting notified asynchronously of connection failure: `ExceptionListener`.
+Please consult the JMS JavaDoc or any good JMS tutorial for more information on how to use this.
 
-The Apache ActiveMQ Artemis core API also provides a similar feature in the form of the class `org.apache.activemq.artemis.core.client.SessionFailureListener`
+The Core API also provides a similar feature in the form of the class `org.apache.activemq.artemis.core.client.SessionFailureListener`
 
-Any ExceptionListener or SessionFailureListener instance will always be called by ActiveMQ Artemis on event of connection failure, *irrespective* of whether the connection was successfully failed over, reconnected or reattached, however you can find out if reconnect or reattach has happened by either the `failedOver` flag passed in on the `connectionFailed` on `SessionfailureListener` or by inspecting the error code on the `javax.jms.JMSException` which will be one of the following:
+Any `ExceptionListener` or `SessionFailureListener` instance will always be called in the event of a connection failure, *irrespective* of whether the connection was successfully failed over, reconnected or reattached.
+However, you can find out if reconnect or reattach has happened by either the `failedOver` flag passed in on the `connectionFailed` on `SessionfailureListener` or by inspecting the error code on the `JMSException` which will be one of the following:
 
-JMSException error codes:
+`JMSException` error codes:
 
 FAILOVER::
-Failover has occurred and we have successfully reattached or reconnected.
+Failover has occurred, and we have successfully reattached or reconnected.
 
 DISCONNECT::
 No failover has occurred and we are disconnected.
 
 === Application-Level Failover
 
-In some cases you may not want automatic client failover, and prefer to handle any connection failure yourself, and code your own manually reconnection logic in your own failure handler.
+In some cases you may not want automatic client failover and prefer to handle any connection failure yourself and code your own manual reconnection logic in your own failure handler.
 We define this as _application-level_ failover, since the failover is handled at the user application level.
 
 To implement application-level failover, if you're using JMS then you need to set an `ExceptionListener` class on the JMS connection.
-The `ExceptionListener` will be called by Apache ActiveMQ Artemis in the event that connection failure is detected.
+The `ExceptionListener` will be called in the event that connection failure is detected.
 In your `ExceptionListener`, you would close your old JMS connections, potentially look up new connection factory instances from JNDI and creating new connections.
 
 For a working example of application-level failover, please see xref:examples.adoc#application-layer-failover[the Application-Layer Failover Example].
 
-If you are using the core API, then the procedure is very similar: you would set a `FailureListener` on the core `ClientSession` instances.
+If you are using the Core API, then the procedure is very similar: you would set a `FailureListener` on the core `ClientSession` instances.

--- a/docs/user-manual/index.adoc
+++ b/docs/user-manual/index.adoc
@@ -9,12 +9,12 @@ It *links* to all chapters following the same basic pattern as _book.adoc. These
 image::images/activemq-logo.png[align="center"]
 
 [.text-center]
-*An in-depth manual on all aspects of Apache ActiveMQ Artemis {project-version}*
+*An in-depth manual on all aspects of {project-name-full} {project-version}*
 
 == Overview
 
 * xref:project-info.adoc#general-project-information[General Project Information]
-* xref:preface.adoc#why-use-apache-activemq-artemis[Why use Apache ActiveMQ Artemis?]
+* xref:preface.adoc#why-use-{project-name-full-url}[Why use {project-name-full}?]
 * xref:messaging-concepts.adoc#messaging-concepts[Messaging Concepts]
 * xref:architecture.adoc#core-architecture[Core Architecture]
 
@@ -138,8 +138,8 @@ image::images/activemq-logo.png[align="center"]
 * xref:graceful-shutdown.adoc#graceful-server-shutdown[Graceful Server Shutdown]
 * xref:web-server.adoc#embedded-web-server[Configuring & Managing the Embedded Web Server]
 * xref:logging.adoc#logging[Logging]
-* xref:embedding-activemq.adoc#embedding-apache-activemq-artemis[Embedding Apache ActiveMQ Artemis]
-* xref:karaf.adoc#artemis-on-apache-karaf[Apache Karaf Integration]
+* xref:embedding-activemq.adoc#embedding-{project-name-full-url}[Embedding {project-name-full}]
+* xref:karaf.adoc#apache-karaf-integration[Apache Karaf Integration]
 * xref:tomcat.adoc#apache-tomcat-support[Apache Tomcat Support]
 * xref:cdi-integration.adoc#cdi-integration[CDI Integration]
 * xref:copied-message-properties.adoc#properties-for-copied-messages[Properties for Copied Messages]

--- a/docs/user-manual/intercepting-operations.adoc
+++ b/docs/user-manual/intercepting-operations.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis supports _interceptors_ to intercept packets entering and exiting the server.
+The broker supports _interceptors_ to intercept packets entering and exiting the server.
 Incoming and outgoing interceptors are be called for any packet entering or exiting the server respectively.
 This allows custom code to be executed, e.g. for auditing packets, filtering or other reasons.
 Interceptors can change the packets they intercept.
@@ -70,13 +70,13 @@ Both incoming and outgoing interceptors are configured in `broker.xml`:
 
 See the documentation on xref:using-server.adoc#adding-runtime-dependencies[adding runtime dependencies] to understand how to make your interceptor available to the broker.
 
-== Interceptors on the Client Side
+== Interceptors on the Core Client
 
-The interceptors can also be run on the Apache ActiveMQ Artemis client side to intercept packets either sent by the client to the server or by the server to the client.
+The interceptors can also be run on the Core client to intercept packets either sent by the client to the server or by the server to the client.
 This is done by adding the interceptor to the `ServerLocator` with the `addIncomingInterceptor(Interceptor)` or `addOutgoingInterceptor(Interceptor)` methods.
 
-As noted above, if an interceptor returns `false` then the sending of the packet is aborted which means that no other interceptors are be called and the packet is not be processed further by the client.
-Typically this process happens transparently to the client (i.e. it has no idea if a packet was aborted or not).
+As noted above, if an interceptor returns `false` then the sending of the packet is aborted which means that no other interceptors are called and the packet is not processed further by the client.
+Typically, this process happens transparently to the client (i.e. it has no idea if a packet was aborted or not).
 However, in the case of an outgoing packet that is sent in a `blocking` fashion a `ActiveMQException` will be thrown to the caller.
 The exception is thrown because blocking sends provide reliability and it is considered an error for them not to succeed.
 `Blocking` sends occurs when, for example, an application invokes `setBlockOnNonDurableSend(true)` or `setBlockOnDurableSend(true)` on its `ServerLocator` or if an application is using a JMS connection factory retrieved from JNDI that has either `block-on-durable-send` or `block-on-non-durable-send` set to `true`.

--- a/docs/user-manual/jms-bridge.adoc
+++ b/docs/user-manual/jms-bridge.adoc
@@ -3,28 +3,28 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis includes a fully functional JMS message bridge.
+A fully functional JMS message bridge is available.
 
 The function of the bridge is to consume messages from a source queue or topic, and send them to a target queue or topic, typically on a different server.
 
 [NOTE]
 ====
 The JMS Bridge is not intended as a replacement for transformation and more expert systems such as Camel.
-The JMS Bridge may be useful for fast transfers as this chapter covers, but keep in mind that more complex scenarios requiring transformations will require you to use a more advanced transformation system that will play on use cases that will go beyond Apache ActiveMQ Artemis.
+The JMS Bridge may be useful for fast transfers as this chapter covers, but keep in mind that more complex scenarios requiring transformations will require you to use a more advanced transformation system.
 ====
 
 The source and target servers do not have to be in the same cluster which makes bridging suitable for reliably sending messages from one cluster to another, for instance across a WAN, and where the connection may be unreliable.
 
-A bridge can be deployed as a standalone application or as a web application managed by the embedded Jetty instance bootstrapped with Apache ActiveMQ Artemis.
+A bridge can be deployed as a standalone application or as a web application managed by the embedded Jetty instance bootstrapped with the broker.
 The source and the target can be located in the same virtual machine or another one.
 
-The bridge can also be used to bridge messages from other non Apache ActiveMQ Artemis JMS servers, as long as they are JMS 1.1 compliant.
+The bridge can also be used to bridge messages from other JMS servers as long as they are JMS 1.1 compliant.
 
 [NOTE]
 ====
 Do not confuse a JMS bridge with a core bridge.
 A JMS bridge can be used to bridge any two JMS 1.1 compliant JMS providers and uses the JMS API.
-A xref:core-bridges.adoc#core-bridges[core bridge]) is used to bridge any two Apache ActiveMQ Artemis instances and uses the core API.
+A xref:core-bridges.adoc#core-bridges[core bridge]) is used to bridge any two broker instances and uses the Core API.
 Always use a core bridge if you can in preference to a JMS bridge.
 The core bridge will typically provide better performance than a JMS bridge.
 Also the core bridge can provide _once and only once_ delivery guarantees without using XA.
@@ -151,13 +151,13 @@ To manage the JMS Bridge using JMX, set the MBeanServer where the JMS Bridge MBe
 If you set the MBeanServer, you also need to set the ObjectName used to register the JMS Bridge MBean (must be unique)
 
 The "transactionManager" property points to a JTA transaction manager implementation and should be set if you need to use the 'ONCE_AND_ONCE_ONLY' Quality of Service.
-Apache ActiveMQ Artemis doesn't ship with such an implementation, but if you are running within an Application Server you can inject the Transaction Manager that is shipped.
+The broker doesn't ship with such an implementation, but if you are running within an Application Server you can inject the Transaction Manager that is shipped.
 
 == Source and Target Connection Factories
 
 The source and target connection factory factories are used to create the connection factory used to create the connection for the source or target server.
 
-The configuration example above uses the default implementation provided by Apache ActiveMQ Artemis that looks up the connection factory using JNDI.
+The configuration example above uses the default implementation that looks up the connection factory using JNDI.
 For other Application Servers or JMS providers a new implementation may have to be provided.
 This can easily be done by implementing the interface `org.apache.activemq.artemis.jms.bridge.ConnectionFactoryFactory`.
 
@@ -165,7 +165,7 @@ This can easily be done by implementing the interface `org.apache.activemq.artem
 
 Again, similarly, these are used to create or lookup up the destinations.
 
-In the configuration example above, we have used the default provided by Apache ActiveMQ Artemis that looks up the destination using JNDI.
+In the configuration example above, we have used the default that looks up the destination using JNDI.
 
 A new implementation can be provided by implementing `org.apache.activemq.artemis.jms.bridge.DestinationFactory` interface.
 
@@ -177,8 +177,8 @@ The quality of service modes used by the bridge are described here in more detai
 
 With this QoS mode messages will reach the destination from the source at most once.
 The messages are consumed from the source and acknowledged before sending to the destination.
-Therefore there is a possibility that if failure occurs between removing them from the source and them arriving at the destination they could be lost.
-Hence delivery will occur at most once.
+Therefore, there is a possibility that if failure occurs between removing them from the source and them arriving at the destination, they could be lost.
+Hence, delivery will occur at most once.
 
 This mode is available for both durable and non-durable messages.
 
@@ -194,9 +194,9 @@ This mode is available for both durable and non-durable messages.
 
 This QoS mode ensures messages will reach the destination from the source once and only once.
 (Sometimes this mode is known as "exactly once").
-If both the source and the destination are on the same Apache ActiveMQ Artemis server instance then this can be achieved by sending and acknowledging the messages in the same local transaction.
+If both the source and the destination are on the same server instance, then this can be achieved by sending and acknowledging the messages in the same local transaction.
 If the source and destination are on different servers this is achieved by enlisting the sending and consuming sessions in a JTA transaction.
-The JTA transaction is controlled by a JTA Transaction Manager which will need to be set via the settransactionManager method on the Bridge.
+The JTA transaction is controlled by a JTA Transaction Manager, which will need to be set via the settransactionManager method on the Bridge.
 
 This mode is only available for durable messages.
 
@@ -219,4 +219,4 @@ If you implement your own factories for looking up JMS resources then you will h
 
 === Examples
 
-Please see xref:examples.adoc#jms-bridge[JMS Bridge Example] which shows how to programmatically instantiate and configure a JMS Bridge to send messages to the source destination and consume them from the target destination between two standalone Apache ActiveMQ Artemis brokers.
+Please see xref:examples.adoc#jms-bridge[JMS Bridge Example] which shows how to programmatically instantiate and configure a JMS Bridge to send messages to the source destination and consume them from the target destination between two standalone brokers.

--- a/docs/user-manual/jms-core-mapping.adoc
+++ b/docs/user-manual/jms-core-mapping.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-This chapter describes how JMS destinations are mapped to the Apache ActiveMQ Artemis address model.
+This chapter describes how JMS destinations are mapped to the xref:address-model.adoc[address model].
 If you haven't already done so, please read about the xref:address-model.adoc[address model] as it introduces concepts which are referenced here.
 
 == JMS Topic
@@ -12,9 +12,9 @@ A JMS topic is implemented as a xref:address-model.adoc#address[*address*] where
 
 A subscription on that JMS topic is represented as a xref:address-model.adoc#multicast[*multicast*] xref:address-model.adoc#queue[*queue*] on the corresponding address. The queue is named according to the whether the subscription is durable and according to the client ID and subscription named provided via the JMS API.
 
-Typically there is just one consumer per queue, but there can be multiple consumers on a queue when using JMS shared topic subscriptions.
-Any messages sent to the JMS topic is therefore routed to every multicast queue bound to the corresponding address and then dispatched to any consumers on those queues (i.e. JMS topic subscriber).
-If there are no queues on the address then the message is simply dropped.
+Typically, there is just one consumer per queue, but there can be multiple consumers on a queue when using JMS shared topic subscriptions.
+Any messages sent to the JMS topic are therefore routed to every multicast queue bound to the corresponding address and then dispatched to any consumers on those queues (i.e. JMS topic subscriber).
+If there are no queues on the address, then the message is simply dropped.
 
 This effectively achieves JMS pub/sub semantics.
 

--- a/docs/user-manual/karaf.adoc
+++ b/docs/user-manual/karaf.adoc
@@ -1,22 +1,21 @@
-= Artemis on Apache Karaf
+= Apache Karaf Integration
 :idprefix:
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis is OSGi ready.
-Below you can find instruction on how to install and configure broker on Apache Karaf OSGi container.
+Below you can find instruction on how to install and configure the broker on Apache Karaf OSGi container.
 
 == Installation
 
-Apache ActiveMQ Artemis provides features that makes it easy to install the broker on Apache Karaf (4.x or later).
-First you need to define the feature URL, like
+It is easy to install the broker on Apache Karaf (4.x or later).
+First, you need to define the feature URL, like
 
 [,sh]
 ----
 karaf@root()> feature:repo-add mvn:org.apache.activemq/artemis-features/1.3.0-SNAPSHOT/xml/features
 ----
 
-This will add Artemis related features
+This will add broker-related features
 
 ----
 karaf@root()> feature:list | grep artemis

--- a/docs/user-manual/large-messages.adoc
+++ b/docs/user-manual/large-messages.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis can be configured to give special treatment to messages which are beyond a configured size.
+Messages which are beyond a configured size can receive special treatment.
 Instead of keeping the entire contents of these messages _in memory_ the broker will hold just a thin object on the queues with a reference to the content (e.g. in a file or a database table).
 
 This is supported on Core Protocol and on the AMQP Protocol.
@@ -76,7 +76,7 @@ This is determined by the URL parameter `minLargeMessageSize`
 
 [NOTE]
 ====
-Apache ActiveMQ Artemis messages are encoded using 2 bytes per character so if the message data is filled with ASCII characters (which are 1 byte) the size of the resulting Apache ActiveMQ Artemis message would roughly double.
+Messages are encoded using 2 bytes per character, so if the message data is filled with ASCII characters (which are 1 byte) the size of the resulting message would roughly double.
 This is important when calculating the size of a "large" message as it may appear to be less than the `minLargeMessageSize` before it is sent, but it then turns into a "large" message once it is encoded.
 ====
 
@@ -104,13 +104,13 @@ Make sure to tune this value according to its specific use-case.
 
 == Streaming large messages from Core Protocol
 
-Apache ActiveMQ Artemis supports setting the body of messages using input and output streams (`java.lang.io`)
+The body of messages can be set using input and output streams (`java.lang.io`)
 
 These streams are then used directly for sending (input streams) and receiving (output streams) messages.
 
-When receiving messages there are 2 ways to deal with the output stream;
+When receiving messages, there are 2 ways to deal with the output stream;
 you may choose to block while the output stream is recovered using the method `ClientMessage.saveOutputStream` or alternatively using the method `ClientMessage.setOutputstream` which will asynchronously write the message to the stream.
-If you choose the latter the consumer must be kept alive until the message has been fully received.
+If you choose the latter, the consumer must be kept alive until the message has been fully received.
 
 You can use any kind of stream you like.
 The most common use case is to send files stored in your disk, but you could also send things like JDBC Blobs, `SocketInputStream`, things you recovered from `HTTPRequests` etc.
@@ -166,9 +166,9 @@ On those cases you can use the message property _AMQ_LARGE_SIZE.
 
 === Streaming over JMS
 
-When using JMS, Apache ActiveMQ Artemis maps the streaming methods on the core API (see ClientMessage API table above) by setting object properties . You can use the method `Message.setObjectProperty` to set the input and output streams.
+When using JMS, the streaming methods on the Core API (see the `ClientMessage` API table above) are mapped by setting object properties. You can use the method `Message.setObjectProperty` to set the input and output streams.
 
-The `InputStream` can be defined through the JMS Object Property JMS_AMQ_InputStream on messages being sent:
+The `InputStream` can be defined through the JMS object property `JMS_AMQ_InputStream` on messages being sent:
 
 [,java]
 ----
@@ -183,7 +183,7 @@ message.setObjectProperty("JMS_AMQ_InputStream", bufferedInput);
 someProducer.send(message);
 ----
 
-The `OutputStream` can be set through the JMS Object Property JMS_AMQ_SaveStream on messages being received in a blocking way.
+The `OutputStream` can be set through the JMS object property `JMS_AMQ_SaveStream` on messages being received in a blocking way.
 
 [,java]
 ----
@@ -199,7 +199,7 @@ BufferedOutputStream bufferedOutput = new BufferedOutputStream(fileOutputStream)
 messageReceived.setObjectProperty("JMS_AMQ_SaveStream", bufferedOutput);
 ----
 
-Setting the `OutputStream` could also be done in a non blocking way using the property JMS_AMQ_OutputStream.
+Setting the `OutputStream` could also be done in a non-blocking way using the property `JMS_AMQ_OutputStream`.
 
 [,java]
 ----
@@ -216,9 +216,9 @@ When using JMS, Streaming large messages are only supported on `StreamMessage` a
 
 === Streaming Alternative on Core Protocol
 
-If you choose not to use the `InputStream` or `OutputStream` capability of Apache ActiveMQ Artemis You could still access the data directly in an alternative fashion.
+If you choose not to use the `InputStream` or `OutputStream` capability you could still access the data directly in an alternative fashion.
 
-On the Core API just get the bytes of the body as you normally would.
+On the Core API get the bytes of the body as you normally would.
 
 [,java]
 ----

--- a/docs/user-manual/last-value-queues.adoc
+++ b/docs/user-manual/last-value-queues.adoc
@@ -26,7 +26,7 @@ Last-Value queues can be statically configured in broker.xml via the `last-value
 </address>
 ----
 
-Specified on creating a queue by using the CORE api specifying the parameter  `lastValue` to `true`.
+Specified on creating a queue by using the Core API specifying the parameter  `lastValue` to `true`.
 
 Or on auto-create when using the JMS Client by using address parameters when  creating the destination used by the consumer.
 
@@ -61,7 +61,7 @@ Last-Value queues can also just be configured via the `last-value` boolean prope
 </address>
 ----
 
-Specified on creating a queue by using the CORE api specifying the parameter  `lastValue` to `true`.
+Specified on creating a queue by using the Core API specifying the parameter  `lastValue` to `true`.
 
 Or on auto-create when using the JMS Client by using address parameters when  creating the destination used by the consumer.
 

--- a/docs/user-manual/libaio.adoc
+++ b/docs/user-manual/libaio.adoc
@@ -3,25 +3,25 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis distributes a native library, used as a bridge for its fast journal, between Apache ActiveMQ Artemis and Linux libaio.
+{project-name-full} distributes a native library, used to integrate with Linux libaio.
 
 `libaio` is a library, developed as part of the Linux kernel project.
 With `libaio` we submit writes to the operating system where they are processed asynchronously.
 Some time later the OS will call our code back when they have been processed.
 
-We use this in our high performance journal if configured to do so, please see xref:persistence.adoc#persistence[Persistence].
+We use this in our high-performance journal if configured to do so, please see xref:persistence.adoc#persistence[Persistence].
 
-These are the native libraries distributed by Apache ActiveMQ Artemis:
+These are the native libraries we distribute:
 
 * libartemis-native-64.so - x86 64 bits
 * We distributed a 32-bit version until early 2017.
 While it's not available on the distribution any longer it should still be possible to compile to a 32-bit environment if needed.
 
-When using libaio, Apache ActiveMQ Artemis will always try loading these files as long as they are on the xref:using-server.adoc#library-path[library path]
+When using libaio, the broker will always load these files at startup as long as they are on the xref:using-server.adoc#library-path[library path].
 
 == Runtime dependencies
 
-If you just want to use the provided native binaries you need to install the required libaio dependency.
+If you just want to use the provided native binaries, you need to install the required libaio dependency.
 You can install libaio using the following steps either as the root user or using `sudo`:
 
 * On Fedora, CentOS, Rocky Linux, Red Hat Enterprise Linux, etc.:
@@ -55,12 +55,11 @@ The value for `<package-name>` will depend on which Linux distribution version y
 |libaio1t64
 |===
 +
-Since the package name in later versions of Ubuntu and Debian is different you'll also need to create a symlink on these versions so that the ActiveMQ Artemis Native library can find the shared library at the expected location, e.g.:
+Since the package name in later versions of Ubuntu and Debian is different, you'll also need to create a symlink on these versions so that the libaio shared library can be found at the expected location, e.g.:
 +
 ----
 ln -s /usr/lib/x86_64-linux-gnu/libaio.so.1t64 /usr/lib/libaio.so.1
 ----
-
 
 == Compiling the native libraries
 
@@ -70,8 +69,6 @@ In the case that you are using Linux on a platform other than x86_32 or x86_64 (
 
 [NOTE]
 ====
-
-
 The native layer is only available on Linux.
 If you are in a platform other than Linux the native compilation will not work
 ====

--- a/docs/user-manual/logging.adoc
+++ b/docs/user-manual/logging.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis uses the https://www.slf4j.org/[SLF4J] logging facade for logging, with the broker assembly providing https://logging.apache.org/log4j/2.x/manual/[Log4J 2] as the logging implementation.
+{project-name-full} uses the https://www.slf4j.org/[SLF4J] logging facade for logging, with the broker assembly providing https://logging.apache.org/log4j/2.x/manual/[Log4J 2] as the logging implementation.
 When the broker is started by executing the `run` command, this is configurable via the `log4j2.properties` file found in the broker instance `etc` directory, which is configured by default to log to both the console and to a file. For the other CLI commands, this is configurable via the `log4j2-utility.properties` file found in the broker instance `etc` directory, which is configured by default to log only errors to the console (in addition to the usual command output).
 
 There are a handful of general loggers available:
@@ -12,7 +12,7 @@ There are a handful of general loggers available:
 | Logger | Description
 
 | rootLogger
-| Logs any calls not handled by the Apache ActiveMQ Artemis loggers
+| Logs any calls not handled by the specific loggers
 
 | org.apache.activemq.artemis.core.server
 | Logs the core server

--- a/docs/user-manual/management-console.adoc
+++ b/docs/user-manual/management-console.adoc
@@ -3,14 +3,14 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis ships by default with a management console.
+{project-name-full} ships by default with a management console.
 It is powered by http://hawt.io[Hawt.io].
 
-Its purpose is to expose the xref:management.adoc#management[Management API] via a user friendly web ui.
+Its purpose is to expose the xref:management.adoc#management[Management API] via a user-friendly web ui.
 
 == Login
 
-To access the management console use a browser and go to the URL link:[http://localhost:8161/console].
+To access the management console, use a browser and go to the URL link:[http://localhost:8161/console].
 
 A login screen will be presented, if your broker is secure, you will need to use a user with admin role, if it is unsecure simply enter any user/password.
 
@@ -51,26 +51,27 @@ image::images/console-artemis-plugin.png[ActiveMQ Artemis Console Artemis Plugin
 
 === Navigation Menu
 
-On the top right is small menu area you will see some icons.
+On the top right is a small menu area where you will see some icons.
 
 * `question mark`
 This will open a menu with the following items
 ** `Help` This will navigate to the console user guide
 ** `About` this will load an about screen, here you will be able to see and validate versions
 * `person`
-will provide a drop down menu with
-** `Preferences` this will open the preferences page
+will provide a drop-down menu with
+** `Preferences` this will open the preference page
 ** `Log out` self descriptive.
 
 === Navigation Tabs
 
-Running below the Navigation Menu you will see several default feature tabs. The 1st 2 are specific to Artemis. The rest of
-this document will feature on these 2 tabs.
+Running below the navigation menu, you will see several default feature tabs.
+The first two are specific to the broker.
+The rest of this document will feature on these two tabs.
 
-* `Artemis` This shows detailed information of Apache ActiveMQ Artemis specific functionality in a tabular format.
-* `Artemis JMX` This is a JMX view of Apache ActiveMQ Artemis specific functionality.
+* `Artemis` This shows detailed information of {project-name-full} specific functionality in a tabular format.
+* `Artemis JMX` This is a JMX view of {project-name-full} specific functionality.
 * `JMX` This exposes the raw Jolokia JMX so you can browse/access all the JMX endpoints exposed by the JVM.
-* `Runtime` This allows you to monitor the thread usage and their state as well as view metrics etc..
+* `Runtime` This allows you to monitor the thread usage and their state as well as view metrics, etc.
 
 In previous versions there was a "Connect" tab which could be used to connect to a remote broker from the same console.
 This was disabled by default for security purposes, but it can be enabled again by removing `-Dhawtio.disableProxy=true` from `artemis.profile` (or `artemis.profile.cmd` on Windows).
@@ -79,13 +80,13 @@ You can install further hawtio plugins if you wish to have further functionality
 
 == Artemis Tab
 
-Click `Artemis` in the left navigation bar to see the Artemis specific plugin. The Artemis tab shows view of information
-in a tabular format.
+Click `Artemis` in the left navigation bar to see the broker-specific plugin.
+The `Artemis` tab shows information in a tabular format.
 (The Artemis tab won't appear if there is no broker in this JVM).
 
 === Status Tab
 
-The Status tan shows the basic health of the broker.
+The `Status` tab shows the basic health of the broker.
 
 ==== Acceptors
 
@@ -93,23 +94,23 @@ This expands to show and expose details of the current configured acceptors.
 
 ==== Broker Network
 
-This expands to show and expose details of the current Cluster of Brokers.
+This expands to show and expose details of the current cluster of brokers.
 
 === Connections Tab
 
-This shows a table of all the brokers connections from clients and other Brokers.
+This shows a table of all the connections from clients and other brokers.
 
 === Sessions Tab
 
-This shows a table of all sessions that belong ti connected clients.
+This shows a table of all sessions that belong to connected clients.
 
 === Producers Tab
 
-This shows a table of all client producers including message sent information.
+This shows a table of all client producers, including messages sent information.
 
 === Consumers Tab
 
-This shows a table of all client consumers including message delivered information.
+This shows a table of all client consumers, including messages delivered information.
 
 === Addresses Tab
 
@@ -119,7 +120,7 @@ This shows a table of all the Broker's addresses
 
 ===== Creating a new Address
 
-To create a new address simply click on the 'Create Address' button and filling in the form presented
+To create a new address simply click on the "Create Address" button and fill in the form presented.
 
 You can also perform operations on an address by clicking on the 3 dots and choosing the appropriate operation.
 

--- a/docs/user-manual/management.adoc
+++ b/docs/user-manual/management.adoc
@@ -3,21 +3,21 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis has an extensive _management API_ that allows a user to modify a server configuration, create new resources (e.g. addresses and queues), inspect these resources (e.g. how many messages are currently held in a queue) and interact with it (e.g. to remove messages from a queue).
-Apache ActiveMQ Artemis also allows clients to subscribe to management notifications.
+{project-name-full} has an extensive _management API_ that allows a user to modify a server's configuration, create new resources (e.g. addresses and queues), inspect these resources (e.g. how many messages are currently held in a queue), and interact with them (e.g. to remove messages from a queue).
+Management _notifications_ are also sent for various events.
 
-There are numerous ways to access Apache ActiveMQ Artemis management API:
+There are numerous ways to access the management API:
 
 * Using JMX -- _JMX_ is the standard way to manage Java applications
 * Using Jolokia -- Jolokia exposes the JMX API of an application through an _HTTP interface_
-* Using the Core Client -- management operations are sent to Apache ActiveMQ Artemis server using _Core Client messages_
+* Using the Core Client -- management operations are sent to the broker using _Core Client messages_
 * Using any JMS Client -- management operations are sent to Apache ActiveMQ  Artemis server using _JMS Client messages_
 * Web Console -- a web application which provides a graphical interface to the management API.
 
-Although there are four different ways to manage Apache ActiveMQ Artemis, each API supports the same functionality.
+Although there are four different ways to manage the broker, each API supports the same functionality.
 If it is possible to manage a resource using JMX it is also possible to achieve the same result using Core messages.
 
-Besides these four management interfaces, a xref:management-console.adoc#management-console[Web Console]  and a Command Line _management utility_ are also available to administrators of  ActiveMQ Artemis.
+Besides these four management interfaces, a xref:management-console.adoc#management-console[Web Console] and a Command Line _management utility_ are also available to administrators.
 
 The choice depends on your requirements, your application settings, and your environment to decide which way suits you best.
 
@@ -34,7 +34,7 @@ They are located in the `org.apache.activemq.artemis.api.core.management` packag
 
 The `ActiveMQServerControl` interface is the entry point for broker management.
 
-* Listing, creating, deploying and destroying queues
+* Listing, creating, deploying, and destroying queues
 +
 A list of deployed queues can be retrieved using the `getQueueNames()` method.
 +
@@ -62,7 +62,7 @@ To reset message counters, it is possible to invoke `resetAllMessageCounters()` 
 
 * Retrieving the server configuration and attributes
 +
-The `ActiveMQServerControl` exposes Apache ActiveMQ Artemis server configuration through all its attributes (e.g. `getVersion()` method to retrieve the server's version, etc.)
+The `ActiveMQServerControl` exposes broker configuration through all its attributes (e.g. `getVersion()` method to retrieve the server's version, etc.)
 
 * Listing, creating and destroying Core bridges and diverts
 +
@@ -94,7 +94,7 @@ Since this method actually stops the server you will probably receive some sort 
 The broker's tmp dir is configured via the system property `java.io.tmpdir`. The default value, set via the launch scripts, is `$ARTEMIS_INSTANCE/tmp`.
 ====
 
-* The status of the broker, a json string, can be obtained through the `getStatus()` operation. The status includes identity, uptime, activation state and information about broker properties configuration and reload.
+* The status of the broker, a json string, can be obtained through the `getStatus()` operation. The status includes identity, uptime, activation state, and information about broker properties configuration and reload.
 
 === Address Management
 
@@ -187,7 +187,7 @@ This is useful where you may need to disable message routing to a queue but wish
 
 === Other Resources Management
 
-Apache ActiveMQ Artemis allows to start and stop its remote resources (acceptors, diverts, bridges, etc.) so that a server can be taken off line for a given period of time without stopping it completely (e.g. if other management operations must be performed such as resolving heuristic transactions).
+The management API allows an administrator to start and stop various broker resources (acceptors, diverts, bridges, etc.) so that a broker can be taken partially off-line for a given period of time without stopping it completely (e.g. if other management operations must be performed such as resolving heuristic transactions).
 These resources are:
 
 * Acceptors
@@ -219,10 +219,10 @@ Cluster connections parameters can be retrieved using the `ClusterConnectionCont
 
 == Management Via JMX
 
-Apache ActiveMQ Artemis can be managed using http://www.oracle.com/technetwork/java/javase/tech/javamanagement-140525.html[JMX].
+The broker can be managed using http://www.oracle.com/technetwork/java/javase/tech/javamanagement-140525.html[JMX].
 
-The management API is exposed by Apache ActiveMQ Artemis using MBeans.
-By  default, Apache ActiveMQ Artemis registers its resources with the domain  `org.apache.activemq.artemis`.
+The management API is exposed using MBeans.
+By  default, these MBeans are registered with the domain  `org.apache.activemq.artemis`.
 For example, the `ObjectName` to manage the anycast queue `exampleQueue` on the address `exampleAddress` is:
 
 ----
@@ -245,12 +245,12 @@ objectNameBuilder = ObjectNameBuilder.create(ArtemisResolver.DEFAULT_DOMAIN, bro
 serverObjectName = objectNameBuilder.getActiveMQServerObjectName()
 ----
 
-Managing Apache ActiveMQ Artemis using JMX is identical to management of any Java Applications using JMX.
+Managing a broker using JMX is identical to the management of any Java Applications using JMX.
 It can be done by reflection or by creating proxies of the MBeans.
 
 === Configuring JMX
 
-By default, JMX is enabled to manage Apache ActiveMQ Artemis.
+By default, JMX is enabled for broker management.
 It can be disabled by setting `jmx-management-enabled` to `false` in `broker.xml`:
 
 [,xml]
@@ -432,9 +432,9 @@ To ensure no user has permission to xref:management.adoc#force_failover[force a 
 
 ==== Local JMX Access with JConsole
 
-Due to the authorisation which is enabled by default Apache ActiveMQ Artemis  can _not_ be managed locally using JConsole when connecting as a _local  process_.
-This is because JConsole does not pass any authentication information when connecting this way which means the user cannot therefore be authorised  for any management operations.
-In order to use JConsole the user will either have to disable authorisation by completely removing the `authorisation` element from `management.xml` or by enabling remote access and providing the proper username and password credentials (discussed next).
+Due to the authorisation which is enabled by default, the broker can _not_ be managed locally using JConsole when connecting as a _local  process_.
+This is because JConsole does not pass any authentication information when connecting this way, which means the user cannot, therefore, be authorised  for any management operations.
+To use JConsole, the user will either have to disable authorisation by completely removing the `authorisation` element from `management.xml` or by enabling remote access and providing the proper username and password credentials (discussed next).
 
 ==== Remote JMX Access
 
@@ -442,7 +442,7 @@ By default, remote JMX access to Artemis is disabled for security reasons.
 
 Artemis has a JMX agent which allows access to JMX MBeans remotely.
 This is configured via the `connector` element in the `management.xml` configuration file.
-To enable this you simply add the following xml:
+To enable this, you add the following XML:
 
 [,xml]
 ----
@@ -509,23 +509,19 @@ See the xref:masking-passwords.adoc#masking-passwords[password masking] document
 
 [NOTE]
 ====
-
-
 It is important to note that the rmi registry will pick an ip address to bind to, If you have a multi IP addresses/NICs  present on the system then you can choose the ip address to use by adding the following to artemis.profile `-Djava.rmi.server.hostname=localhost`
 ====
 
 [NOTE]
 ====
-
-
 Remote connections using the default JVM Agent not enabled by default as Artemis exposes the MBean Server via its own configuration.
 This is so Artemis can leverage the JAAS authentication layer via JMX.
 If you want to expose this then you will need to disable both the connector and the authorisation by removing them from the `management.xml` configuration.
 Please refer to https://docs.oracle.com/javase/8/docs/technotes/guides/management/agent.html[Java Management guide] to configure the server for remote management (system properties must be set in `artemis.profile`).
 ====
 
-By default, Apache ActiveMQ Artemis server uses the JMX domain "org.apache.activemq.artemis".
-To manage several Apache ActiveMQ Artemis servers from the _same_ MBeanServer, the JMX domain can be configured for each individual Apache ActiveMQ Artemis server by setting `jmx-domain` in `broker.xml`:
+By default, the broker uses the JMX domain ``"``org.apache.activemq.artemis``"``.
+To manage several brokers from the _same_ MBeanServer, the JMX domain can be configured for each individual broker by setting `jmx-domain` in `broker.xml`:
 
 [,xml]
 ----
@@ -535,7 +531,7 @@ To manage several Apache ActiveMQ Artemis servers from the _same_ MBeanServer, t
 
 === Example
 
-See the xref:examples.adoc#jmx-management[JMX Management Example] which shows how to use a remote connection to JMX and MBean proxies to manage Apache ActiveMQ Artemis.
+See the xref:examples.adoc#jmx-management[JMX Management Example] which shows how to use a remote connection to JMX and MBean proxies to manage a broker.
 
 === Exposing JMX using Jolokia
 
@@ -926,7 +922,7 @@ For query operations on the MBeanServer, the results of the query are limited to
 
 == Using Management Message API
 
-The management message API in ActiveMQ Artemis is accessed by sending Core Client messages to a special address, the _management address_.
+The management message API is accessed by sending Core Client messages to a special address, the _management address_.
 
 _Management messages_ are regular Core Client messages with well-known properties that the server needs to understand to interact with the management API:
 
@@ -934,7 +930,7 @@ _Management messages_ are regular Core Client messages with well-known propertie
 * The name of the management operation
 * The parameters of the management operation
 
-When such a management message is sent to the management address, Apache ActiveMQ Artemis server will handle it, extract the information, invoke the operation on the managed resources and send a _management reply_ to the management message's reply-to address (specified by `ClientMessageImpl.REPLYTO_HEADER_NAME`).
+When such a management message is sent to the management address the broker will handle it, extract the information, invoke the operation on the managed resources, and send a _management reply_ to the management message's reply-to address (specified by `ClientMessageImpl.REPLYTO_HEADER_NAME`).
 
 A `ClientConsumer` can be used to consume the management reply and retrieve the result of the operation (if any) stored in the reply's body.
 For portability, results are returned as a https://json.org[JSON] String rather than Java Serialization (the `org.apache.activemq.artemis.api.core.management.ManagementHelper` can be used to convert the JSON string to Java objects).
@@ -989,8 +985,7 @@ This is also configured in broker.xml:
 
 [,xml]
 ----
-<!-- users with the admin role will be allowed to manage -->
-<!-- Apache ActiveMQ Artemis using management messages    -->
+<!-- users with the admin role will be allowed to manage the broker using management messages -->
 <security-setting match="activemq.management">
    <permission type="manage" roles="admin" />
 </security-setting>
@@ -1034,13 +1029,13 @@ If you want the `admin` role to have full access, use a wildcard after the manag
 
 === Management Example
 
-See the xref:examples.adoc#management[Management Example] which shows how to use JMS messages to manage the Apache ActiveMQ Artemis server.
+See the xref:examples.adoc#management[Management Example] which shows how to use JMS messages to manage the broker.
 
 == Management Notifications
 
-Apache ActiveMQ Artemis emits _notifications_ to inform listeners of potentially interesting events (creation of new resources, security violation, etc.).
+The broker emits _notifications_ to inform listeners of potentially interesting events (creation of new resources, security violation, etc.).
 
-These notifications can be received by two different ways:
+These notifications can be received in two different ways:
 
 * JMX notifications
 * Notification messages
@@ -1051,15 +1046,15 @@ If JMX is enabled (see Configuring JMX section), JMX notifications can be receiv
 
 === Notification Messages
 
-Apache ActiveMQ Artemis defines a special _management notification address_.
+A special address is defined for _management notification_.
 Queues can be bound to this address so that clients will receive management notifications as messages.
 
 A client which wants to receive management notifications must create a queue bound to the management notification address.
 It can then receive the notifications from its queue.
 
-Notifications messages are regular messages with additional properties corresponding to the notification (its type, when it occurred, the resources which were concerned, etc.).
+Notification messages are regular messages with additional properties corresponding to the notification (its type, when it occurred, the resources which were concerned, etc.).
 
-Since notifications are regular messages, it is possible to use message selectors to filter out notifications and receives only a subset of all the notifications emitted by the server.
+Since notifications are regular messages, it is possible to use message selectors to filter out notifications and receive only a subset of all the notifications emitted by the server.
 
 ==== Configuring The Management Notification Address
 
@@ -1088,7 +1083,7 @@ Default value is `false`
 
 ==== Receiving Notification Messages
 
-Apache ActiveMQ Artemis's Core JMS Client can be used to receive notifications:
+A Core JMS Client can be used to receive notifications:
 
 [,java]
 ----
@@ -1115,7 +1110,7 @@ notificationConsumer.setMessageListener(new MessageListener() {
 
 === Example
 
-See the xref:examples.adoc#management-notification[Management Notification Example] which shows how to use a JMS `MessageListener` to receive management notifications from ActiveMQ Artemis server.
+See the xref:examples.adoc#management-notification[Management Notification Example] which shows how to use a JMS `MessageListener` to receive management notifications.
 
 === Notification Types and Headers
 
@@ -1206,7 +1201,7 @@ MESSAGE_EXPIRED (29)::
 
 == Message Counters
 
-Message counters can be used to obtain information on queues _over time_ as Apache ActiveMQ Artemis keeps a history on queue metrics.
+Message counters can be used to obtain information on queues _over time_ as the broker keeps a history on queue metrics.
 
 They can be used to show _trends_ on queues.
 For example, using the management API, it would be possible to query the number of messages in a queue at regular interval.
@@ -1267,7 +1262,7 @@ For example, to retrieve message counters on a queue using JMX:
 
 [,java]
 ----
-// retrieve a connection to Apache ActiveMQ Artemis's MBeanServer
+// retrieve a connection to the broker's MBeanServer
 MBeanServerConnection mbsc = ...
 QueueControlMBean queueControl = (QueueControl)MBeanServerInvocationHandler.newProxyInstance(mbsc,
    on,

--- a/docs/user-manual/masking-passwords.adoc
+++ b/docs/user-manual/masking-passwords.adoc
@@ -3,19 +3,18 @@
 :idseparator: -
 :docinfo: shared
 
-By default all passwords in Apache ActiveMQ Artemis server's configuration files are in plain text form.
-This usually poses no security issues as those files should be well protected from unauthorized accessing.
+By default, all passwords in {project-name-full}'s configuration files are in plain text form.
+This usually poses no security issues as those files should be well protected from unauthorized access.
 However, in some circumstances a user doesn't want to expose its passwords to more eyes than necessary.
 
-Apache ActiveMQ Artemis can be configured to use 'masked' passwords in its configuration files.
+To this end, the broker can be configured to use "masked" passwords in its configuration files.
 A masked password is an obscure string representation of a real password.
-To mask a password a user will use an 'codec'.
+To mask a password, a user will use a 'codec'.
 The codec takes in the real password and outputs the masked version.
 A user can then replace the real password in the configuration files with the new masked password.
-When Apache ActiveMQ Artemis loads a masked password it uses the codec to decode it back into the real password.
+When the broker loads a masked password it uses the codec to decode it back into the real password.
 
-Apache ActiveMQ Artemis provides a default codec.
-Optionally users can use or implement their own codec for masking the passwords.
+A default codec is provided, but users can also implement their own if desired.
 
 In general, a masked password can be identified using one of two ways.
 The first one is the `ENC()` syntax, i.e. any string value wrapped in `ENC()` is to be treated as a masked password.
@@ -95,7 +94,7 @@ Read more about <<using-a-custom-codec,using a custom codec>>.
 
 === artemis-users.properties
 
-Apache ActiveMQ Artemis' default JAAS security manager uses plain properties files where the user passwords are specified in a hashed form by default.
+The default JAAS security manager uses plain properties files where the user passwords are specified in a hashed form by default.
 Note, the passwords are technically _hashed_ rather than masked in this context.
 The default `PropertiesLoginModule` will not decode the passwords in `artemis-users.properties` but will instead hash the input and compare the two hashed values for password verification.
 
@@ -135,7 +134,7 @@ Because Acceptors and Connectors are pluggable implementations, each transport w
 
 The preferred way is simply to use the `ENC()` syntax.
 
-If using the legacy `mask-password` and `password-codec` values then when a `connector` or `acceptor` is initialised, Apache ActiveMQ Artemis will add these values to the parameters using the keys `activemq.usemaskedpassword` and `activemq.passwordcodec` respectively.
+If using the legacy `mask-password` and `password-codec` values then when a `connector` or `acceptor` is initialised, the following values will be added to the parameters using the keys `activemq.usemaskedpassword` and `activemq.passwordcodec` respectively.
 The Netty and InVM implementations will use these as needed and any other implementations will have access to these to use if they so wish.
 
 === Core Bridges
@@ -196,7 +195,7 @@ This indicates the cluster password is a masked value `80cf731af62c290`.
 <cluster-password>80cf731af62c290</cluster-password>
 ----
 +
-This indicates the cluster password is a masked value and Apache ActiveMQ Artemis will use <<the-default-codec,the default codec>> to decode it.
+This indicates the cluster password is masked and <<the-default-codec,the default codec>> will be used to decode it.
 All other passwords in the configuration file, Connectors, Acceptors and Bridges, will also use masked passwords.
 
 === bootstrap.xml
@@ -362,9 +361,9 @@ Example 2 Using the "UseMaskedPassword" property:
 As described in the previous sections, all password masking requires a codec.
 A codec uses an algorithm to convert a masked password into its original clear text form in order to be used in various security operations.
 The algorithm used for decoding must match that for encoding.
-Otherwise the decoding may not be successful.
+Otherwise, the decoding may not be successful.
 
-For user's convenience Apache ActiveMQ Artemis provides a default codec.
+For user's convenience a default codec is provided.
 However, a user can implement their own if they wish.
 
 === The Default Codec
@@ -401,7 +400,7 @@ It can be set immediately _before_ the broker starts and then cleared from the e
 === Using a custom codec
 
 It is possible to use a custom codec rather than the built-in one.
-Simply make sure the codec is in Apache ActiveMQ Artemis's classpath.
+Simply make sure the codec is in the broker's classpath.
 The custom codec can also be service loaded rather than class loaded, if the codec's service provider is installed in the classpath.
 Then configure the server to use it as follows:
 
@@ -425,8 +424,8 @@ Then configure your cluster-password like this:
 <cluster-password>ENC(masked_password)</cluster-password>
 ----
 
-When Apache ActiveMQ Artemis reads the cluster-password it will initialize the `NewCodec` and use it to decode "mask_password".
-It also process all passwords using the new defined codec.
+When the `cluster-password` is read the broker will initialize the `NewCodec` and use it to decode "mask_password".
+It will also process all passwords using the newly defined codec.
 
 ==== Implementing Custom Codecs
 

--- a/docs/user-manual/maven-plugin.adoc
+++ b/docs/user-manual/maven-plugin.adoc
@@ -3,22 +3,22 @@
 :idseparator: -
 :docinfo: shared
 
-Since Artemis 1.1.0 Artemis provides the possibility of using Maven Plugins to manage the life cycle of servers.
+A Maven Plugin is available to manage the life cycle of brokers.
 
 == When to use it
 
-These Maven plugins were initially created to manage server instances across our examples.
-They can create a server, start, and do any CLI operation over servers.
+These Maven plugins were initially created to manage broker instances across our examples.
+They can create a server, start, and do any CLI operation on these brokers.
 
-You could for example use these maven plugins on your testsuite or deployment automation.
+You could, for example, use these Maven plugins on your testsuite or deployment automation.
 
 == Goals
 
 There are three goals that you can use
 
 create::
-This will create a server accordingly to your arguments.
-You can do some extra tricks here such as installing extra libraries for external modules.
+This will create a server according to your arguments.
+You can do some extra tricks here, such as installing extra libraries for external modules.
 
 cli::
 This will perform any CLI operation.
@@ -53,23 +53,22 @@ I won't detail every operation of the create plugin here, but I will try to desc
 
 | configuration
 | A place that will hold any file to replace on the configuration.
-For instance if you are providing your own broker.xml.
-Default is "$\{basedir}/target/classes/activemq/server0"
+For instance, if you are providing your own `broker.xml`.
+Default is `$\{basedir}/target/classes/activemq/server0`
 
 | home
 | The location where you downloaded and installed artemis.
-Default is "${activemq.basedir}"
+Default is `${activemq.basedir}`
 
 | alternateHome
 | This is used case you have two possible locations for your home (e.g. one under compile and one under production
 
 | instance
 | Where the server is going to be installed.
-Default is "$\{basedir}/target/server0"
+Default is `$\{basedir}/target/server0`
 
 | liblist[]
-| A list of libraries to be installed under ./lib.
-ex: "org.jgroups:jgroups:3.6.0.Final"
+| A list of libraries to be installed under `./lib` (e.g. `org.jgroups:jgroups:3.6.0.Final`)
 |===
 
 Example:

--- a/docs/user-manual/message-expiry.adoc
+++ b/docs/user-manual/message-expiry.adoc
@@ -5,16 +5,16 @@
 
 Messages can be set with an optional _time to live_ when sending them.
 
-Apache ActiveMQ Artemis will not deliver a message to a consumer after it's time-to-live has been exceeded.
-If the message hasn't been delivered by the time that time-to-live is reached the server can discard it.
+{project-name-full} will not deliver a message to a consumer after it's time-to-live has been exceeded.
+If the message hasn't been delivered by the time that time-to-live is reached, the server can discard it.
 
-Apache ActiveMQ Artemis's addresses can be assigned an expiry address so that, when messages are expired, they are removed from the queue and sent to the expiry address.
+Addresses can be assigned an expiry address so that, when messages are expired, they are removed from the queue and sent to the expiry address.
 Many different queues can be bound to an expiry address.
 These _expired_ messages can later be consumed for further inspection.
 
 == Core API
 
-Using the Apache ActiveMQ Artemis Core API you can set an expiration time directly on the message:
+Using the Core API you can set an expiration time directly on the message:
 
 [,java]
 ----
@@ -204,7 +204,7 @@ Here is an example configuration:
 </address-setting>
 ----
 
-The queue holding the expired messages can be accessed directly either by using the queue's name by itself (e.g. when using the core client) or by using the fully qualified queue name (e.g. when using a JMS client) just like any other queue.
+The queue holding the expired messages can be accessed directly either by using the queue's name by itself (e.g. when using the Core client) or by using the fully qualified queue name (e.g. when using a JMS client) just like any other queue.
 Also, note that the queue is auto-created which means it will be auto-deleted as per the relevant `address-settings`.
 
 == Configuring The Expiry Reaper Thread

--- a/docs/user-manual/message-grouping.adoc
+++ b/docs/user-manual/message-grouping.adoc
@@ -5,10 +5,10 @@
 
 Message groups are sets of messages that have the following characteristics:
 
-* Messages in a message group share the same group id, i.e. they have same group identifier property (`JMSXGroupID` for JMS, `_AMQ_GROUP_ID` for Apache ActiveMQ Artemis Core API).
+* Messages in a message group share the same group id, i.e. they have same group identifier property (`JMSXGroupID` for JMS, `_AMQ_GROUP_ID` for the Core API).
 * Messages in a message group are always consumed by the same consumer, even if there are many consumers on a queue.
 They pin all messages with the same group id to the same consumer.
-If that consumer closes another consumer is chosen and will receive all messages with the same group id.
+If that consumer closes, another consumer is chosen and will receive all messages with the same group id.
 
 Message groups are useful when you want all messages for a certain value of the property to be processed serially by the same consumer.
 
@@ -198,7 +198,7 @@ There is a number of ways to set `group-buckets`.
 </address>
 ----
 
-Specified on creating a Queue by using the CORE api specifying the parameter  `group-buckets` to `20`.
+Specified on creating a Queue by using the Core API specifying the parameter  `group-buckets` to `20`.
 
 Or on auto-create when using the JMS Client by using address parameters when  creating the destination used by the consumer.
 
@@ -311,4 +311,4 @@ This is because this will determine how often the last-time-use value should be 
 
 === Clustered Grouping Example
 
-See the xref:examples.adoc#clustered-grouping[Clustered Grouping Example] which shows how to configure message groups with a ActiveMQ Artemis Cluster.
+See the xref:examples.adoc#clustered-grouping[Clustered Grouping Example] which shows how to configure message groups with a cluster.

--- a/docs/user-manual/messaging-concepts.adoc
+++ b/docs/user-manual/messaging-concepts.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis is an asynchronous messaging system, an example of https://en.wikipedia.org/wiki/Message-oriented_middleware[Message Oriented Middleware], we'll just call them messaging systems in the remainder of this book.
+{project-name-full} is an asynchronous messaging system, an example of https://en.wikipedia.org/wiki/Message-oriented_middleware[Message Oriented Middleware], we'll just call them messaging systems in the remainder of this book.
 
 We'll first present a brief overview of what kind of things messaging systems do, where they're useful and the kind of concepts you'll hear about in the messaging world.
 
@@ -11,13 +11,13 @@ If you're already familiar with what a messaging system is and what it's capable
 
 == General Concepts
 
-Messaging systems allow you to loosely couple heterogeneous systems together, whilst typically providing reliability, transactions and many other features.
+Messaging systems allow you to loosely couple heterogeneous systems together, whilst typically providing reliability, transactions, and many other features.
 
 Unlike systems based on a https://en.wikipedia.org/wiki/Remote_procedure_call[Remote Procedure Call] (RPC) pattern, messaging systems primarily use an asynchronous message passing pattern with no tight relationship between requests and responses.
-Most messaging systems also support a request-response mode but this is not a primary feature of messaging systems.
+Most messaging systems also support a request-response mode, but this is not a primary feature of messaging systems.
 
-Designing systems to be asynchronous from end-to-end allows you to really take advantage of your hardware resources, minimizing the amount of threads blocking on IO operations, and to use your network bandwidth to its full capacity.
-With an RPC approach you have to wait for a response for each request you make so are limited by the network round trip time, or _latency_ of your network.
+Designing systems to be asynchronous from end-to-end allows you to really take advantage of your hardware resources, minimizing the number of threads blocking on IO operations, and to use your network bandwidth to its full capacity.
+With an RPC approach you have to wait for a response for each request you make so are limited by the network round trip time or _latency_ of your network.
 With an asynchronous system you can pipeline flows of messages in different directions, so are limited by the network _bandwidth_ not the latency.
 This typically allows you to create much higher performance applications.
 
@@ -54,7 +54,7 @@ Let's also imagine there are many consumers on the order queue - each representi
 The messaging system delivers each message to one and only one of the ordering processing components.
 Different messages can be processed by different order processors, but a single order is only processed by one order processor - this ensures orders aren't processed twice.
 
-As an order processor receives a message, it fulfills the order, sends order information to the warehouse system and then updates the order database with the order details.
+As an order processor receives a message, it fulfills the order, sends order information to the warehouse system, and then updates the order database with the order details.
 Once it's done that it acknowledges the message to tell the server that the order has been processed and can be forgotten about.
 Often the send to the warehouse system, update in database and acknowledgement will be completed in a single transaction to ensure https://en.wikipedia.org/wiki/ACID[ACID] properties.
 
@@ -85,7 +85,7 @@ The messaging system allows you to configure which delivery guarantees you requi
 == Transactions
 
 Messaging systems typically support the sending and acknowledgement of multiple messages in a single local transaction.
-Apache ActiveMQ Artemis also supports the sending and acknowledgement of message as part of a large global transaction - using the Java mapping of XA: JTA.
+{project-name-full} also supports the sending and acknowledgement of message as part of a large global transaction - using the Java mapping of XA: JTA.
 
 == Durability
 
@@ -116,7 +116,7 @@ It is only available to clients running Java.
 
 It does not define a standard wire format - it only defines a programmatic API so clients and servers from different vendors cannot directly interoperate since each will use the vendor's own internal wire protocol.
 
-Apache ActiveMQ Artemis provides client implementations which are a fully compliant with xref:using-jms.adoc#using-jms-or-jakarta-messaging[JMS 1.1 & 2.0 as well as Jakarta Messaging 2.0 & 3.0].
+{project-name-full} provides client implementations which are a fully compliant with xref:using-jms.adoc#using-jms-or-jakarta-messaging[JMS 1.1 & 2.0 as well as Jakarta Messaging 2.0, 3.0, & 3.1].
 
 === System specific APIs
 
@@ -124,16 +124,16 @@ Many systems provide their own programmatic API for which to interact with the m
 The advantage of this it allows the full set of system functionality to be exposed to the client application.
 API's like JMS are not normally rich enough to expose all the extra features that most messaging systems provide.
 
-Apache ActiveMQ Artemis provides its own core client API for clients to use if they wish to have access to functionality over and above that accessible via the JMS API.
+The Core API is available for clients to use if they wish to have access to functionality over and above that accessible via the JMS API.
 
-Please see xref:core.adoc#core-api[Core] for using the Core API with Apache ActiveMQ Artemis.
+Please see xref:core.adoc#core-api[Core] for using the Core API.
 
 == High Availability
 
 High Availability (HA) means that the system should remain operational after failure of one or more of the servers.
 The degree of support for HA varies between various messaging systems.
 
-Apache ActiveMQ Artemis provides automatic failover where your sessions are automatically reconnected to a backup server on event of a server failure.
+{project-name-full} provides automatic failover where your sessions are automatically reconnected to a backup server on event of a server failure.
 
 For more information on HA, please see xref:ha.adoc#high-availability-and-failover[High Availability and Failover].
 
@@ -143,11 +143,9 @@ Many messaging systems allow you to create groups of messaging servers called _c
 Clusters allow the load of sending and consuming messages to be spread over many servers.
 This allows your system to scale horizontally by adding new servers to the cluster.
 
-Degrees of support for clusters varies between messaging systems, with some systems having fairly basic clusters with the cluster members being hardly aware of each other.
+Degrees of support for clusters vary between messaging systems, with some systems having fairly basic clusters with the cluster members being hardly aware of each other.
 
-Apache ActiveMQ Artemis provides very configurable state-of-the-art clustering model where messages can be intelligently load balanced between the servers in the cluster, according to the number of consumers on each node, and whether they are ready for messages.
-
-Apache ActiveMQ Artemis also has the ability to automatically redistribute messages between nodes of a cluster to prevent starvation on any particular node.
+{project-name-full} provides a very configurable state-of-the-art clustering model where messages can be intelligently load balanced between the servers in the cluster, according to the number of consumers on each node, and whether they are ready for messages. It also has the ability to automatically redistribute messages between nodes of a cluster to prevent starvation on any particular node.
 
 For full details on clustering, please see xref:clusters.adoc#clusters[Clusters].
 
@@ -158,9 +156,9 @@ Some messaging systems allow isolated clusters or single nodes to be bridged tog
 A bridge normally consumes from a queue on one server and forwards messages to another queue on a different server.
 Bridges cope with unreliable connections, automatically reconnecting when the connections becomes available again.
 
-Apache ActiveMQ Artemis bridges can be configured with filter expressions to only forward certain messages, and transformation can also be hooked in.
+Bridges can be configured with filter expressions to only forward certain messages, and transformation can also be hooked in.
 
-Apache ActiveMQ Artemis also allows routing between queues to be configured in server side configuration.
+Routing between queues can also be configured.
 This allows complex routing networks to be set up forwarding or copying messages from one destination to another, forming a global network of interconnected brokers.
 
 For more information please see xref:core-bridges.adoc#core-bridges[Core Bridges] and xref:diverts.adoc#diverting-and-splitting-message-flows[Diverting and Splitting Message Flows].

--- a/docs/user-manual/metrics.adoc
+++ b/docs/user-manual/metrics.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis can export metrics to a variety of monitoring systems via the https://micrometer.io/[Micrometer] vendor-neutral application metrics facade.
+{project-name-full} can export metrics to a variety of monitoring systems via the https://micrometer.io/[Micrometer] vendor-neutral application metrics facade.
 
 Important runtime metrics have been instrumented via the Micrometer API, and all a user needs to do is implement `org.apache.activemq.artemis.core.server.metrics.ActiveMQMetricsPlugin` in order to instantiate and configure a `io.micrometer.core.instrument.MeterRegistry` implementation.
 Relevant implementations of `MeterRegistry` are available from the https://github.com/micrometer-metrics/micrometer/tree/master/implementations[Micrometer code-base].
@@ -51,7 +51,7 @@ A _tag_ is a piece of metadata that gives context to the metric.
 These tags are the foundation of what is sometimes referred to as "dimensional metrics."
 Metrics _may_ have additional tags, but at the very least they will all have the `broker` tag.
 
-Lastly, all metrics specifically for ActiveMQ Artemis are prefixed with `artemis.`.
+Lastly, all metrics specifically for the broker are prefixed with `artemis.`.
 
 === Broker
 

--- a/docs/user-manual/mqtt.adoc
+++ b/docs/user-manual/mqtt.adoc
@@ -3,11 +3,11 @@
 :idseparator: -
 :docinfo: shared
 
-MQTT is a light weight, client to server, publish / subscribe messaging protocol.
+MQTT is a light weight, client-to-server, publish / subscribe messaging protocol.
 MQTT has been specifically designed to reduce transport overhead (and thus network traffic) and code footprint on client devices.
 For this reason MQTT is ideally suited to constrained devices such as sensors and actuators and is quickly becoming the defacto standard communication protocol for IoT.
 
-Apache ActiveMQ Artemis supports the following MQTT versions (with links to their respective specifications):
+{project-name-full} supports the following MQTT versions (with links to their respective specifications):
 
 * https://public.dhe.ibm.com/software/dw/webservices/ws-mqtt/mqtt-v3r1.html[3.1]
 * https://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html[3.1.1]
@@ -166,19 +166,19 @@ This conversion isn't free so *if you want the best MQTT performance* use `broke
 
 Of course, changing the default syntax also means other clients on other protocols will need to follow this same syntax as well as the `match` values of your `address-setting` configuration elements.
 
-== Web Sockets
+== WebSockets
 
-Apache ActiveMQ Artemis also supports MQTT over https://html.spec.whatwg.org/multipage/web-sockets.html[Web Sockets].
-Modern web browsers which support Web Sockets can send and receive MQTT messages.
+MQTT over https://html.spec.whatwg.org/multipage/web-sockets.html[WebSockets] is also supported.
+Modern web browsers which support WebSockets can send and receive MQTT messages.
 
-MQTT over Web Sockets is supported via a normal MQTT acceptor:
+MQTT over WebSockets is supported via a normal MQTT acceptor:
 
 [,xml]
 ----
 <acceptor name="mqtt-ws-acceptor">tcp://host:1883?protocols=MQTT</acceptor>
 ----
 
-With this configuration, Apache ActiveMQ Artemis will accept MQTT connections over Web Sockets on the port `1883`.
+With this configuration, the broker will accept MQTT connections over WebSockets on the port `1883`.
 Web browsers can then connect to `ws://<server>:1883` using a Web Socket to send and receive MQTT messages.
 
 SSL/TLS is also available, e.g.:

--- a/docs/user-manual/openwire.adoc
+++ b/docs/user-manual/openwire.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis supports the http://activemq.apache.org/openwire.html[OpenWire] protocol so that an Apache ActiveMQ Classic JMS client can talk directly to an Apache ActiveMQ Artemis server.
+{project-name-full} supports the http://activemq.apache.org/openwire.html[OpenWire] protocol so that an Apache ActiveMQ Classic JMS client can talk directly to an {project-name-full} server.
 By default there is an `acceptor` configured to accept OpenWire connections on port `61616`.
 
 See the general xref:protocols-interoperability.adoc#protocols-and-interoperability[Protocols and Interoperability] chapter for details on configuring an `acceptor` for OpenWire.

--- a/docs/user-manual/paging.adoc
+++ b/docs/user-manual/paging.adoc
@@ -3,13 +3,13 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis transparently supports huge queues containing millions of messages while the server is running with limited memory.
+The broker transparently supports huge queues containing millions of messages with limited memory.
 
-In such a situation it's not possible to store all of the queues in memory at any one time, so Apache ActiveMQ Artemis transparently _pages_ messages into and out of memory as they are needed, thus allowing massive queues with a low memory footprint.
+In such a situation it's not possible to store all of the queues in memory at any one time, so the broker transparently _pages_ messages into and out of memory as they are needed, thus allowing massive queues with a low memory footprint.
 
-Apache ActiveMQ Artemis will start paging messages to disk, when the size of all messages in memory for an address exceeds a configured maximum size.
+The broker will start paging messages to disk when the size of all messages in memory for an address exceeds a configured maximum size.
 
-The default configuration from Artemis has destinations with paging.
+The default configuration uses paging.
 
 == Page Files
 
@@ -36,7 +36,7 @@ This is different to browsing as we will "browse" the entire queue looking for m
 You can configure the location of the paging folder in `broker.xml`.
 
 * `paging-directory` Where page files are stored.
-Apache ActiveMQ Artemis will create one folder for each address being paged under this configured location.
+The broker will create one folder for each address being paged under this configured location.
 Default is `data/paging`.
 
 == Paging Mode
@@ -255,4 +255,4 @@ If the limit determined from `page-limit-bytes`, once converted to a number of p
 
 == Example
 
-See the xref:examples.adoc#paging[Paging Example] which shows how to use paging with  Apache ActiveMQ Artemis.
+See the xref:examples.adoc#paging[Paging Example] which shows how to use paging.

--- a/docs/user-manual/perf-tools.adoc
+++ b/docs/user-manual/perf-tools.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Artemis provides some built-in performance test tools based on the https://javaee.github.io/jms-spec/pages/JMS20FinalRelease[JMS 2 API] to help users (and developers) to stress test a configured Artemis broker instance in different scenarios.
+Performance test tools based on the https://javaee.github.io/jms-spec/pages/JMS20FinalRelease[JMS 2 API] are available to help users (and developers) stress test a broker instance in different scenarios.
 
 These command-line tools won't represent a full-fat benchmark (such as https://openmessaging.cloud/docs/benchmarks/[Open Messaging]), but can be used as building blocks to produce one.
 They are also quite useful on their own.
@@ -59,8 +59,7 @@ WARN  [org.apache.activemq.artemis.core.client] AMQ212053: CompletionListener/Se
 It shows two things:
 
 . the load generator uses https://jakarta.ee/specifications/messaging/2.0/apidocs/javax/jms/messageproducer#send-javax.jms.Destination-javax.jms.Message-javax.jms.CompletionListener-[async message producers]
-. `confirmationWindowSize` is an Artemis CORE protocol specific setting;
-the `perf` commands uses CORE as the default JMS provider
+. `confirmationWindowSize` is specific to the Core protocol; the `perf` commands uses Core as the default JMS provider
 
 === Live Latency Console Reporting
 
@@ -111,7 +110,7 @@ transfer time::
 percentiles of latency to transfer messages from producer(s) to consumer(s)
 
 The `perf` commands uses https://jakarta.ee/specifications/messaging/2.0/apidocs/javax/jms/messageproducer#send-javax.jms.Destination-javax.jms.Message-javax.jms.CompletionListener-[JMS 2 async message producers] that allow the load generator to accumulate in-flight sent messages and depending on the protocol implementation, may block its producer thread due to producer flow control.
-e.g: the Artemis CORE protocol can block producers threads to refill producers credits, while the https://qpid.apache.org/components/jms/index.html[QPID-JMS] won't.
+e.g: the Core client can block producer threads to refill credits while https://qpid.apache.org/components/jms/index.html[Qpid JMS] won't.
 
 The `perf` tool is implementing its own in-flight sent requests tracking and can be configured to limit the amount of pending sent messages,  while reporting the rate by which producers are "blocked" awaiting completions
 

--- a/docs/user-manual/perf-tuning.adoc
+++ b/docs/user-manual/perf-tuning.adoc
@@ -3,16 +3,16 @@
 :idseparator: -
 :docinfo: shared
 
-In this chapter we'll discuss how to tune Apache ActiveMQ Artemis for optimum performance.
+In this chapter we'll discuss how to tune {project-name-full} for optimum performance.
 
 == Tuning persistence
 
-* To get the best performance from Apache ActiveMQ Artemis whilst using persistent messages it is recommended that the file store is used.
-Apache ActiveMQ Artemis also supports JDBC persistence, but there is a performance cost when persisting to a database vs local disk.
+* To get the best performance whilst using persistent messages it is recommended that the file store is used.
+JDBC persistence is also supported, but there is a performance cost when persisting to a database vs. local disk.
 * Put the message journal on its own physical volume.
-If the disk is shared with other processes e.g. transaction co-ordinator, database or other journals which are also reading and writing from it, then this may greatly reduce performance since the disk head may be skipping all over the place between the different files.
-One of the advantages of an append only journal is that disk head movement is minimised - this advantage is destroyed if the disk is shared.
-If you're using paging or large messages make sure they're ideally put on separate volumes too.
+If the disk is shared with other processes (e.g. transaction co-ordinator, database or other journals which are also reading and writing from it), then this may greatly reduce performance since the disk head may be skipping all over the place between the different files.
+One of the advantages of an append-only journal is that disk head movement is minimised - this advantage is destroyed if the disk is shared.
+If you're using paging or large messages, make sure they're ideally put on separate volumes too.
 * Minimum number of journal files.
 Set `journal-min-files` to a number of files that would fit your average sustainable rate.
 This number represents the lower threshold of the journal file pool.
@@ -56,14 +56,14 @@ By default JMS messages are durable.
 If you don't really need durable messages then set them to be non-durable.
 Durable messages incur a lot more overhead in persisting them to storage.
 * Batch many sends or acknowledgements in a single transaction.
-Apache ActiveMQ Artemis will only require a network round trip on the commit, not on every send or acknowledgement.
+The Core client will only require a network round trip on the commit, not on every send or acknowledgement.
 
 == Other Tunings
 
-There are various other places in Apache ActiveMQ Artemis where we can perform some tuning:
+There are various other tunings available:
 
 * Use Asynchronous Send Acknowledgements.
-If you need to send durable messages non transactionally and you need a guarantee that they have reached the server by the time the call to send() returns, don't set durable messages to be sent blocking, instead use asynchronous send acknowledgements to get your acknowledgements of send back in a separate stream, see xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits] for more information on this.
+If you need to send durable messages non-transactionally and you need a guarantee that they have reached the server by the time the call to send() returns, don't set durable messages to be sent blocking, instead use asynchronous send acknowledgements to get your acknowledgements of send back in a separate stream, see xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits] for more information on this.
 * Use pre-acknowledge mode.
 With pre-acknowledge mode, messages are acknowledged `before` they are sent to the client.
 This reduces the amount of acknowledgement traffic on the wire.
@@ -75,7 +75,7 @@ If you don't need message persistence, turn it off altogether by setting `persis
 * Sync transactions lazily.
 Setting `journal-sync-transactional` to `false` in `broker.xml` can give you better transactional persistent performance at the expense of some possibility of loss of transactions on failure.
 See xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits] for more information.
-* Sync non transactional lazily.
+* Sync non-transactional lazily.
 Setting `journal-sync-non-transactional` to `false` in `broker.xml` can give you better non-transactional persistent performance at the expense of some possibility of loss of durable messages on failure.
 See  xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits] for more information.
 * Send messages non blocking.
@@ -84,9 +84,9 @@ This means you don't have to wait a whole network round trip for every message s
 See  xref:send-guarantees.adoc#guarantees-of-sends-and-commits[Guarantees of sends and commits] for more information.
 * If you have very fast consumers, you can increase consumer-window-size.
 This effectively disables consumer flow control.
-* Use the core API not JMS.
-Using the JMS API you will have slightly lower performance than using the core API, since all JMS operations need to be translated into core operations before the server can handle them.
-If using the core API try to use methods that take `SimpleString` as much as possible.
+* Use the Core API not JMS.
+Using the JMS API you will have slightly lower performance than using the Core API, since all JMS operations need to be translated into core operations before the server can handle them.
+If using the Core API try to use methods that take `SimpleString` as much as possible.
 `SimpleString`, unlike java.lang.String does not require copying before it is written to the wire, so if you re-use `SimpleString` instances between calls then you can avoid some unnecessary copying.
 * If using frameworks like Spring, configure destinations permanently broker side and enable `cacheDestinations` on the client side.
 See the xref:using-jms.adoc#setting-the-destination-cache[Setting The Destination Cache] for more information on this.
@@ -118,7 +118,6 @@ serveruser   hard  nofile  20000
 This would allow up to 20000 file handles to be open by the user `serveruser`.
 
 * Use `batch-delay` and set `direct-deliver` to false for the best throughput for very small messages.
-Apache ActiveMQ Artemis comes with a preconfigured connector/acceptor pair (`netty-throughput`) in `broker.xml` and JMS connection factory (`ThroughputConnectionFactory`) in ``activemq-jms.xml``which can be used to give the very best throughput, especially for small messages.
 See the xref:configuring-transports.adoc#configuring-the-transport[Configuring the Transport] for more information on this.
 
 == Tuning the VM
@@ -127,13 +126,13 @@ We highly recommend you use the latest Java JVM for the best performance.
 We test internally using the Sun JVM, so some of these tunings won't apply to JDKs from other providers (e.g. IBM or JRockit)
 
 * Memory settings.
-Give as much memory as you can to the server.
-Apache ActiveMQ Artemis can run in low memory by using paging (described in xref:paging.adoc#paging[Paging]) but if it can run with all queues in RAM this will improve performance.
+Give as much memory as you can to the broker.
+It can run in low memory by using xref:paging.adoc#paging[paging], but if it can run with all queues in RAM this will improve performance.
 The amount of memory you require will depend on the size and number of your queues and the size and number of your messages.
-Use the JVM arguments `-Xms` and `-Xmx` to set server available RAM.
+Use the JVM arguments `-Xms` and `-Xmx` to set available RAM.
 We recommend setting them to the same high value.
 +
-When under periods of high load, it is likely that Artemis will be generating and destroying lots of objects.
+When under periods of high load, it is likely that the broker will be generating and destroying lots of objects.
 This can result in a build up of stale objects.
 To reduce the chance of running out of memory and causing a full GC (which may introduce pauses and unintentional behaviour), it is recommended that the max heap size (`-Xmx`) for the JVM is set at least to 5 x the `global-max-size` of the broker.
 As an example, in a situation where the broker is under high load and running with a `global-max-size` of 1GB, it is recommended the max heap size is set to 5GB.

--- a/docs/user-manual/persistence.adoc
+++ b/docs/user-manual/persistence.adoc
@@ -3,71 +3,74 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis ships with two persistence options.
+{project-name-full} ships with two persistence options.
 The file journal which is  highly optimized for the messaging use case and gives great performance, and also the JDBC Store, which uses JDBC to connect to a database of your choice.
 
 == File Journal (Default)
 
-The file journal is an _append only_ journal.
+The file journal is an _append-only_ journal.
 It consists of a set of files on disk.
 Each file is pre-created to a fixed size and initially filled with padding.
 As operations are performed on the server, e.g. add message, update message, delete message, records are appended to the journal.
-When one journal file is full we move to the next one.
+When one journal file is full, we move to the next one.
 
-Because records are only appended, i.e. added to the end of the journal we minimise disk head movement, i.e. we minimise random access operations which is typically the slowest operation on a disk.
+Because records are only appended, i.e. added to the end of the journal we minimise disk head movement, i.e. we minimise random access operations, which is typically the slowest operation on a disk.
 
 Making the file size configurable means that an optimal size can be chosen, i.e. making each file fit on a disk cylinder.
-Modern disk topologies are complex and we are not in control over which cylinder(s) the file is mapped onto so this is not an exact science.
+Modern disk topologies are complex and we are not in control over which cylinder(s) the file is mapped onto, so this is not an exact science.
 But by minimising the number of disk cylinders the file is using, we can minimise the amount of disk head movement, since an entire disk cylinder is accessible simply by the disk rotating - the head does not have to move.
 
-As delete records are added to the journal, Apache ActiveMQ Artemis has a sophisticated file garbage collection algorithm which can determine if a particular journal file is needed any more - i.e. has all its data been deleted in the same or other files.
+As delete records are added to the journal a sophisticated file garbage collection algorithm determines if a particular journal file is needed any more - i.e. has all its data been deleted in the same or other files.
 If so, the file can be reclaimed and re-used.
 
-Apache ActiveMQ Artemis also has a compaction algorithm which removes dead space from the journal and compresses up the data so it takes up less files on disk.
+A compaction algorithm occasionally removes dead space from the journal and compresses up the data so it takes up fewer files on disk.
 
 The journal also fully supports transactional operation if required, supporting both local and XA transactions.
 
-The majority of the journal is written in Java, however we abstract out the interaction with the actual file system to allow different pluggable implementations.
-Apache ActiveMQ Artemis ships with two implementations:
+The majority of the journal is written in Java; however, we abstract out the interaction with the actual file system to allow different pluggable implementations.
+{project-name-full} ships with three implementations - NIO, AIO, & Memory Mapped.
 
-=== Journal and Data Retention
+=== Java NIO
 
-ActiveMQ Artemis provides a way to store and replay historical data. Refer to xref:data-retention.adoc[Data Retention] chapter for more information.
-
-=== Java https://en.wikipedia.org/wiki/New_I/O[NIO]
-
-The first implementation uses standard Java NIO to interface with the file system.
+The first implementation uses standard Java https://en.wikipedia.org/wiki/New_I/O[NIO] to interface with the file system.
 This provides extremely good performance and runs on any platform where there's a Java 6+ runtime.
 
 === Linux Asynchronous IO
 
 The second implementation uses a thin native code wrapper to talk to the Linux asynchronous IO library (AIO).
-With AIO, Apache ActiveMQ Artemis will be called back when the data has made it to disk, allowing us to avoid explicit syncs altogether and simply send back confirmation of completion when AIO informs us that the data has been persisted.
+With AIO, the broker will be called back when the data has made it to disk.
+This avoids explicit syncs altogether and allows the broker to simply send back confirmation of completion when AIO informs us that the data has been persisted.
 
 Using AIO will typically provide even better performance than using Java NIO.
 
 This journal option is only available when running Linux kernel 2.6 or later and after having installed libaio (if it's not already installed).
-For instructions on how to install libaio please see Installing AIO section.
+Instructions on how to install libaio are referenced <<Installing AIO,here>>.
 
-Also, please note that AIO will only work with the following file systems: ext2, ext3, ext4, jfs, xfs and NFSV4.
+Also, please note that AIO will only work with the following file systems: ext2, ext3, ext4, jfs, xfs, and NFSv4.
 
 For more information on libaio please see xref:libaio.adoc#libaio-native-libraries[lib AIO].
 
-libaio is part of the kernel project.
+libaio is part of the Linux kernel project.
 
-=== Memory mapped
+=== Memory Mapped
 
 The third implementation uses a file-backed https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.MapMode.html#READ_WRITE[READ_WRITE] https://en.wikipedia.org/wiki/Memory-mapped_file[memory mapping] against the OS page cache to interface with the file system.
 
-This provides extremely good performance (especially under strictly process failure durability requirements),  almost zero copy (actually _is_ the kernel page cache) and zero garbage (from the Java HEAP perspective) operations and runs  on any platform where there's a Java 4+ runtime.
+This provides extremely good performance (especially under strictly process failure durability requirements).
+It requires almost zero copies (actually _are_ the kernel page cache), generates zero garbage (from the Java heap perspective), and runs on any platform where there's a Java 4+ runtime.
 
-Under power failure durability requirements it will perform at least on par with the NIO journal with the only  exception of Linux OS with kernel less or equals 2.6, in which the https://docs.oracle.com/javase/8/docs/api/java/nio/MappedByteBuffer.html#force%28%29[_msync_]) implementation necessary to ensure  durable writes was different (and slower) from the https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.html#force%28boolean%29[_fsync_] used is case of NIO journal.
+Under power failure durability requirements, it will perform at least on par with the NIO journal with the only exception of Linux OS with kernel less or equals 2.6, in which the https://docs.oracle.com/javase/8/docs/api/java/nio/MappedByteBuffer.html#force%28%29[_msync_]) implementation necessary to ensure  durable writes was different (and slower) from the https://docs.oracle.com/javase/8/docs/api/java/nio/channels/FileChannel.html#force%28boolean%29[_fsync_] used is case of NIO journal.
 
 It benefits by the configuration of OS https://en.wikipedia.org/wiki/Page_%28computer_memory%29[huge pages], in particular when is used a big number of journal files and sizing them as multiple of the OS page size in bytes.
 
+=== Journal and Data Retention
+
+Historical data can be stored and replayed.
+Refer to xref:data-retention.adoc[Data Retention] chapter for more information.
+
 === Standard Files
 
-The standard Apache ActiveMQ Artemis core server uses two instances of the journal:
+The broker uses two instances of the journal:
 
 * Bindings journal.
 +
@@ -85,20 +88,20 @@ File size is `1048576`, and it is located at the bindings folder.
 +
 This journal instance stores all message related data, including the message themselves and also duplicate-id caches.
 +
-By default Apache ActiveMQ Artemis will try and use an AIO journal.
+By default, the broker will try to use an AIO journal.
 If AIO is not available, e.g. the platform is not Linux with the correct kernel version or AIO has not been installed then it will automatically fall back to using Java NIO which is available on any Java platform.
 +
 The files on this journal are prefixed as `activemq-data`.
 Each file has an `amq` extension.
 File size is by the default `10485760` (configurable), and it is located at the journal folder.
 
-For large messages, Apache ActiveMQ Artemis persists them outside the message journal.
+Large messages are persisted outside the message journal.
 This is discussed in xref:large-messages.adoc#large-messages[Large Messages].
 
-Apache ActiveMQ Artemis can also be configured to page messages to disk in low memory situations.
+The broker can also be configured to page messages to disk in low-memory situations.
 This is discussed in xref:paging.adoc#paging[Paging].
 
-If no persistence is required at all, Apache ActiveMQ Artemis can also be configured not to persist any data at all to storage as discussed in the Configuring the broker for Zero Persistence section.
+If no persistence is required at all, that can also be configured as discussed <<zero-persistence,here>>.
 
 ==== Configuring the bindings journal
 
@@ -144,15 +147,15 @@ Valid values are `NIO`, `ASYNCIO` or `MAPPED`.
 +
 Choosing `NIO` chooses the Java NIO journal.
 Choosing `ASYNCIO` chooses the Linux asynchronous IO journal.
-If you choose `ASYNCIO` but are not running Linux or you do not have libaio installed then Apache ActiveMQ Artemis will detect this and automatically fall back to using `NIO`.
+If you choose `ASYNCIO` but are not running Linux or you do not have libaio installed then `NIO` will be used as a fall back.
 Choosing `MAPPED` chooses the Java Memory Mapped journal.
 
 journal-sync-transactional::
-If this is set to true then Apache ActiveMQ Artemis will make sure all transaction data is flushed to disk on transaction boundaries (commit, prepare and rollback).
+If this is set to `true` then all transaction data is flushed to disk on transaction boundaries (commit, prepare, and rollback).
 The default value is `true`.
 
 journal-sync-non-transactional::
-If this is set to true then Apache ActiveMQ Artemis will make sure non transactional message data (sends and acknowledgements) are flushed to disk each time.
+If this is set to `true` then non-transactional message data (sends and acknowledgements) are flushed to disk each time.
 The default value for this is `true`.
 
 journal-file-size::
@@ -161,15 +164,16 @@ The default value for this is `10485760` bytes (10MiB).
 
 journal-min-files::
 The minimum number of files the journal will maintain.
-When Apache ActiveMQ Artemis starts and there is no initial message data, Apache ActiveMQ Artemis will pre-create `journal-min-files` number of files.
+When the broker starts and there is no initial message data it will pre-create `journal-min-files` number of files.
 +
-Creating journal files and filling them with padding is a fairly expensive operation and we want to minimise doing this at run-time as files get filled.
-By pre-creating files, as one is filled the journal can immediately resume with the next one without pausing to create it.
+Creating journal files and filling them with padding is a fairly expensive operation, and we want to minimise doing this at run-time as files get filled.
+By pre-creating files, as one is filled, the journal can immediately resume with the next one without pausing to create it.
 +
-Depending on how much data you expect your queues to contain at steady state you should tune this number of files to match that total amount of data.
+Depending on how much data you expect your queues to contain at steady state, you should tune this number of files to match that total amount of data.
 
 journal-pool-files::
-The system will create as many files as needed however when reclaiming files it will shrink back to the `journal-pool-files`.
+The system will create as many files as needed.
+However, when reclaiming files, it will shrink back to the `journal-pool-files`.
 +
 The default to this parameter is -1, meaning it will never delete files on the journal once created.
 +
@@ -264,12 +268,12 @@ If you've been used to using disks with write cache enabled in their default set
 
 On Linux you can inspect and/or change your disk's write cache settings using the tools `hdparm` (for IDE disks) or `sdparm` or `sginfo` (for SDSI/SATA disks)
 
-On Windows you can check / change the setting by right clicking on the disk and clicking properties.
+On Windows you can check / change the setting by right-clicking on the disk and clicking properties.
 ****
 
 === Installing AIO
 
-The Java NIO journal gives great performance, but If you are running Apache ActiveMQ Artemis using Linux Kernel 2.6 or later, we highly recommend you use the `ASYNCIO` journal for the very best persistence performance.
+The Java NIO journal gives great performance, but if you are using Linux Kernel 2.6 or later, we highly recommend you use the `ASYNCIO` journal for the very best persistence performance.
 
 It's not possible to use the ASYNCIO journal under other operating systems or earlier versions of the Linux kernel.
 
@@ -277,16 +281,16 @@ If you are running Linux kernel 2.6 or later and don't already have `libaio` ins
 
 == JDBC Persistence
 
-The Apache ActiveMQ Artemis JDBC persistence layer offers the ability to store broker state (messages, address & queue  definitions, etc.) using a database.
+The JDBC persistence layer offers the ability to store broker state (messages, address & queue  definitions, etc.) using a database.
 
 [NOTE]
 ====
-Using the ActiveMQ Artemis File Journal is the *recommended* configuration as it offers higher levels of performance and is more mature.
+Using the file-based journal is the *recommended* configuration as it typically offers the highest levels of performance.
 Performance for both paging and large messages is especially diminished with JDBC.
 The JDBC  persistence layer is targeted to those users who _must_ use a database e.g. due to internal company policy.
 ====
 
-ActiveMQ Artemis currently has support for a limited number of database vendors:
+These databases are supported:
 
 . PostgreSQL
 . MySQL
@@ -296,11 +300,11 @@ ActiveMQ Artemis currently has support for a limited number of database vendors:
 . Apache Derby
 
 The JDBC store uses a JDBC connection to store messages and bindings data in records in database tables.
-The data stored in the database tables is encoded using Apache ActiveMQ Artemis internal encodings.
+The data stored in the database tables uses internal encodings.
 
 === Configuring JDBC Persistence
 
-To configure Apache ActiveMQ Artemis to use a database for persisting messages and bindings data you must do two things.
+To configure the broker to use a database for persisting messages and bindings data you must do two things.
 
 . See the documentation on xref:using-server.adoc#adding-runtime-dependencies[adding runtime dependencies] to  understand how to make the JDBC driver available to the broker.
 . Create a store element in your broker.xml config file under the `<core>` element.
@@ -329,15 +333,15 @@ NOTE: When configuring the server using the XML configuration files please ensur
 "&" for example, is typical in JDBC connection url and should be escaped to "&".
 
 bindings-table-name::
-The name of the table in which bindings data will be persisted for the ActiveMQ Artemis server.
+The name of the table in which bindings data will be persisted.
 Specifying table names allows users to share single database amongst multiple servers, without interference.
 
 message-table-name::
-The name of the table in which bindings data will be persisted for the ActiveMQ Artemis server.
+The name of the table in which message data will be persisted.
 Specifying table names allows users to share single database amongst multiple servers, without interference.
 
 large-message-table-name::
-The name of the table in which messages and related data will be persisted for the ActiveMQ Artemis server.
+The name of the table in which large messages and related data will be persisted.
 Specifying table names allows users to share single database amongst multiple servers, without interference.
 
 page-store-table-name::
@@ -345,7 +349,7 @@ The name of the table to house the page store directory information.
 Note that each address will have its own page table which will use this name appended with a unique id of up to 20 characters.
 
 node-manager-store-table-name::
-The name of the table in which the HA Shared Store locks (i.e. primary and backup) and HA related data will be persisted for the ActiveMQ Artemis server.
+The name of the table in which the HA Shared Store locks (i.e. primary and backup) and HA related data will be persisted.
 Specifying table names allows users to share single database amongst multiple servers, without interference.
 Each Shared Store primary/backup pairs must use the same table name and isn't supported to share the same table between multiple (and unrelated) primary/backup pairs.
 
@@ -378,10 +382,12 @@ jdbc-max-page-size-bytes::
 The maximal size a page can use. The default and recommended maximum value is 100K bytes.
 Using larger sizes will result in downloading large blobs that would affect performance when using paged messages.
 
-NOTE: Some DBMS (e.g. Oracle, 30 chars) have restrictions on the size of table names, this should be taken into consideration when configuring table names for the Artemis database store, pay particular attention to the page store table name, which can be appended with a unique ID of up to 20 characters.
+NOTE: Some DBMS (e.g. Oracle, 30 chars) have restrictions on the size of table names.
+This should be taken into consideration when configuring table names for the database store.
+Pay particular attention to the page-store table name, which can be appended with a unique ID of up to 20 characters.
 (for Oracle this would mean configuring a page-store-table-name of max size of 10 chars).
 
-It is also possible to explicitly add the user and password rather than in the JDBC url if you need to encode it, this would look like:
+It is also possible to explicitly add the user and password rather than in the JDBC url if you need to encode it, e.g.:
 
 [,xml]
 ----
@@ -403,7 +409,7 @@ It is also possible to explicitly add the user and password rather than in the J
 
 === Configuring JDBC connection pooling
 
-To configure Apache ActiveMQ Artemis to use a database with a JDBC connection pool you need to set the data source properties, for example:
+To configure the broker to use a database with a JDBC connection pool you need to set the data source properties, e.g.:
 
 [,xml]
 ----
@@ -435,8 +441,8 @@ Instead, if there is an attempt to write to the journal's tables during the reco
 == Zero Persistence
 
 In some situations, zero persistence is sometimes required for a messaging system.
-Configuring Apache ActiveMQ Artemis to perform zero persistence is straightforward.
+Configuring zero persistence is straightforward.
 Simply set the parameter `persistence-enabled` in `broker.xml` to `false`.
 
 Please note that if you set this parameter to false, then _zero_ persistence will occur.
-That means no bindings data, message data, large message data, duplicate id caches or paging data will be persisted.
+That means no bindings data, message data, large message data, duplicate id caches, or paging data will be persisted.

--- a/docs/user-manual/pre-acknowledge.adoc
+++ b/docs/user-manual/pre-acknowledge.adoc
@@ -9,11 +9,11 @@ JMS specifies 3 acknowledgement modes:
 * `CLIENT_ACKNOWLEDGE`
 * `DUPS_OK_ACKNOWLEDGE`
 
-Apache ActiveMQ Artemis supports two additional modes: `PRE_ACKNOWLEDGE` and `INDIVIDUAL_ACKNOWLEDGE`
+{project-name-full} supports two additional modes: `PRE_ACKNOWLEDGE` and `INDIVIDUAL_ACKNOWLEDGE`
 
-In some cases you can afford to lose messages in event of failure, so it would make sense to acknowledge the message on the server _before_ delivering it to the client.
+In some cases you can afford to lose messages in the event of a failure, so it would make sense to acknowledge the message on the server _before_ delivering it to the client.
 
-This extra mode is supported by Apache ActiveMQ Artemis and will call it _pre-acknowledge_ mode.
+This extra mode is called _pre-acknowledge_ mode.
 
 The disadvantage of acknowledging on the server before delivery is that the message will be lost if the system crashes _after_ acknowledging the message on the server but _before_ it is delivered to the client.
 In that case, the message is lost and will not be recovered when the system restart.

--- a/docs/user-manual/preface.adoc
+++ b/docs/user-manual/preface.adoc
@@ -1,4 +1,4 @@
-= Why use Apache ActiveMQ Artemis?
+= Why use {project-name-full}?
 :idprefix:
 :idseparator: -
 :docinfo: shared
@@ -6,16 +6,16 @@
 Here are just a few reasons:
 
 * 100% open source software.
-Apache ActiveMQ Artemis is licensed using the Apache Software License v 2.0 to minimise barriers to adoption.
-* Apache ActiveMQ Artemis is designed with usability in mind.
+{project-name-full} is licensed using the Apache Software License v 2.0 to minimise barriers to adoption.
+* {project-name-full} is designed with usability in mind.
 * Written in Java.
 Runs on any platform with a Java 11+ runtime, that's everything from Windows desktops to IBM mainframes.
 * Amazing performance.
-Our ground-breaking high performance journal provides persistent messaging performance at rates normally seen for non-persistent messaging, our non-persistent messaging performance rocks the boat too.
+Our ground-breaking high-performance journal provides persistent messaging performance at rates normally seen for non-persistent messaging, our non-persistent messaging performance rocks the boat too.
 * Full feature set.
 All the features you'd expect in any serious messaging system, and others you won't find anywhere else.
 * Elegant, clean-cut design with minimal third party dependencies.
-Run ActiveMQ Artemis stand-alone, run it in integrated in your favourite Java EE application server, or run it embedded inside your own product.
+Run the broker stand-alone, run it in integrated in your favourite Java EE application server, or run it embedded inside your own product.
 It's up to you.
 * Seamless high availability.
 We provide a HA solution with automatic client failover so you can guarantee zero message loss or duplication in event of server failure.

--- a/docs/user-manual/project-info.adoc
+++ b/docs/user-manual/project-info.adoc
@@ -3,10 +3,10 @@
 :idseparator: -
 :docinfo: shared
 
-* Apache ActiveMQ Artemis is an open source project to build a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
-* Apache ActiveMQ Artemis is an example of Message Oriented Middleware (MoM).
-For a description of MoMs and other messaging concepts please see the xref:messaging-concepts.adoc#messaging-concepts[Messaging Concepts].
-* If you have any questions related to the use or development of Apache ActiveMQ Artemis please use one of our https://activemq.apache.org/contact[mailing lists].
+* {project-name-full} is an open source project to build a multi-protocol, embeddable, very high performance, clustered, asynchronous messaging system.
+* {project-name-full} is an example of Message Oriented Middleware (MoM).
+For a description of MoMs and other messaging concepts, please see the xref:messaging-concepts.adoc#messaging-concepts[Messaging Concepts].
+* If you have any questions related to the use or development of {project-name-full} please use one of our https://activemq.apache.org/contact[mailing lists].
 * *Official project page*: https://activemq.apache.org/components/artemis/.
 * *Download*: https://activemq.apache.org/components/artemis/download/
 * *Git repository*: https://github.com/apache/activemq-artemis[https://github.com/apache/activemq-artemis^]

--- a/docs/user-manual/protocols-interoperability.adoc
+++ b/docs/user-manual/protocols-interoperability.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis has a powerful & flexible core which provides a foundation upon which other protocols can be implemented.
+{project-name-full} has a powerful & flexible core which provides a foundation upon which other protocols can be implemented.
 Each protocol implementation translates the ideas of its specific protocol onto this core.
 
 The broker ships with a client implementation which interacts directly with this core.
@@ -22,8 +22,7 @@ https://en.wikipedia.org/wiki/AMQP[AMQP] is a specification for interoperable me
 It also defines a wire format, so any AMQP client can work with any messaging system that supports AMQP.
 AMQP clients are available in many different programming languages.
 
-Apache ActiveMQ Artemis implements the https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=amqp[AMQP 1.0] specification.
-Any client that supports the 1.0 specification will be able to interact with Apache ActiveMQ Artemis.
+Any client that supports the https://www.oasis-open.org/committees/tc_home.php?wg_abbrev=amqp[AMQP 1.0] specification will be able to interact with {project-name-full}.
 
 Please see xref:amqp.adoc#amqp[AMQP] for more details.
 
@@ -31,7 +30,7 @@ Please see xref:amqp.adoc#amqp[AMQP] for more details.
 
 https://mqtt.org/[MQTT] is a lightweight connectivity protocol.
 It is designed to run in environments where device and networks are constrained.
-Any client that supports the 3.1, 3.1.1, or 5 specification will be able to interact with Apache ActiveMQ Artemis.
+Any client that supports the 3.1, 3.1.1, or 5 specification will be able to interact with {project-name-full}.
 
 Please see xref:mqtt.adoc#mqtt[MQTT] for more details.
 
@@ -40,28 +39,27 @@ Please see xref:mqtt.adoc#mqtt[MQTT] for more details.
 https://stomp.github.io/[Stomp] is a very simple text protocol for interoperating with messaging systems.
 It defines a wire format, so theoretically any Stomp client can work with any messaging system that supports Stomp.
 Stomp clients are available in many different programming languages.
-Any client that supports the 1.0, 1.1, or 1.2 specification will be able to interact with Apache ActiveMQ Artemis.
+Any client that supports the 1.0, 1.1, or 1.2 specification will be able to interact with {project-name-full}.
 
 Please see xref:stomp.adoc#stomp[Stomp] for more details.
 
 === OpenWire
 
-ActiveMQ Classic defines its own wire protocol: OpenWire.
-In order to support ActiveMQ Classic clients, Apache ActiveMQ Artemis supports OpenWire.
-Any application using the OpenWire JMS client library shipped with ActiveMQ 5.12.x or higher can be used with Apache ActiveMQ Artemis.
+ActiveMQ defines its own wire protocol: OpenWire.
+Any application using the OpenWire JMS client library shipped with ActiveMQ 5.12.x or higher can be used with {project-name-full}.
 
 Please see xref:openwire.adoc#openwire[OpenWire] for more details.
 
 === Core
 
-ActiveMQ Artemis defines its own wire protocol: Core.
+{project-name-short} defines its own wire protocol: Core.
 
 Please see xref:core.adoc#using-core[Core] for more details.
 
 ==== APIs and Other Interfaces
 
 Although JMS and Jakarta Messaging are standardized APIs, they do not define a network protocol.
-The ActiveMQ Artemis xref:using-jms.adoc#using-jms-or-jakarta-messaging[JMS & Jakarta Messaging clients] are implemented on top of the core protocol.
+The {project-name-short} xref:using-jms.adoc#using-jms-or-jakarta-messaging[JMS & Jakarta Messaging clients] are implemented on top of the core protocol.
 We also provide a xref:using-jms.adoc#jndi[client-side JNDI implementation].
 
 == Configuring Acceptors
@@ -69,7 +67,7 @@ We also provide a xref:using-jms.adoc#jndi[client-side JNDI implementation].
 In order to make use of a particular protocol, a transport must be configured with the desired protocol enabled.
 There is a whole section on configuring transports that can be found xref:configuring-transports.adoc#configuring-the-transport[here].
 
-The default configuration shipped with the ActiveMQ Artemis distribution comes with a number of acceptors already defined, one for each of the above protocols plus a generic acceptor that supports all protocols.
+The default configuration shipped with the distribution comes with a number of acceptors already defined, one for each of the above protocols plus a generic acceptor that supports all protocols.
 To enable  protocols on a particular acceptor simply add the `protocols` url parameter to the acceptor url where the value is one or more protocols (separated by commas).
 If the `protocols` parameter is omitted from the url *all* protocols are  enabled.
 
@@ -105,8 +103,8 @@ Here are the supported protocols and their corresponding value used in the `prot
 |===
 | Protocol | `protocols` value
 
-| Core (Artemis & HornetQ native) | `CORE`
-| OpenWire (Classic native) | `OPENWIRE`
+| Core | `CORE`
+| OpenWire | `OPENWIRE`
 | AMQP | `AMQP`
 | MQTT | `MQTT`
 | STOMP | `STOMP`

--- a/docs/user-manual/resource-adapter.adoc
+++ b/docs/user-manual/resource-adapter.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-For using Apache ActiveMQ Artemis in a Java EE or Jakarta EE environment, you can use the JCA Resource Adapter.
+For using {project-name-full} in a Java EE or Jakarta EE environment, you can use the JCA Resource Adapter.
 
 A JCA-based JMS connection factory has 2 big advantages over a plain JMS connection factory:
 
@@ -107,7 +107,7 @@ You can't configure any properties.
 
 Config options https://github.com/apache/activemq-artemis/blob/{{ config.version }}/artemis-ra/src/main/java/org/apache/activemq/artemis/ra/inflow/ActiveMQActivationSpec.java[ActiveMQActivationSpec]
 
-In the activation spec you can configure all the things you need to get messages consumed from ActiveMQ Artemis.
+In the activation spec you can configure all the things you need to get messages consumed.
 
 useJndi::
 true if you want lookup destinations via jndi.
@@ -138,7 +138,7 @@ subscriptionDurability::
 Durable / NonDurable
 
 subscriptionName::
-Artemis holds all messages for this name if you use durable subscriptions
+the broker holds all messages for this name if you use durable subscriptions
 
 == Logging
 

--- a/docs/user-manual/restart-sequence.adoc
+++ b/docs/user-manual/restart-sequence.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis ships with 2 architectures for providing HA features.
+{project-name-full} ships with 2 architectures for providing HA features.
 The primary and backup brokers can be configured either using network replication or using shared storage.
 This document will share restart sequences for the brokers under various circumstances when the client applications are  connected to it.
 

--- a/docs/user-manual/ring-queues.adoc
+++ b/docs/user-manual/ring-queues.adoc
@@ -129,7 +129,7 @@ Therefore, since a ring queue prefers messages at the tail of the queue over mes
 
 Transaction or core session rollbacks are treated the same way.
 
-If you wish to avoid these kinds of situations and you're using the core client directly or the core JMS client you can minimize messages in delivery by reducing the size of `consumerWindowSize` (1024 * 1024 bytes by default).
+If you wish to avoid these kinds of situations and you're using the Core client directly or the core JMS client you can minimize messages in delivery by reducing the size of `consumerWindowSize` (1024 * 1024 bytes by default).
 
 == Scheduled Messages
 

--- a/docs/user-manual/scheduled-messages.adoc
+++ b/docs/user-manual/scheduled-messages.adoc
@@ -26,7 +26,7 @@ producer.send(message);
 TextMessage messageReceived = (TextMessage) consumer.receive();
 ----
 
-Scheduled messages can also be sent using the core API, by setting the same property on the core message before sending.
+Scheduled messages can also be sent using the Core API, by setting the same property on the core message before sending.
 
 == Example
 

--- a/docs/user-manual/security.adoc
+++ b/docs/user-manual/security.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-This chapter describes how security works with Apache ActiveMQ Artemis and how you can configure it.
+This chapter describes how security works with {project-name-full} and how you can configure it.
 
 == Basic Configuration
 
@@ -45,18 +45,12 @@ It's also possible to set `reject-empty-validated-user`.
 If `true` the server will reject any message that doesn't have a validated user.
 This option is `false` by default.
 
-== Role based security for addresses
+== Role-based security for addresses
 
-Apache ActiveMQ Artemis contains a flexible role-based security model for applying security to queues, based on their addresses.
+Role-based security is applied to queues based on their address.
+Either an exact match on the address or a xref:wildcard-syntax.adoc#wildcard-syntax[wildcard match] can be used.
 
-As explained in xref:core.adoc#using-core[Using Core], Apache ActiveMQ Artemis core consists mainly of sets of queues bound to addresses.
-A message is sent to an address and the server looks up the set of queues that are bound to that address, the server then routes the message to those set of queues.
-
-Apache ActiveMQ Artemis allows sets of permissions to be defined against the queues based on their address.
-An exact match on the address can be used or a xref:wildcard-syntax.adoc#wildcard-syntax[wildcard match] can be used.
-
-There are different permissions that can be given to the set of queues which match the address.
-Those permissions are:
+Here are different permissions that can be granted:
 
 createAddress::
 This permission allows the user to create an address fitting the `match`.
@@ -88,7 +82,7 @@ This permission allows the user to browse a queue bound to the matching address.
 manage::
 This permission allows the user to invoke management operations by sending management messages to the management address.
 
-The following two permissions pertain to operations on the xref:management.adoc#management[management apis] of the broker. They split management operations into two sets, read only for `view`, and `edit` for mutating operations. The split is controlled by a regular expression. Methods that match will require the `view` permission, all others require `edit`. The regular expression can be modified through the configuration attribute xref:configuration-index.adoc#view-permission-method-match-pattern[`view-permission-method-match-pattern`]. These permissions are applicable to the xref:management.adoc#fine-grained-rbac-on-management-messages[management address] and to xref:management.adoc#jmx-authorization-in-broker-xml[MBean access]. They are granted to match addresses prefixed with the xref:configuration-index.adoc#management-rbac-prefix[management prefix].
+The following two permissions pertain to operations on the xref:management.adoc#management[management apis] of the broker. They split management operations into two sets, read-only for `view`, and `edit` for mutating operations. The split is controlled by a regular expression. Methods that match will require the `view` permission, all others require `edit`. The regular expression can be modified through the configuration attribute xref:configuration-index.adoc#view-permission-method-match-pattern[`view-permission-method-match-pattern`]. These permissions are applicable to the xref:management.adoc#fine-grained-rbac-on-management-messages[management address] and to xref:management.adoc#jmx-authorization-in-broker-xml[MBean access]. They are granted to match addresses prefixed with the xref:configuration-index.adoc#management-rbac-prefix[management prefix].
 
 view::
 This permission allows access to a read-only subset of management operations.
@@ -115,21 +109,19 @@ Let's take a simple example, here's a security block from `broker.xml` file:
 
 Using the default xref:wildcard-syntax.adoc#wildcard-syntax[wildcard syntax] the `#` character signifies "any sequence of words".
 Words are delimited by the `.` character.
-Therefore, the above security block applies to any address that starts with the string "globalqueues.europe.".
+Therefore, the above security block applies to any address that starts with the string `globalqueues.europe.`.
 
-Only users who have the `admin` role can create or delete durable queues bound to an address that starts with the string "globalqueues.europe."
+Only users who have the `admin` role can create or delete durable queues bound to an address that starts with the string `globalqueues.europe.`.
 
-Any users with the roles `admin`, `guest`, or `europe-users` can create or delete temporary queues bound to an address that starts with the string "globalqueues.europe."
+Any users with the roles `admin`, `guest`, or `europe-users` can create or delete temporary queues bound to an address that starts with the string `globalqueues.europe.`.
 
-Any users with the roles `admin` or `europe-users` can send messages to these addresses or consume messages from queues bound to an address that starts with the string "globalqueues.europe."
+Any users with the roles `admin` or `europe-users` can send messages to these addresses or consume messages from queues bound to an address that starts with the string `globalqueues.europe.`.
 
-The mapping between a user and what roles they have is handled by the security manager.
-Apache ActiveMQ Artemis ships with a user manager that reads user credentials from a file on disk, and can also plug into JAAS or JBoss Application Server security.
+The security manager handles the mapping between a user and what roles they have.
+For more information on configuring the security manager, please see <<User credentials,here>>.
 
-For more information on configuring the security manager, please see 'Changing the Security Manager'.
-
-There can be zero or more `security-setting` elements in each xml file.
-Where more than one match applies to a set of addresses the _more specific_ match takes precedence.
+There can be zero or more `security-setting` elements where more than one match applies to a set of addresses.
+The _more specific_ match takes precedence.
 
 Let's look at an example of that, here's another `security-setting` block:
 
@@ -149,9 +141,9 @@ All the settings will be taken from the more specific matching block, so for the
 The permissions `createDurableQueue`, `deleteDurableQueue`, `createNonDurableQueue`, `deleteNonDurableQueue` are not inherited from the other `security-setting` block.
 
 By not inheriting permissions, it allows you to effectively deny permissions in more specific `security-setting` blocks by simply not specifying them.
-Otherwise it would not be possible to deny permissions in sub-groups of addresses.
+Otherwise, it would not be possible to deny permissions in sub-groups of addresses.
 
-=== Fine-grained security using fully qualified queue name
+=== Fine-grained security using a fully qualified queue name
 
 In certain situations it may be necessary to configure security that is more fine-grained that simply across an entire address.
 For example, consider an address with multiple queues:
@@ -248,8 +240,8 @@ See the JavaDoc on `org.apache.activemq.artemis.core.server.SecuritySettingPlugi
 
 ==== LegacyLDAPSecuritySettingPlugin
 
-This plugin will read the security information that was previously handled by http://activemq.apache.org/security.html[`LDAPAuthorizationMap`] and the http://activemq.apache.org/cached-ldap-authorization-module.html[`cachedLDAPAuthorizationMap`] in Apache ActiveMQ Classic and turn it into Artemis security settings where possible.
-The security implementations of ActiveMQ Classic and Artemis don't match perfectly so some translation must occur to achieve near equivalent functionality.
+This plugin will read the security information that was previously handled by http://activemq.apache.org/security.html[`LDAPAuthorizationMap`] and the http://activemq.apache.org/cached-ldap-authorization-module.html[`cachedLDAPAuthorizationMap`] in Apache ActiveMQ and turn it into {project-name-short} security settings where possible.
+The security implementations of ActiveMQ and {project-name-short} don't match perfectly so some translation must occur to achieve near equivalent functionality.
 
 Here is an example of the plugin's configuration:
 
@@ -364,11 +356,11 @@ This is a 1-character value that should match the `delimiter` xref:wildcard-synt
 The plugin will translate any `.` character to this value in an LDAP entry defining a destination name.
 The default value is `.`.
 
-The name of the queue or topic defined in LDAP will serve as the "match" for the security-setting, the permission value will be mapped from the ActiveMQ Classic type to the Artemis type, and the role will be mapped as-is.
+The name of the queue or topic defined in LDAP will serve as the "match" for the security-setting, the permission value will be mapped from the ActiveMQ type to the {project-name-short} type, and the role will be mapped as-is.
 
-ActiveMQ Classic only has 3 permission types - `read`, `write`, and `admin`.
+ActiveMQ only has 3 permission types - `read`, `write`, and `admin`.
 These permission types are described on their http://activemq.apache.org/security.html[website].
-However, as described previously, ActiveMQ Artemis has 9 permission types - `createAddress`, `deleteAddress`, `createDurableQueue`, `deleteDurableQueue`, `createNonDurableQueue`, `deleteNonDurableQueue`, `send`, `consume`, `browse`, and `manage`.
+However, as described previously, {project-name-short} has 9 permission types - `createAddress`, `deleteAddress`, `createDurableQueue`, `deleteDurableQueue`, `createNonDurableQueue`, `deleteNonDurableQueue`, `send`, `consume`, `browse`, and `manage`.
 Here's how the old types are mapped to the new types:
 
 read::
@@ -382,25 +374,25 @@ admin::
 
 As mentioned, there are a few places where a translation was performed to achieve some equivalence.:
 
-* This mapping doesn't include the Artemis `manage` permission type by default since there is no type analogous for that in ActiveMQ Classic.
+* This mapping doesn't include the {project-name-short} `manage` permission type by default since there is no type analogous for that in ActiveMQ.
 However, if `mapAdminToManage` is `true` then the legacy `admin` permission will be mapped to the `manage` permission.
-* The `admin` permission in ActiveMQ Classic relates to whether or not the broker will auto-create a destination if it doesn't exist and the user sends a message to it.
-Artemis automatically allows the automatic creation of a destination if the user has permission to send message to it.
-Therefore, the plugin will map the `admin` permission to the 6 aforementioned permissions in Artemis by default.
+* The `admin` permission in ActiveMQ relates to whether or not the broker will auto-create a destination if it doesn't exist and the user sends a message to it.
+{project-name-short} automatically allows the automatic creation of a destination if the user has permission to send messages to it.
+Therefore, the plugin will map the `admin` permission to the 6 aforementioned permissions in {project-name-short} by default.
 If `mapAdminToManage` is `true` then the legacy `admin` permission will be mapped to the `manage` permission as well.
 
 == Secure Sockets Layer (SSL) Transport
 
-When messaging clients are connected to servers, or servers are connected to other servers (e.g. via bridges) over an untrusted network then Apache ActiveMQ Artemis allows that traffic to be encrypted using the Secure Sockets Layer (SSL) transport.
+When messaging clients are connected to servers, or servers are connected to other servers (e.g. via bridges) over an untrusted network, then traffic can be encrypted using the Secure Sockets Layer (SSL) transport.
 
 For more information on configuring the SSL transport, please see xref:configuring-transports.adoc#configuring-the-transport[Configuring the Transport].
 
 == User credentials
 
-Apache ActiveMQ Artemis ships with three security manager implementations:
+Three security manager implementations are available:
 
 * The flexible, pluggable `ActiveMQJAASSecurityManager` which supports any standard JAAS login module.
-Artemis ships with several login modules which will be discussed further down.
+Several login modules (discussed later) are available.
 This is the default security manager.
 * The `ActiveMQBasicSecurityManager` which doesn't use JAAS and only supports auth via username & password credentials.
 It also supports adding, removing, and updating users via the management API.
@@ -441,7 +433,7 @@ In short, the file defines:
 * a flag which indicates whether the success of the login module is `required`, `requisite`, `sufficient`, or `optional` (see more details on these flags in the https://docs.oracle.com/en/java/javase/17/docs/api/java.base/javax/security/auth/login/Configuration.html[JavaDoc])
 * a list of configuration options specific to the login module implementation
 
-By default, the location and name of `login.config` is specified on the Artemis command-line which is set by `etc/artemis.profile` on linux and  `etc\artemis.profile.cmd` on Windows.
+By default, the location and name of `login.config` is specified on the command-line which is set by `etc/artemis.profile` on Linux and  `etc\artemis.profile.cmd` on Windows.
 
 ==== Dual Authentication
 
@@ -603,8 +595,8 @@ guest=password
 Passwords in `artemis-users.properties` can be hashed.
 Such passwords should follow the syntax `ENC(<hash>)`.
 
-Hashed passwords can easily be added to `artemis-users.properties` using the `user` CLI command from the Artemis _instance_.
-This command will not work  from the Artemis home, and it will also not work unless the broker has been started.
+Hashed passwords can easily be added to `artemis-users.properties` using the `user` CLI command from the broker _instance_.
+This command will not work from the broker home, and it will also not work unless the broker is running.
 
 [,sh]
 ----
@@ -623,8 +615,8 @@ users=system,user
 guests=guest
 ----
 
-As mentioned above, the Artemis command-line interface supports a command to `add` a user.
-Commands to `list` (one or all) users, `remove` a user, and `reset` a user's password and/or role(s) are also supported via the command-line interface as well as the normal management interfaces (e.g. JMX, web console, etc.).
+As mentioned above, the xref:using-cli.adoc#command-line-interface[command-line interface] supports a command to `add` a user.
+Commands to `list` (one or all) users, `remove` a user, and `reset` a user's password and/or role(s) are also supported via the xref:using-cli.adoc#command-line-interface[command-line interface] as well as the normal management interfaces (e.g. JMX, web console, etc.).
 
 ____
 *Warning*
@@ -640,7 +632,7 @@ ____
 ==== LDAPLoginModule
 
 The LDAP login module enables you to perform authentication and authorization by checking the incoming credentials against user data stored in a central X.500 directory server.
-For systems that already have an X.500 directory server in place, this means that you can rapidly integrate ActiveMQ Artemis with the existing security database and user accounts can be managed using the X.500 system.
+For systems that already have an X.500 directory server in place, this means that you can rapidly integrate the broker with the existing security database and user accounts can be managed using the X.500 system.
 It is implemented by `org.apache.activemq.artemis.spi.core.security.jaas.LDAPLoginModule`.
 
 initialContextFactory::
@@ -1045,7 +1037,7 @@ users=system:serviceaccounts:other-ns:test-sa
 === SCRAM-SHA SASL Mechanism
 
 SCRAM (Salted Challenge Response Authentication Mechanism) is an authentication mechanism that can establish mutual authentication using passwords.
-Apache ActiveMQ Artemis supports SCRAM-SHA-256 and SCRAM-SHA-512 SASL mechanisms to provide authentication for AMQP connections.
+SCRAM-SHA-256 and SCRAM-SHA-512 SASL mechanisms can provide authentication for AMQP connections.
 
 The following properties of SCRAM make it safe to use SCRAM-SHA even on unencrypted connections:
 
@@ -1123,13 +1115,13 @@ amqp-sasl-gssapi {
 
 === Role Mapping
 
-On the server, a Kerberos or SCRAM-SHA JAAS authenticated Principal must be added to the Subject's principal set as an Apache ActiveMQ Artemis UserPrincipal using the corresponding Apache ActiveMQ Artemis `Krb5LoginModule` or `SCRAMLoginModule` login modules.
+On the server, a Kerberos or SCRAM-SHA JAAS authenticated principal must be added to the Subject's principal set as a `UserPrincipal` using the corresponding `Krb5LoginModule` or `SCRAMLoginModule` login modules.
 They are separate to allow conversion and role mapping to be as restrictive or permissive as desired.
 
-The <<propertiesloginmodule,PropertiesLoginModule>> or <<ldaploginmodule,LDAPLoginModule>> can then be used to map the authenticated  Principal to an Apache ActiveMQ Artemis <<role-based-security-for-addresses,Role>>.
-Note that in the case of Kerberos, the Peer Principal does not exist as an Apache ActiveMQ Artemis user, only as a role member.
+The <<propertiesloginmodule,`PropertiesLoginModule`>> or <<ldaploginmodule,`LDAPLoginModule`>> can then be used to map the authenticated  Principal to a <<role-based-security-for-addresses,role>>.
+Note that in the case of Kerberos, the Peer Principal does not exist as a user, only as a role member.
 
-In the following example, any existing Kerberos authenticated peer will convert to an Apache ActiveMQ Artemis user principal and will have role mapping applied by the LDAPLoginModule as appropriate.
+In the following example, any existing Kerberos authenticated peer will convert to a user principal and will have role mapping applied by the `LDAPLoginModule` as appropriate.
 
 ----
 activemq {
@@ -1172,7 +1164,7 @@ Nevertheless, if you just want to share user data between a single live/backup p
 User management is provided by the broker's management API.
 This includes the ability to add, list, update, and remove users & roles.
 As with all management functions, this is available via JMX, management messages, HTTP (via Jolokia), web console, etc.
-These functions are also available from the ActiveMQ Artemis command-line interface.
+These functions are also available from the xref:using-cli.adoc#command-line-interface[command-line interface].
 Having the broker store this data directly means that it must be running in order to manage users.
 There is no way to modify the bindings data manually.
 
@@ -1317,7 +1309,6 @@ Please see xref:management.adoc#management[Management] for instructions on how t
 
 == Securing the console
 
-Artemis comes with a web console that allows user to browse Artemis documentation via an embedded server.
 By default the web access is plain HTTP.
 It is configured in `bootstrap.xml`:
 
@@ -1330,7 +1321,7 @@ It is configured in `bootstrap.xml`:
 </web>
 ----
 
-Alternatively you can edit the above configuration to enable secure access using HTTPS protocol.
+Alternatively, you can edit the above configuration to enable secure access using HTTPS protocol.
 e.g.:
 
 [,xml]
@@ -1409,27 +1400,29 @@ keytool -storetype pkcs12 -keystore client-truststore.p12 -storepass securepass 
 
 ## Controlling JMS ObjectMessage deserialization
 
-Artemis provides a simple class filtering mechanism with which a user can specify which packages are to be trusted and which are not. Objects whose classes are from trusted packages can be deserialized without problem, whereas those from 'not trusted' packages will be denied deserialization.
+A simple class filtering mechanism is available so that a user can specify which packages are to be trusted and which are not.
+Objects whose classes are from trusted packages can be deserialized without problem, whereas those from 'not trusted' packages will be denied deserialization.
 
-Artemis keeps a `deny list` to keep track of packages that are not trusted and a `allow list` for trusted packages. By default both lists are empty, meaning any serializable object is allowed to be deserialized.
+A `deny list` tracks packages that are not trusted and an `allow list` tracks trusted packages.
+By default, both lists are empty, meaning _any_ serializable object is allowed to be deserialized.
 If an object whose class matches one of the packages in deny list, it is not allowed to be deserialized.
 If it matches one in the allow list the object can be deserialized.
 If a package appears in both deny list and allow list, the one in deny list takes precedence.
-If a class neither matches with `deny list` nor with the `allow list`, the class deserialization will be denied unless the allow list is empty (meaning the user doesn't specify the allow list at all).
+If a class neither matches with deny list nor with the allow list, the class deserialization will be denied unless the allow list is empty (meaning the user doesn't specify the allow list at all).
 
-A class is considered as a 'match' if:
+A class is considered as a "match" if:
 
 * its full name exactly matches one of the entries in the list.
 * its package matches one of the entries in the list or is a sub-package of one of the entries.
 
-For example, if a class full name is "org.apache.pkg1.Class1", some matching
+For example, if a class full name is `org.apache.pkg1.Class1`, some matching
 entries could be:
 
 * `org.apache.pkg1.Class1` - exact match.
 * `org.apache.pkg1` - exact package match.
-* `org.apache` -- sub package match.
+* `org.apache` -- sub-package match.
 
-A `*` means 'match-all' in a deny or allow list.
+A `*` means "match-all".
 
 ### Config via Connection Factories
 

--- a/docs/user-manual/send-guarantees.adoc
+++ b/docs/user-manual/send-guarantees.adoc
@@ -5,7 +5,7 @@
 
 == Transaction Completion
 
-When committing or rolling back a transaction with Apache ActiveMQ Artemis, the request to commit or rollback is sent to the server, and the call will block on the client side until a response has been received from the server that the commit or rollback was executed.
+When committing or rolling back a transaction, the request to commit or rollback is sent to the server, and the call will block on the client side until a response has been received from the server that the commit or rollback was executed.
 
 When the commit or rollback is received on the server, it will be committed to the journal, and depending on the value of the parameter `journal-sync-transactional` the server will ensure that the commit or rollback is durably persisted to storage before sending the response back to the client.
 If this parameter has the value `false` then commit or rollback may not actually get persisted to storage until some time after the response has been sent to the client.
@@ -16,38 +16,38 @@ Setting this parameter to `false` can improve performance at the expense of some
 
 This parameter is set in `broker.xml`
 
-== Non Transactional Message Sends
+== Non-Transactional Message Sends
 
-If you are sending messages to a server using a non transacted session, Apache ActiveMQ Artemis can be configured to block the call to send until the message has definitely reached the server, and a response has been sent back to the client.
-This can be configured individually for durable and non-durable messages, and is determined by the following two URL parameters:
+If you are sending messages to a server using a non-transacted session, the Core client can be configured to block the call to `send` until the message has definitely reached the server and a response has been sent back to the client.
+This can be configured individually for durable and non-durable messages and is determined by the following two URL parameters:
 
 blockOnDurableSend::
-If this is set to `true` then all calls to send for durable messages on non transacted sessions will block until the message has reached the server, and a response has been sent back.
+If this is set to `true` then all calls to send for durable messages on non-transacted sessions will block until the message has reached the server, and a response has been sent back.
 The default value is `true`.
 
 blockOnNonDurableSend::
-If this is set to `true` then all calls to send for non-durable messages on non transacted sessions will block until the message has reached the server, and a response has been sent back.
+If this is set to `true` then all calls to send for non-durable messages on non-transacted sessions will block until the message has reached the server, and a response has been sent back.
 The default value is `false`.
 
-Setting block on sends to `true` can reduce performance since each send requires a network round trip before the next send can be performed.
+Blocking a send operation can reduce performance since each send requires a network round trip before the next send can be performed.
 This means the performance of sending messages will be limited by the network round trip time (RTT) of your network, rather than the bandwidth of your network.
-For better performance we recommend either batching many messages sends together in a transaction since with a transactional session, only the commit / rollback blocks not every send, or, using Apache ActiveMQ Artemis's advanced _asynchronous send acknowledgements feature_ described in Asynchronous Send Acknowledgements.
+For better performance we recommend either batching many sends together in a transaction (since only the commit & rollback blocks with a transactional session), or using the advanced <<Asynchronous Send Acknowledgements,asynchronous send acknowledgements feature>>.
 
-When the server receives a message sent from a non transactional session, and that message is durable and the message is routed to at least one durable queue, then the server will persist the message in permanent storage.
+When the server receives a message sent from a non-transactional session, and that message is durable and the message is routed to at least one durable queue, then the server will persist the message in permanent storage.
 If the journal parameter `journal-sync-non-transactional` is set to `true` the server will not send a response back to the client until the message has been persisted and the server has a guarantee that the data has been persisted to disk.
 The default value for this parameter is `true`.
 
-== Non Transactional Acknowledgements
+== Non-Transactional Acknowledgements
 
-If you are acknowledging the delivery of a message at the client side using a non transacted session, Apache ActiveMQ Artemis can be configured to block the call to acknowledge until the acknowledge has definitely reached the server, and a response has been sent back to the client.
+If you are acknowledging the delivery of a message at the client side using a non-transacted session, the Core client can be configured to block the call to acknowledge until the acknowledge has definitely reached the server, and a response has been sent back to the client.
 This is configured with the parameter `BlockOnAcknowledge`.
-If this is set to `true` then all calls to acknowledge on non transacted sessions will block until the acknowledge has reached the server, and a response has been sent back.
+If this is set to `true` then all calls to acknowledge on non-transacted sessions will block until the acknowledge has reached the server, and a response has been sent back.
 You might want to set this to `true` if you want to implement a strict _at most once_ delivery policy.
 The default value is `false`
 
 == Asynchronous Send Acknowledgements
 
-If you are using a non transacted session but want a guarantee that every message sent to the server has reached it, then, as discussed in Guarantees of Non Transactional Message Sends, you can configure Apache ActiveMQ Artemis to block the call to send until the server has received the message, persisted it and sent back a response.
+If you are using a non-transacted session but want a guarantee that every message sent to the server has reached it, then, as discussed in <<Non-Transactional Message Sends,here>>, you can configure the Core client to block the `send` operation until the server has received the message, persisted it, and sent back a response.
 This works well but has a severe performance penalty - each call to send needs to block for at least the time of a network round trip (RTT) - the performance of sending is thus limited by the latency of the network, _not_ limited by the network bandwidth.
 
 Let's do a little bit of maths to see how severe that is.
@@ -58,17 +58,17 @@ With a RTT of 0.25 ms, the client can send _at most_ 1000/ 0.25 = 4000 messages 
 If each message is < 1500 bytes and a standard 1500 bytes MTU (Maximum Transmission Unit) size is used on the network, then a 1GiB network has a _theoretical_ upper limit of (1024 * 1024 * 1024 / 8) / 1500 = 89478 messages per second if messages are sent without blocking!
 These figures aren't an exact science but you can clearly see that being limited by network RTT can have serious effect on performance.
 
-To remedy this, Apache ActiveMQ Artemis provides an advanced new feature called _asynchronous send acknowledgements_.
-With this feature, Apache ActiveMQ Artemis can be configured to send messages without blocking in one direction and asynchronously getting acknowledgement from the server that the messages were received in a separate stream.
+To remedy this, the Core client provides an advanced new feature called _asynchronous send acknowledgements_.
+With this feature, the Core client can be configured to send messages without blocking in one direction and asynchronously getting acknowledgement from the server that the messages were received in a separate stream.
 By de-coupling the send from the acknowledgement of the send, the system is not limited by the network RTT, but is limited by the network bandwidth.
 Consequently better throughput can be achieved than is possible using a blocking approach, while at the same time having absolute guarantees that messages have successfully reached the server.
 
 The window size for send acknowledgements is determined by the confirmation-window-size parameter on the connection factory or client session factory.
 Please see xref:client-failover.adoc#core-client-failover[Client Failover] for more info on this.
 
-To use the feature using the core API, you implement the interface `org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler` and set a handler instance on your `ClientSession`.
+To use the feature using the Core API, you implement the interface `org.apache.activemq.artemis.api.core.client.SendAcknowledgementHandler` and set a handler instance on your `ClientSession`.
 
-Then, you just send messages as normal using your `ClientSession`, and as messages reach the server, the server will send back an acknowledgement of the send asynchronously, and some time later you are informed at the client side by Apache ActiveMQ Artemis calling your handler's `sendAcknowledged(ClientMessage message)` method, passing in a reference to the message that was sent.
+Then, you just send messages as normal using your `ClientSession`, and as messages reach the server, the server will send back an acknowledgement of the send asynchronously, and some time later you are informed at the client side by the invocation of your handler's `sendAcknowledged(ClientMessage message)` method, passing in a reference to the message that was sent.
 
 To enable asynchronous send acknowledgements you must make sure `confirmationWindowSize` is set to a positive integer value, e.g. 10MiB
 

--- a/docs/user-manual/slow-consumers.adoc
+++ b/docs/user-manual/slow-consumers.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-In this section we will discuss how Apache ActiveMQ Artemis can be configured to deal with slow consumers.
+In this section we will discuss how {project-name-full} can be configured to deal with slow consumers.
 A slow consumer with a server-side queue (e.g. JMS topic subscriber) can pose a significant problem for broker performance.
 If messages build up in the consumer's server-side queue then memory will begin filling up and the broker may enter paging mode which would impact performance negatively.
 However, criteria can be set so that consumers which don't acknowledge messages quickly enough can potentially be disconnected from the broker, which in the case of a non-durable JMS subscriber, would allow the broker to remove the subscription and all of its messages freeing up valuable server resources.
@@ -24,4 +24,4 @@ See xref:thread-pooling.adoc#thread-management[thread pooling] for more details 
 
 == Example
 
-See the xref:examples.adoc#slow-consumer[slow consumer example] which shows how to detect a slow consumer with Apache ActiveMQ Artemis.
+See the xref:examples.adoc#slow-consumer[slow consumer example] which shows how to detect a slow consumer.

--- a/docs/user-manual/stomp.adoc
+++ b/docs/user-manual/stomp.adoc
@@ -4,11 +4,11 @@
 :docinfo: shared
 
 https://stomp.github.io/[STOMP] is a text-orientated wire protocol that allows STOMP clients to communicate with STOMP Brokers.
-Apache ActiveMQ Artemis supports STOMP 1.0, 1.1 and 1.2.
+{project-name-full} supports STOMP 1.0, 1.1 and 1.2.
 
-STOMP clients are available for several languages and platforms making it a good choice for interoperability.
+STOMP clients are available for several languages and platforms, making it a good choice for interoperability.
 
-By default there are `acceptor` elements configured to accept STOMP connections on ports `61616` and `61613`.
+By default, there are `acceptor` elements configured to accept STOMP connections on ports `61616` and `61613`.
 
 See the general xref:protocols-interoperability.adoc#protocols-and-interoperability[Protocols and Interoperability] chapter for details on configuring an `acceptor` for STOMP.
 
@@ -19,26 +19,26 @@ Refer to the STOMP xref:examples.adoc[examples] for a look at some of this funct
 === Transactional Acknowledgements
 
 The STOMP specification identifies *transactional acknowledgements* as an optional feature.
-Support for transactional acknowledgements is not implemented in Apache ActiveMQ Artemis.
-The `ACK` frame can not be part of a transaction.
+Support for transactional acknowledgements is not implemented.
+The `ACK` frame cannot be part of a transaction.
 It will be ignored if its `transaction` header is set.
 
 === Virtual Hosting
 
-Apache ActiveMQ Artemis currently doesn't support virtual hosting, which means the `host` header in `CONNECT` frame will be ignored.
+Virtual hosting isn't supported which means the `host` header in `CONNECT` frame will be ignored.
 
 == Mapping STOMP destinations to addresses and queues
 
-STOMP clients deals with _destinations_ when sending messages and subscribing.
-Destination names are simply strings which are mapped to some form of destination on the server - how the server translates these is left to the server implementation.
+STOMP clients deal with _destinations_ when sending messages and subscribing.
+Destination names are simply strings that are mapped to some form of destination on the server - how the server translates this is left to the implementation.
 
-In Apache ActiveMQ Artemis, these destinations are mapped to _addresses_ and _queues_ depending on the operation being done and the desired semantics (e.g. anycast or multicast).
+These destinations are mapped to _addresses_ and _queues_ depending on the operation being done and the desired semantics (e.g. anycast or multicast).
 
 == Logging
 
 Incoming and outgoing STOMP frames can be logged by enabling `DEBUG` for `org.apache.activemq.artemis.core.protocol.stomp.StompConnection`.
 This can be extremely useful for debugging or simply monitoring client activity.
-Along with the STOMP frame itself the remote IP address of the client is logged as well as the internal connection ID so that frames from the same client can be correlated.
+Along with the STOMP frame itself, the remote IP address of the client is logged as well as the internal connection ID so that frames from the same client can be correlated.
 
 Follow xref:logging.adoc#configuring-a-specific-level-for-a-logger[these steps] to configure logging appropriately.
 
@@ -250,19 +250,19 @@ When a large message is delivered to a STOMP consumer, the broker will automatic
 If a large message is compressed, the server will uncompressed it before sending it to stomp clients.
 The default value of `stompMinLargeMessageSize` is the same as the default value of xref:large-messages.adoc#configuring-the-core-client[minLargeMessageSize].
 
-== Web Sockets
+== WebSockets
 
-Apache ActiveMQ Artemis also supports STOMP over https://html.spec.whatwg.org/multipage/web-sockets.html[Web Sockets].
-Modern web browsers which support Web Sockets can send and receive STOMP messages.
+STOMP over https://html.spec.whatwg.org/multipage/web-sockets.html[WebSockets] is also supported.
+Modern web browsers which support WebSockets can send and receive STOMP messages.
 
-STOMP over Web Sockets is supported via the normal STOMP acceptor:
+STOMP over WebSockets is supported via the normal STOMP acceptor:
 
 [,xml]
 ----
 <acceptor name="stomp-ws-acceptor">tcp://localhost:61614?protocols=STOMP</acceptor>
 ----
 
-With this configuration, Apache ActiveMQ Artemis will accept STOMP connections over Web Sockets on the port `61614`.
+With this configuration, the broker will accept STOMP connections over WebSockets on the port `61614`.
 Web browsers can then connect to `ws://<server>:61614` using a Web Socket to send and receive STOMP messages.
 
 A companion JavaScript library to ease client-side development is available from https://github.com/jmesnil/stomp-websocket[GitHub] (please see its http://jmesnil.net/stomp-websocket/doc/[documentation] for a complete description).
@@ -277,7 +277,7 @@ By default the broker encodes them as binary.
 However, this can be changed by using the `webSocketEncoderType` acceptor URL parameter.
 Valid values are `binary` and `text`.
 
-The `stomp-websockets` xref:examples.adoc[example] shows how to configure an Apache ActiveMQ Artemis broker to have web browsers and Java applications exchanges messages.
+The `stomp-websockets` xref:examples.adoc[example] shows how to configure a broker to have web browsers and Java applications exchanges messages.
 
 == Flow Control
 
@@ -286,7 +286,7 @@ This is broadly discussed in the xref:flow-control.adoc#flow-control[Flow Contro
 
 This ability is similar to the `activemq.prefetchSize` header supported by ActiveMQ Classic.
 However, that header specifies the size in terms of _messages_ whereas `consumer-window-size` specifies the size in terms of _bytes_.
-ActiveMQ Artemis supports the `activemq.prefetchSize` header for backwards compatibility but the value will be interpreted as _bytes_ just like `consumer-window-size` would be.
+The `activemq.prefetchSize` header is supported for backwards compatibility, but the value will be interpreted as _bytes_ just like `consumer-window-size` would be.
 If both `activemq.prefetchSize` and `consumer-window-size` are set then the value for `consumer-window-size` will be used.
 
 Setting `consumer-window-size` to `0` will ensure that once a STOMP client receives a message that it will _not_ receive another one until it sends the appropriate `ACK` or `NACK` frame for the message it already has.

--- a/docs/user-manual/thread-pooling.adoc
+++ b/docs/user-manual/thread-pooling.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-This chapter describes how Apache ActiveMQ Artemis uses and pools threads and how you can manage them.
+This chapter describes how {project-name-full} uses and pools threads and how you can manage them.
 
 First we'll discuss how threads are managed and used on the server side then we'll look at the client side.
 
@@ -81,7 +81,7 @@ The name for threads from this pool will contain `activemq-paging-<brokerName>`.
 
 === Netty Acceptors
 
-Apache ActiveMQ Artemis will, by default, cap Netty threads on a per-acceptor basis at three times the number of cores (or hyper-threads) as reported by `Runtime.getRuntime().availableProcessors()` for processing network traffic.
+Netty threads for processing network traffic, by default, are capped on a per-acceptor basis at three times the number of cores (or hyper-threads) as reported by `Runtime.getRuntime().availableProcessors()`.
 To override this value, you can set the number of threads by specifying the parameter `remotingThreads` in the transport configuration.
 See the xref:configuring-transports.adoc#configuring-the-transport[configuring transports] for more information on this.
 
@@ -91,7 +91,7 @@ For example, for the acceptor named `amqp` the corresponding thread names will c
 === Other Server-Side Threads
 
 A thread dump from the server's JVM will have other threads as well.
-Here's other names you might find in a thread dump and the function they perform.
+Here are other names you might find in a thread dump and the function they perform.
 
 `activemq-web`::
 thread pool managed by Jetty (i.e. the xref:web-server.adoc[embedded web server]) to handle HTTP connections (e.g. from the web console or other Jolokia clients)
@@ -113,7 +113,7 @@ executes Log4j2 tasks related to `CronTriggeringPolicy` used by default `log4j2.
 
 == Client-Side Thread Management
 
-On the client side, Apache ActiveMQ Artemis maintains a single, "global" static scheduled thread pool and a single, "global" static general thread pool for use by all clients using the same classloader in that JVM instance.
+On the client side, the Core client maintains a single, "global" static scheduled thread pool and a single, "global" static general thread pool for use by all clients using the same classloader in that JVM instance.
 
 The static scheduled thread pool has a maximum size of `5` threads by default.
 This can be changed using the `scheduledThreadPoolMaxSize` URI parameter.
@@ -121,6 +121,6 @@ This can be changed using the `scheduledThreadPoolMaxSize` URI parameter.
 The general purpose thread pool has an unbounded maximum size.
 This is changed using the `threadPoolMaxSize` URL parameter.
 
-If required Apache ActiveMQ Artemis can also be configured so that each `ClientSessionFactory` instance does not use these "global" static pools but instead maintains its own scheduled and general purpose pool.
+If required the Core client can also be configured so that each `ClientSessionFactory` instance does not use these "global" static pools but instead maintains its own scheduled and general purpose pool.
 Any sessions created from that `ClientSessionFactory` will use those pools instead.
 This is configured using the `useGlobalPools` boolean URL parameter.

--- a/docs/user-manual/tomcat.adoc
+++ b/docs/user-manual/tomcat.adoc
@@ -5,10 +5,10 @@
 
 == Resource Context Client Configuration
 
-Apache ActiveMQ Artemis provides support for configuring the client in the `context.xml` of the Tomcat container.
+A {project-name-short} client can be configured in the `context.xml` of the Tomcat container.
 
-This is very similar to the way this is done in ActiveMQ Classic so anyone migrating should find this familiar.
-Please note though the connection url and properties that can be set for ActiveMQ Artemis are different please see https://activemq.apache.org/artemis/migration/[Migration Documentation]
+This is very similar to the way this is done in ActiveMQ so anyone migrating should find this familiar.
+Please note, the connection url and properties are different please see https://activemq.apache.org/artemis/migration/[Migration Documentation]
 
 === Example of Connection Factory
 

--- a/docs/user-manual/transaction-config.adoc
+++ b/docs/user-manual/transaction-config.adoc
@@ -3,15 +3,15 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis has its own Resource Manager for handling the lifespan of JTA transactions.
+{project-name-full} has its own Resource Manager for handling the lifespan of JTA transactions.
 When a transaction is started the resource manager is notified and keeps a record of the transaction and its current state.
 It is possible in some cases for a transaction to be started but then forgotten about.
 Maybe the client died and never came back.
 If this happens then the transaction will just sit there indefinitely.
 
-To cope with this Apache ActiveMQ Artemis can, if configured, scan for old transactions and rollback any it finds.
+To cope with this the broker can, if configured, scan for old transactions and rollback any it finds.
 The default for this is 3000000 milliseconds (5 minutes), i.e. any transactions older than 5 minutes are removed.
 This timeout can be changed by editing the `transaction-timeout` property in `broker.xml` (value must be in milliseconds).
 The property `transaction-timeout-scan-period` configures how often, in milliseconds, to scan for old transactions.
 
-Please note that Apache ActiveMQ Artemis will not unilaterally rollback any XA transactions in a prepared state - this must be heuristically rolled back via the management API if you are sure they will never be resolved by the transaction manager.
+Please note that the broker will not unilaterally rollback any XA transactions in a prepared state - this must be heuristically rolled back via the management API if you are sure they will never be resolved by the transaction manager.

--- a/docs/user-manual/undelivered-messages.adoc
+++ b/docs/user-manual/undelivered-messages.adoc
@@ -52,7 +52,7 @@ Delayed redelivery is defined in the address-setting configuration:
 </address-setting>
 ----
 
-If a `redelivery-delay` is specified, Apache ActiveMQ Artemis will wait this delay before redelivering the messages.
+If a `redelivery-delay` is specified, the broker will wait this delay before redelivering the messages.
 
 By default, there is no redelivery delay (``redelivery-delay``is set to 0).
 
@@ -115,7 +115,7 @@ To prevent a client infinitely receiving the same undelivered message (regardles
 
 Any such messages can then be diverted to queue(s) where they can later be perused by the system administrator for action to be taken.
 
-Apache ActiveMQ Artemis's addresses can be assigned a dead letter address.
+Addresses can be assigned a dead letter address.
 Once the messages have been unsuccessfully delivered for a given number of attempts, they are removed from their queue and sent to the relevant dead letter address.
 These _dead letter_ messages can later be consumed from the dead letter address for further inspection.
 
@@ -185,7 +185,7 @@ Here is an example configuration:
 </address-setting>
 ----
 
-The queue holding the undeliverable messages can be accessed directly either by using the queue's name by itself (e.g. when using the core client) or by using the fully qualified queue name (e.g. when using a JMS client) just like any other queue.
+The queue holding the undeliverable messages can be accessed directly either by using the queue's name by itself (e.g. when using the Core client) or by using the fully qualified queue name (e.g. when using a JMS client) just like any other queue.
 Also, note that the queue is auto-created which means it will be auto-deleted as per the relevant `address-settings`.
 
 === Example
@@ -194,14 +194,14 @@ See: Dead Letter section of the xref:examples.adoc#examples[Examples] for an exa
 
 == Delivery Count Persistence
 
-In normal use, Apache ActiveMQ Artemis does not update delivery count _persistently_ until a message is rolled back (i.e. the delivery count is not updated _before_ the message is delivered to the consumer).
+In normal use, the broker does not update delivery count _persistently_ until a message is rolled back (i.e. the delivery count is not updated _before_ the message is delivered to the consumer).
 In most messaging use cases, the messages are consumed, acknowledged and forgotten as soon as they are consumed.
 In these cases, updating the delivery count persistently before delivering the message would add an extra persistent step _for each message delivered_, implying a significant performance penalty.
 
 However, if the delivery count is not updated persistently before the message delivery happens, in the event of a server crash, messages might have been delivered but that will not have been reflected in the delivery count.
 During the recovery phase, the server will not have knowledge of that and will deliver the message with `redelivered` set to `false` while it should be `true`.
 
-As this behavior breaks strict JMS semantics, Apache ActiveMQ Artemis allows to persist delivery count before message delivery but this feature is disabled by default due to performance implications.
+As this behavior breaks strict JMS semantics, the broker can persist the delivery count before message delivery, but this feature is disabled by default due to performance implications.
 
 To enable it, set `persist-delivery-count-before-delivery` to `true` in `broker.xml`:
 

--- a/docs/user-manual/unit-testing.adoc
+++ b/docs/user-manual/unit-testing.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Artemis resources can be run inside JUnit Tests by using provided Rules (for JUnit 4) or Extensions (for JUnit 5).
+Broker resources can be run inside JUnit tests by using provided rules (for JUnit 4) or extensions (for JUnit 5).
 This can make it easier to embed messaging functionality in your tests.
 
 These are provided by the packages `artemis-junit` (JUnit 4) and `artemis-junit-5` (JUnit 5).

--- a/docs/user-manual/upgrading.adoc
+++ b/docs/user-manual/upgrading.adoc
@@ -3,18 +3,18 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Classic (and previous versions) is runnable out of the box by executing the command: `./bin/activemq run`.
-The ActiveMQ Artemis broker follows a different paradigm where the project distribution serves as the broker "home" and one or more broker "instances" are created which reference the "home" for resources (e.g. jar files) which can be safely shared between broker instances.
+Apache ActiveMQ is runnable out of the box by executing the command: `./bin/activemq run`.
+The {project-name-short} broker follows a different paradigm where the project distribution serves as the broker "home" and one or more broker "instances" are created which reference the "home" for resources (e.g. jar files) which can be safely shared between broker instances.
 Therefore, an instance of the broker must be created before it can be run.
-This may seems like an overhead at first glance, but it becomes very practical when updating to a new Artemis version for example.
+This may seem like an overhead at first glance, but it becomes very practical when updating to a new version, for example.
 
-To create an Artemis broker instance navigate into the Artemis home folder and run: `./bin/artemis create /path/to/myBrokerInstance` on the command line.
+To create a broker instance, navigate into the home folder and run: `./bin/artemis create /path/to/myBrokerInstance` on the command line.
 
-Because of this separation it's very easy to upgrade Artemis in most cases.
+Because of this separation, it's very easy to upgrade in most cases.
 
-NOTE: It's recommended to choose a folder different from where Apache Artemis was downloaded.
-This separation allows you run multiple broker instances with the same Artemis "home" for example.
-It also simplifies updating to newer versions of Artemis.
+NOTE: It's recommended to choose a folder different from where the broker was downloaded.
+This separation allows you to run multiple broker instances with the same "home," for example.
+It also simplifies updating to newer versions.
 
 == General Upgrade Procedure
 
@@ -28,7 +28,7 @@ It contains a property which is relevant for the upgrade:
 ARTEMIS_HOME='/path/to/apache-artemis-version'
 ----
 
-If you run Artemis as a service on windows you have to do the following additional steps:
+If you run the broker as a service on windows you have to do the following additional steps:
 
 . Navigate to the `bin` folder of the broker instance that's being upgraded
 . Open `artemis-service.xml`.
@@ -42,11 +42,12 @@ The `ARTEMIS_HOME` property is used to link the instance with the home.
 _In most cases_ the instance can be upgraded to a newer version simply by changing the value of this property to the location of the new broker home.
 Please refer to the aforementioned xref:versions.adoc#versions[versions] document for additional upgrade steps (if required).
 
-It is also possible to do many of these update steps automatically as can be seen in the next section.
+It is also possible to do many of these update steps automatically, as can be seen in the next section.
 
 == Upgrading tool
 
-An upgrade helper tool from the new broker download can be used to refresh various configuration files and scripts from an existing broker instance from a prior version, and thus automate much of work to upgrade the instance to use the new version.
+An upgrade helper tool from the new broker download can be used to refresh various configuration files and scripts from an existing broker instance from a prior version.
+This automates much of the work to upgrade the instance to the new version.
 
 WARNING: You should back up your existing broker instance before running the command.
 

--- a/docs/user-manual/using-cli.adoc
+++ b/docs/user-manual/using-cli.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-ActiveMQ Artemis has a Command Line Interface (CLI) that can used to manage a few aspects of the broker like instance creation, basic user management, queue & address management, etc.
+A Command Line Interface (CLI) can used to manage a few aspects of the broker like instance creation, basic user management, queue & address management, etc.
 This interface is designed for simple use-cases with _humans_ in mind.
 It is not an exhaustive set of commands for complete broker management.
 There is a comprehensive xref:management.adoc[management API] available with many operations that return JSON formatted output which is better suited for use in scripts and other automated processes.
@@ -339,7 +339,7 @@ myUser
 Type the password for a retry
 ----
 
-== Artemis Shell
+== Shell
 
 To initialize the shell session, type `./artemis shell` (or just `./artemis` if you prefer):
 
@@ -348,7 +348,7 @@ To initialize the shell session, type `./artemis shell` (or just `./artemis` if 
 $ ./artemis
 ----
 
-The ActiveMQ Artemis shell provides an interface that can be used to execute commands directly without leaving the Java Virtual Machine.
+The shell provides an interface that can be used to execute commands directly without leaving the Java Virtual Machine.
 
 [,console]
 ----

--- a/docs/user-manual/using-jms.adoc
+++ b/docs/user-manual/using-jms.adoc
@@ -3,17 +3,17 @@
 :idseparator: -
 :docinfo: shared
 
-Although Apache ActiveMQ Artemis provides a JMS agnostic messaging API, many users will be more comfortable using JMS.
+Although {project-name-full} provides a JMS agnostic messaging API, many users will be more comfortable using JMS.
 
 JMS is a very popular API standard for messaging, and most messaging systems provide a JMS API.
 If you are completely new to JMS we suggest you follow the https://docs.oracle.com/javaee/7/tutorial/partmessaging.htm[Oracle JMS tutorial] - a full JMS tutorial is out of scope for this guide.
 
-Apache ActiveMQ Artemis also ships with a wide range of examples, many of which demonstrate JMS API usage.
+There are a wide range of examples, many of which demonstrate JMS API usage.
 A good place to start would be to play around with the simple JMS Queue and Topic example, but we also provide examples for many other parts of the JMS API.
 A full description of the examples is available in xref:examples.adoc#examples[Examples].
 
 In this section we'll go through the main steps in configuring the server for JMS and creating a simple JMS program.
-We'll also show how to configure and use JNDI, and also how to use JMS with Apache ActiveMQ Artemis without using any JNDI.
+We'll also show how to configure and use JNDI, and also how to use JMS without using any JNDI.
 
 == A simple ordering system
 
@@ -28,18 +28,16 @@ We also want to pre-deploy the queue, i.e. specify the queue in the server confi
 == JNDI
 
 The JMS specification establishes the convention that _administered objects_ (i.e. JMS queue, topic and connection factory instances) are made available via the JNDI API.
-Brokers are free to implement JNDI as they see fit assuming the implementation fits the API.
-Apache ActiveMQ Artemis does not have a JNDI server.
+Brokers are free to implement JNDI as they see fit, assuming the implementation fits the API.
+{project-name-full} does not have a JNDI server.
 Rather, it uses a client-side JNDI implementation that relies on special properties set in the environment to construct the appropriate JMS objects.
-In other words, no objects are stored in JNDI on the Apache ActiveMQ Artemis server, instead they are simply instantiated on the client based on the provided configuration.
+In other words, no objects are stored in JNDI on the broker; instead, they are simply instantiated on the client based on the provided configuration.
 Let's look at the different kinds of administered objects and how to configure them.
 
 [NOTE]
 ====
-
-
-The following configuration properties _are strictly required when Apache ActiveMQ Artemis is running in stand-alone mode_.
-When Apache ActiveMQ Artemis is integrated to an application server (e.g. Wildfly) the application server itself will almost certainly provide a JNDI client with its own properties.
+The following configuration properties _are strictly required when the broker is running in stand-alone mode_.
+When integrated into an application server (e.g. Wildfly) the application server itself will almost certainly provide a JNDI client with its own properties.
 ====
 
 === ConnectionFactory JNDI
@@ -47,7 +45,7 @@ When Apache ActiveMQ Artemis is integrated to an application server (e.g. Wildfl
 A JMS connection factory is used by the client to make connections to the server.
 It knows the location of the server it is connecting to, as well as many other configuration parameters.
 
-Here's a simple example of the JNDI context environment for a client looking up a connection factory to access an _embedded_ instance of Apache ActiveMQ Artemis:
+Here's a simple example of the JNDI context environment for a client looking up a connection factory to access an _embedded_ broker:
 
 [,properties]
 ----
@@ -90,7 +88,7 @@ In the example above the client is using the `tcp` scheme for the provider URL.
 A client may also specify multiple comma-delimited host:port combinations in the URL (e.g. `(tcp://remote-host1:5445,remote-host2:5445)`).
 Whether there is one or many host:port combinations in the URL they are treated as the _initial connector(s)_ for the underlying connection.
 
-The `udp` scheme is also supported which should use a host:port combination that matches the `group-address` and `group-port` from the corresponding `broadcast-group` configured on the ActiveMQ Artemis server(s).
+The `udp` scheme is also supported which should use a host:port combination that matches the `group-address` and `group-port` from the corresponding `broadcast-group` configured on the broker(s).
 
 Each scheme has a specific set of properties which can be set using the traditional URL query string format (e.g. `scheme://host:port?key1=value1&key2=value2`) to customize the underlying transport mechanism.
 For example, if a client wanted to connect to a remote server using TCP and SSL it would create a connection factory like so, `tcp://remote-host:5445?ssl-enabled=true`.
@@ -173,8 +171,8 @@ The interface provided will depend on whether you're using the JMS or Jakarta Me
 JMS destinations are also typically looked up via JNDI.
 As with connection factories, destinations can be configured using special properties in the JNDI context environment.
 The property _name_ should follow the pattern: `queue.<jndi-binding>` or `topic.<jndi-binding>`.
-The property _value_ should be the name of the queue hosted by the Apache ActiveMQ Artemis server.
-For example, if the server had a JMS queue configured like so:
+The property _value_ should be the name of the queue hosted by the broker.
+For example, if the broker had a JMS queue configured like so:
 
 [,xml]
 ----
@@ -221,7 +219,7 @@ Queue orderQueue = (Queue)ic.lookup("queues/OrderQueue");
 
 Connection connection = cf.createConnection();
 
-//And we create a non transacted JMS Session, with AUTO\_ACKNOWLe.g. //acknowledge mode:
+//And we create a non-transacted JMS Session, with AUTO\_ACKNOWLe.g. //acknowledge mode:
 
 Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 
@@ -264,14 +262,14 @@ ____
 
 == Directly instantiating JMS Resources without using JNDI
 
-Although it is a very common JMS usage pattern to lookup JMS _Administered Objects_ (that's JMS Queue, Topic and ConnectionFactory instances) from JNDI, in some cases you just think "Why do I need JNDI?
+Although it is a widespread JMS usage pattern to look up JMS _Administered Objects_ (i.e. JMS Queue, Topic and ConnectionFactory instances) from JNDI, in some cases you just think "Why do I need JNDI?
 Why can't I just instantiate these objects directly?"
 
-With Apache ActiveMQ Artemis you can do exactly that.
-Apache ActiveMQ Artemis supports the direct instantiation of JMS Queue, Topic and ConnectionFactory instances, so you don't have to use JNDI at all.
+With {project-name-full} you can do exactly that.
+It supports the direct instantiation of JMS Queue, Topic and ConnectionFactory instances, so you don't have to use JNDI at all.
 
 ____
-For a full working example of direct instantiation please look at the xref:examples.adoc#instantiate-jms-objects-directly[Instantiate JMS Objects  Directly] example under the JMS  section of the examples.
+For a full working example of direct instantiation, please look at the xref:examples.adoc#instantiate-jms-objects-directly[Instantiate JMS Objects  Directly] example under the JMS  section of the examples.
 ____
 
 Here's our simple example, rewritten to not use JNDI at all:
@@ -293,7 +291,7 @@ Queue orderQueue = ActiveMQJMSClient.createQueue("OrderQueue");
 
 Connection connection = cf.createConnection();
 
-//And we create a non transacted JMS Session, with AUTO\_ACKNOWLe.g. //acknowledge mode:
+//And we create a non-transacted JMS Session, with AUTO\_ACKNOWLe.g. //acknowledge mode:
 
 Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
 

--- a/docs/user-manual/using-server.adoc
+++ b/docs/user-manual/using-server.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-This chapter will familiarise you with how to use the Apache ActiveMQ Artemis server.
+This chapter will familiarise you with how to use the {project-name-full} server.
 
 We'll show where it is, how to start and stop it, and we'll describe the directory layout and what all the files are and what they do.
 
@@ -26,13 +26,13 @@ The following highlights some important folders on the distribution:
 ----
 
 bin::
-binaries and scripts needed to run ActiveMQ Artemis.
+binaries and scripts needed to run the broker.
 
 lib::
-jars and libraries needed to run ActiveMQ Artemis
+jars and libraries needed to run the broker
 
 schema::
-XML Schemas used to validate ActiveMQ Artemis configuration files
+XML Schemas used to validate the broker configuration files
 
 web::
 The folder where the web context is loaded when the broker runs.
@@ -41,7 +41,7 @@ The folder where the web context is loaded when the broker runs.
 
 A broker _instance_ is the directory containing all the configuration and runtime data, such as logs and message journal, associated with a broker process.
 It is recommended that you do _not_ create the instance directory under `+${ARTEMIS_HOME}+`.
-This separation is encouraged so that you can more easily upgrade when the next version of ActiveMQ Artemis is released.
+This separation is encouraged so that you can more easily upgrade when the next version of the broker is released.
 
 On Unix systems, it is a common convention to store this kind of runtime data under the `/var/lib` directory.
 For example, to create an instance at `/var/lib/mybroker`, run the following commands in your command line shell:
@@ -332,7 +332,7 @@ Assuming you created the broker instance under `/var/lib/mybroker` all you need 
 /var/lib/mybroker/bin/artemis run
 ----
 
-To stop the Apache ActiveMQ Artemis instance you will use the same `artemis` script, but with the `stop` argument.
+To stop the instance you will use the same `artemis` script, but with the `stop` argument.
 Example:
 
 [,console]
@@ -340,9 +340,9 @@ Example:
 /var/lib/mybroker/bin/artemis stop
 ----
 
-Please note that Apache ActiveMQ Artemis requires a Java 11 or later.
+Please note that {project-name-full} requires a Java 17 or later.
 
-By default the `etc/bootstrap.xml` configuration is used.
+By default, the `etc/bootstrap.xml` configuration is used.
 The configuration can be changed e.g. by running `+./artemis run -- xml:path/to/bootstrap.xml+` or another config of your choosing.
 
 Environment variables are used to provide ease of changing ports, hosts and data directories used and can be found in `etc/artemis.profile` on linux and `etc\artemis.profile.cmd` on Windows.
@@ -414,11 +414,11 @@ Configures an embedded web server for things like the admin console.
 
 === Broker configuration file
 
-The configuration for the Apache ActiveMQ Artemis core broker is contained in `broker.xml`.
+The configuration for the broker is contained in `broker.xml`.
 
-There are many attributes which you can configure for Apache ActiveMQ Artemis.
+There are many attributes that you can configure.
 In most cases the defaults will do fine, in fact every attribute can be defaulted which means a file with a single empty `configuration` element is a valid configuration file.
-The different configuration will be explained throughout the manual or you can refer to the configuration reference xref:configuration-index.adoc#configuration-reference[here].
+The different configurations will be explained throughout the manual, or you can refer to the configuration reference xref:configuration-index.adoc#configuration-reference[here].
 
 == Other Use-Cases
 
@@ -438,7 +438,7 @@ It is also possible to not supply a default (i.e. `${activemq.remoting.netty.hos
 
 === Windows Server
 
-On windows you will have the option to run ActiveMQ Artemis as a service.
+On Windows you will have the option to run the broker as a service.
 Just use the following command to install it:
 
 ----

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -91,7 +91,7 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 * MQTT performance improvements for:
 ** xref:mqtt.adoc#persistent-subscriptions[persisting subscriptions]
 ** matching subscription identifiers to topic filters for 5.0 clients
-* Upgrade to https://activemq.apache.org/components/artemis-console/download/release-notes-1.2.1[ActiveMQ Artemis Console 1.2.1] with lots of usability improvements
+* Upgrade to https://activemq.apache.org/components/artemis-console/download/release-notes-1.2.1[{project-name-short} Console 1.2.1] with lots of usability improvements
 * Support for XOAUTH SASL mechanism for xref:amqp-broker-connections.adoc[AMQP broker connections]
 * And for developers...almost 2,500 lines of code were eliminated by consistently using the convenience methods from Java's `java.util.Objects` class across the code-base (e.g. https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Objects.html#hash(java.lang.Object...)[`hash`], https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Objects.html#toString(java.lang.Object)[`toString`], https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Objects.html#equals(java.lang.Object,java.lang.Object)[`equals`], https://docs.oracle.com/en/java/javase/17/docs/api/java.base/java/util/Objects.html#requireNonNull(T)[`requireNonNull`], etc.).
 
@@ -370,7 +370,7 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 
 * Mirrored Core Messages can now be sent on their native format without conversions
 * Mirror bug fixes and improvements
-* https://issues.apache.org/jira/browse/ARTEMIS-3474[ActiveMQ Artemis has now adopted] more inclusive language definitions.
+* https://issues.apache.org/jira/browse/ARTEMIS-3474[{project-name-short} has now adopted] more inclusive language definitions.
 * The examples are now part of its own repository:  https://github.com/apache/activemq-artemis-examples/
 
 === Upgrading from 2.31.x
@@ -418,10 +418,10 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 
 === Highlights
 
-* Introduced an xref:using-cli.adoc#artemis-shell[interactive shell] for running CLI command as well as xref:using-cli.adoc#bash-and-zsh-auto-complete[Bash & ZSH auto-complete support].
+* Introduced an xref:using-cli.adoc#shell[interactive shell] for running CLI command as well as xref:using-cli.adoc#bash-and-zsh-auto-complete[Bash & ZSH auto-complete support].
 * Added a CLI cluster verification tool to help monitor broker topologies.
 Use via the `check cluster` command.
-* The `queue stat` command is now able to to verify the message counts on the entire cluster topology when clustering is in use.
+* The `queue stat` command is now able to verify the message counts on the entire cluster topology when clustering is in use.
 * Added xref:amqp-broker-connections.adoc#federation[AMQP Federation] support to broker connections.
 * xref:mqtt.adoc#persistent-subscriptions[MQTT subscription state is now persisted].
 * Significantly improved the Paging JDBC Persistence.
@@ -431,7 +431,7 @@ See https://issues.apache.org/jira/browse/ARTEMIS-4383[ARTEMIS-4383] for more de
 
 === Upgrading from 2.30.0
 
-* Due to https://issues.apache.org/jira/browse/ARTEMIS-4372[ARTEMIS-4372] and the introduction of the new Artemis shell feature when you invoke `./artemis` it will now start the new shell to navigate through the CLI commands rather than just spitting out the `help` text.
+* Due to https://issues.apache.org/jira/browse/ARTEMIS-4372[ARTEMIS-4372] and the introduction of the new shell feature when you invoke `./artemis` it will now start the new shell to navigate through the CLI commands rather than just spitting out the `help` text.
 
 == 2.30.0
 
@@ -691,7 +691,7 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?version=12351083&projectI
 === Highlights
 
 * xref:mqtt.adoc#mqtt[MQTT 5] is now supported.
-* A new set of xref:perf-tools.adoc#performance-tools[performance tools] are now available to evaluate throughput and Response Under Load performance of Artemis
+* A new set of xref:perf-tools.adoc#performance-tools[performance tools] are now available to evaluate throughput and Response Under Load performance of {project-name-short}
 * Diverts now support xref:diverts.adoc#composite-divert[multiple addresses]
 * xref:config-reload.adoc#configuration-reload[Runtime configuration reloading] now supports bridges.
 * xref:paging.adoc#paging-mode[Paging] can now be configured by message count.
@@ -759,11 +759,11 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 === Upgrading from 2.17.0
 
 . Due to https://issues.apache.org/jira/browse/ARTEMIS-3367[ARTEMIS-3367] the default setting for `verifyHost` on _core connectors_ has been changed from `false` to `true`.
-This means that *core clients will now expect the `CN` or Subject Alternative Name values of the broker's SSL certificate to match the hostname in the client's URL*.
+This means that *Core clients will now expect the `CN` or Subject Alternative Name values of the broker's SSL certificate to match the hostname in the client's URL*.
 +
 This impacts all core-based clients including core JMS clients and core connections between cluster nodes.
 Although this is a "breaking" change, _not_ performing hostname verification is a security risk (e.g. due to man-in-the-middle attacks).
-Enabling it by default aligns core client behavior with industry standards.
+Enabling it by default aligns Core client behavior with industry standards.
 To deal with this you can do one of the following:
 
  ** Update your SSL certificates to use a hostname which matches the hostname in the client's URL.
@@ -1210,7 +1210,7 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 
 === Upgrading from 2.4.0
 
-. Due to changes from https://issues.apache.org/jira/browse/ARTEMIS-1644[ARTEMIS-1644] any `acceptor` that needs to be compatible with HornetQ and/or Artemis 1.x clients needs to have `anycastPrefix=jms.queue.;multicastPrefix=jms.topic.` in the `acceptor` url.
+. Due to changes from https://issues.apache.org/jira/browse/ARTEMIS-1644[ARTEMIS-1644] any `acceptor` that needs to be compatible with HornetQ and/or {project-name-short} 1.x clients needs to have `anycastPrefix=jms.queue.;multicastPrefix=jms.topic.` in the `acceptor` url.
 This prefix used to be configured automatically behind the scenes when the broker detected  these old types of clients, but that broke certain use-cases with no possible work-around.
 See  https://issues.apache.org/jira/browse/ARTEMIS-1644[ARTEMIS-1644] for more details.
 
@@ -1222,7 +1222,7 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 === Highlights
 
 * xref:management.adoc#role-based-authorisation-for-jmx[JMX configuration via XML] rather than having to use system properties via command line or start script.
-* Configuration of xref:protocols-interoperability.adoc#stomp-over-web-sockets[max frame payload length for STOMP web-socket].
+* Configuration of xref:protocols-interoperability.adoc#stomp-over-websockets[max frame payload length for STOMP web-socket].
 * Ability to configure HA using JDBC persistence.
 * Implement xref:management.adoc#management[role-based access control for management objects].
 

--- a/docs/user-manual/web-server.adoc
+++ b/docs/user-manual/web-server.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis embeds the https://www.eclipse.org/jetty/[Jetty web server].
+{project-name-full} embeds the https://www.eclipse.org/jetty/[Jetty web server].
 Its main purpose is to host the xref:management-console.adoc#management-console[Management Console].
 However, it can also host other web applications.
 

--- a/docs/user-manual/wildcard-routing.adoc
+++ b/docs/user-manual/wildcard-routing.adoc
@@ -3,7 +3,7 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis allows the routing of messages via wildcard addresses.
+{project-name-full} allows the routing of messages via wildcard addresses.
 
 If a queue is created with an address of say `news.#` then it will receive any messages sent to addresses that match this, for instance `news.europe` or `news.usa` or `news.usa.sport`.
 If you create a consumer on this queue, this allows a consumer to consume messages which are sent to a _hierarchy_ of addresses.

--- a/docs/user-manual/wildcard-syntax.adoc
+++ b/docs/user-manual/wildcard-syntax.adoc
@@ -3,11 +3,11 @@
 :idseparator: -
 :docinfo: shared
 
-Apache ActiveMQ Artemis uses a specific syntax for representing wildcards in security settings, address settings and when creating consumers.
+{project-name-full} uses a specific syntax for representing wildcards in security settings, address settings and when creating consumers.
 
 The syntax is similar to that used by https://www.amqp.org[AMQP].
 
-An Apache ActiveMQ Artemis wildcard expression contains *words separated by a delimiter*.
+An wildcard expression contains *words separated by a delimiter*.
 The default delimiter is `.` (full stop).
 
 The special characters `#` and `*` also have special meaning and can take the place of a **word**.


### PR DESCRIPTION
This commit adds a few parameters to the doc build and uses those parameters throughout the docs. Changes include:

 - Eliminating unnecessary uses of the full project name
 - Updating punctuation to increase clarity
 - Fixing spelling, spacing, & captitalization for consistency