### PR TITLE
ARTEMIS-5744 don't modify AddressInfo during auto-create checks

### DIFF
--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -315,26 +315,44 @@
       </resource>
    </resources>
    <plugins>
-   <plugin>
-      <artifactId>maven-resources-plugin</artifactId>
-      <executions>
-         <execution>
-            <id>copy-security-resources</id>
-            <phase>validate</phase>
-            <goals>
-               <goal>copy-resources</goal>
-            </goals>
-            <configuration>
-               <outputDirectory>${basedir}/target/test-classes</outputDirectory>
-               <resources>
-                  <resource>
-                     <directory>../tests/security-resources</directory>
-                  </resource>
-               </resources>
-            </configuration>
-         </execution>
-      </executions>
-   </plugin>
+      <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-dependency-plugin</artifactId>
+         <executions>
+            <execution>
+               <goals>
+                  <goal>properties</goal>
+               </goals>
+            </execution>
+         </executions>
+      </plugin>
+      <plugin>
+         <groupId>org.apache.maven.plugins</groupId>
+         <artifactId>maven-surefire-plugin</artifactId>
+         <configuration>
+            <argLine>${activemq-surefire-argline} -javaagent:${org.mockito:mockito-core:jar}</argLine>
+         </configuration>
+      </plugin>
+      <plugin>
+         <artifactId>maven-resources-plugin</artifactId>
+         <executions>
+            <execution>
+               <id>copy-security-resources</id>
+               <phase>validate</phase>
+               <goals>
+                  <goal>copy-resources</goal>
+               </goals>
+               <configuration>
+                  <outputDirectory>${basedir}/target/test-classes</outputDirectory>
+                  <resources>
+                     <resource>
+                        <directory>../tests/security-resources</directory>
+                     </resource>
+                  </resources>
+               </configuration>
+            </execution>
+         </executions>
+      </plugin>
    </plugins>
 </build>
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -1924,7 +1924,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
                                                                        autoCommitSends, autoCommitAcks, preAcknowledge, xa, defaultAddress, callback, autoCreateQueues, context, prefixes));
       }
 
-      ServerSessionImpl session = new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, configuration.isPersistDeliveryCountBeforeDelivery(), xa, connection, storageManager, postOffice, resourceManager, securityStore, managementService, this, configuration.getManagementAddress(), defaultAddress == null ? null : SimpleString.of(defaultAddress), callback, context, pagingManager, prefixes, securityDomain, isLegacyProducer);
+      ServerSessionImpl session = new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, configuration.isPersistDeliveryCountBeforeDelivery(), xa, connection, this, defaultAddress == null ? null : SimpleString.of(defaultAddress), callback, context, prefixes, securityDomain, isLegacyProducer);
 
       sessions.put(name, session);
       totalSessionCount.incrementAndGet();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -229,17 +229,10 @@ public class ServerSessionImpl extends CriticalComponentImpl implements ServerSe
                             final boolean strictUpdateDeliveryCount,
                             final boolean xa,
                             final RemotingConnection remotingConnection,
-                            final StorageManager storageManager,
-                            final PostOffice postOffice,
-                            final ResourceManager resourceManager,
-                            final SecurityStore securityStore,
-                            final ManagementService managementService,
                             final ActiveMQServer server,
-                            final SimpleString managementAddress,
                             final SimpleString defaultAddress,
                             final SessionCallback callback,
                             final OperationContext context,
-                            final PagingManager pagingManager,
                             final Map<SimpleString, RoutingType> prefixes,
                             final String securityDomain,
                             boolean isLegacyProducer) throws Exception {
@@ -261,22 +254,22 @@ public class ServerSessionImpl extends CriticalComponentImpl implements ServerSe
 
       this.remotingConnection = remotingConnection;
 
-      this.storageManager = storageManager;
+      this.storageManager = server.getStorageManager();
 
-      this.postOffice = postOffice;
+      this.postOffice = server.getPostOffice();
 
-      this.resourceManager = resourceManager;
+      this.resourceManager = server.getResourceManager();
 
-      this.securityStore = securityStore;
+      this.securityStore = server.getSecurityStore();
 
-      this.pagingManager = pagingManager;
+      this.pagingManager = server.getPagingManager();
 
       timeoutSeconds = resourceManager.getTimeoutSeconds();
       this.xa = xa;
 
       this.strictUpdateDeliveryCount = strictUpdateDeliveryCount;
 
-      this.managementService = managementService;
+      this.managementService = server.getManagementService();
 
       this.name = name;
 
@@ -287,7 +280,7 @@ public class ServerSessionImpl extends CriticalComponentImpl implements ServerSe
          prefixEnabled = true;
       }
 
-      this.managementAddress = managementAddress;
+      this.managementAddress = managementService.getManagementAddress();
 
       this.callback = callback;
 
@@ -1905,7 +1898,7 @@ public class ServerSessionImpl extends CriticalComponentImpl implements ServerSe
             if (addressSettings.isAutoCreateAddresses() || queueConfig.isTemporary()) {
                // Try to update the address with the new routing-type if possible.
                try {
-                  createAddress(addressInfo.addRoutingType(queueConfig.getRoutingType()), true);
+                  createAddress(new AddressInfo(addressInfo.getName(), EnumSet.copyOf(addressInfo.getRoutingTypes())).addRoutingType(queueConfig.getRoutingType()).setTemporary(addressInfo.isTemporary()), true);
                } catch (ActiveMQAddressExistsException e) {
                   // The address may have been created by another thread in the mean-time. Catch and do nothing.
                }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImplTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.server.impl;
+
+import org.apache.activemq.artemis.api.core.QueueConfiguration;
+import org.apache.activemq.artemis.api.core.RoutingType;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.security.SecurityStore;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.management.ManagementService;
+import org.apache.activemq.artemis.core.settings.HierarchicalRepository;
+import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.artemis.core.transaction.ResourceManager;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.utils.ExecutorFactory;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.apache.activemq.artemis.utils.actors.ArtemisExecutor;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+public class ServerSessionImplTest {
+
+   @Test
+   public void testCheckAutoCreateModifyExistingAddressInfo() throws Exception {
+      ActiveMQServer server = setupMockServerForServerSession();
+      final String NAME = RandomUtil.randomAlphaNumericString(10);
+
+      // the routing-types for this AddressInfo object should not be modified by the checkAutoCreate method
+      AddressInfo addressInfo = new AddressInfo(NAME).addRoutingType(RoutingType.ANYCAST);
+
+      setupMocksForAddressStuff(server, addressInfo);
+
+      ServerSessionImpl session = new ServerSessionImpl(null, null, null, null, 0, false, false, false, false, true, mock(RemotingConnection.class), server, null, null, null, null, null, false);
+
+      QueueConfiguration queueConfiguration = QueueConfiguration.of(NAME).setRoutingType(RoutingType.MULTICAST);
+
+      session.checkAutoCreate(queueConfiguration);
+
+      ArgumentCaptor<AddressInfo> addressInfoCaptor = ArgumentCaptor.forClass(AddressInfo.class);
+      verify(server).addOrUpdateAddressInfo(addressInfoCaptor.capture());
+      assertTrue(addressInfoCaptor.getValue().getRoutingTypes().contains(RoutingType.MULTICAST));
+      assertTrue(addressInfoCaptor.getValue().getRoutingTypes().contains(RoutingType.ANYCAST));
+
+      // confirm that the routing-types were not modified
+      assertFalse(addressInfo.getRoutingTypes().contains(RoutingType.MULTICAST));
+      assertTrue(addressInfo.getRoutingTypes().contains(RoutingType.ANYCAST));
+   }
+
+   /*
+    * Create mocks to return the desired AddressInfo and AddressSettings from the ActiveMQServer.
+    */
+   private void setupMocksForAddressStuff(ActiveMQServer server, AddressInfo addressInfo) {
+      // return the desired AddressSettings
+      HierarchicalRepository<AddressSettings> addressSettingsRepository = mock(HierarchicalRepository.class);
+      when(server.getAddressSettingsRepository()).thenReturn(addressSettingsRepository);
+      when(addressSettingsRepository.getMatch(addressInfo.getName().toString())).thenReturn(new AddressSettings().setAutoCreateAddresses(true));
+
+      // return the desired AddressInfo
+      when(server.getAddressInfo(addressInfo.getName())).thenReturn(addressInfo);
+   }
+
+   /*
+    * Create a mock ActiveMQServer instance specifically to pass to the constructor of ServerSessionImpl.
+    */
+   private ActiveMQServer setupMockServerForServerSession() {
+      ActiveMQServer server = mock(ActiveMQServer.class);
+
+      when(server.getManagementService()).thenReturn(mock(ManagementService.class));
+      when(server.getConfiguration()).thenReturn(mock(Configuration.class));
+      when(server.getResourceManager()).thenReturn(mock(ResourceManager.class));
+      when(server.getSecurityStore()).thenReturn(mock(SecurityStore.class));
+      ExecutorFactory executorFactory = mock(ExecutorFactory.class);
+      when(executorFactory.getExecutor()).thenReturn(mock(ArtemisExecutor.class));
+      when(server.getExecutorFactory()).thenReturn(executorFactory);
+
+      return server;
+   }
+}

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/HangConsumerTest.java
@@ -553,7 +553,7 @@ public class HangConsumerTest extends ActiveMQTestBase {
                                                         Map<SimpleString, RoutingType> prefixes,
                                                         String securityDomain,
                                                         boolean isLegacyProducer) throws Exception {
-         return new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, getConfiguration().isPersistDeliveryCountBeforeDelivery(), xa, connection, getStorageManager(), getPostOffice(), getResourceManager(), getSecurityStore(), getManagementService(), this, getConfiguration().getManagementAddress(), defaultAddress == null ? null : SimpleString.of(defaultAddress), new MyCallback(callback), context, getPagingManager(), prefixes, securityDomain, isLegacyProducer);
+         return new ServerSessionImpl(name, username, password, validatedUser, minLargeMessageSize, autoCommitSends, autoCommitAcks, preAcknowledge, getConfiguration().isPersistDeliveryCountBeforeDelivery(), xa, connection, this, defaultAddress == null ? null : SimpleString.of(defaultAddress), new MyCallback(callback), context, prefixes, securityDomain, isLegacyProducer);
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/consumer/OrphanedConsumerDefenseTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/consumer/OrphanedConsumerDefenseTest.java
@@ -17,9 +17,6 @@
 
 package org.apache.activemq.artemis.tests.integration.consumer;
 
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
-
 import java.lang.invoke.MethodHandles;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -27,11 +24,9 @@ import java.util.HashMap;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
-import org.apache.activemq.artemis.core.paging.PagingManager;
 import org.apache.activemq.artemis.core.persistence.OperationContext;
 import org.apache.activemq.artemis.core.persistence.StorageManager;
 import org.apache.activemq.artemis.core.persistence.impl.nullpm.NullStorageManager;
-import org.apache.activemq.artemis.core.postoffice.PostOffice;
 import org.apache.activemq.artemis.core.protocol.ServerPacketDecoder;
 import org.apache.activemq.artemis.core.protocol.core.impl.RemotingConnectionImpl;
 import org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnection;
@@ -63,6 +58,10 @@ import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.mockito.Mockito.mock;
 
 /**
  * as worked through ARTEMIS-4476 we fixed the possibility of a ghost consumer (a term coined by a user), where the
@@ -110,6 +109,10 @@ public class OrphanedConsumerDefenseTest extends ActiveMQTestBase {
       ActiveMQServer mockServer = Mockito.mock(ActiveMQServer.class);
       Mockito.when(mockServer.getExecutorFactory()).thenReturn(executorFactory);
       Mockito.when(mockServer.getConfiguration()).thenReturn(configuration);
+      Mockito.when(mockServer.getManagementService()).thenReturn(mock(ManagementService.class));
+      Mockito.when(mockServer.getConfiguration()).thenReturn(mock(Configuration.class));
+      Mockito.when(mockServer.getResourceManager()).thenReturn(mock(ResourceManager.class));
+      Mockito.when(mockServer.getSecurityStore()).thenReturn(mock(SecurityStore.class));
 
       BufferHandler bufferHandler = Mockito.mock(BufferHandler.class);
       InVMConnection inVMConnection = new InVMConnection(1, bufferHandler, Mockito.mock(BaseConnectionLifeCycleListener.class), artemisExecutor);
@@ -118,7 +121,7 @@ public class OrphanedConsumerDefenseTest extends ActiveMQTestBase {
       remotingConnection.destroy();
       ServerSessionImpl session = new ServerSessionImpl(RandomUtil.randomUUIDString(), RandomUtil.randomUUIDString(), RandomUtil.randomUUIDString(),
                                                         RandomUtil.randomUUIDString(), 1000, true, true, true, true, true,
-                                                        remotingConnection, storageManager, Mockito.mock(PostOffice.class), Mockito.mock(ResourceManager.class), Mockito.mock(SecurityStore.class), Mockito.mock(ManagementService.class), mockServer, RandomUtil.randomUUIDSimpleString(), RandomUtil.randomUUIDSimpleString(), Mockito.mock(SessionCallback.class), Mockito.mock(OperationContext.class), Mockito.mock(PagingManager.class), new HashMap<>(), "securityDomain", false);
+                                                        remotingConnection, mockServer, RandomUtil.randomUUIDSimpleString(), Mockito.mock(SessionCallback.class), Mockito.mock(OperationContext.class), new HashMap<>(), "securityDomain", false);
 
       try {
          new ServerConsumerImpl(1, session, null, null, 1, true, false, new NullStorageManager(), sessionCallback, true, true, managementService, false, 0, server);


### PR DESCRIPTION
Aside from fixing the issue where the broker would modify the `AddressInfo` object during auto-create checks this commit also simplifies the ctor of `ServerSessionImpl` and updates the `pom.xml` to avoid a warning when running Mockito tests on JDK 21+.