### PR TITLE
ARTEMIS-5686 fix retroactive address name parsing

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ResourceNames.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/api/core/management/ResourceNames.java
@@ -73,7 +73,7 @@ public final class ResourceNames {
    }
 
    public static String decomposeRetroactiveResourceAddressName(String prefix, String delimiter, String address) {
-      return address.substring(address.indexOf(prefix) + prefix.length(), address.indexOf(delimiter + trimLastCharacter(ADDRESS)));
+      return address.substring(prefix.length(), address.length() - (delimiter.length() + ADDRESS.length() + RETROACTIVE_SUFFIX.length()));
    }
 
    private static String trimLastCharacter(String toTrim) {

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/management/ResourceNamesTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/api/core/management/ResourceNamesTest.java
@@ -85,6 +85,15 @@ public class ResourceNamesTest {
    }
 
    @TestTemplate
+   public void testDecomposeRetroactiveAddressNamedAddress() {
+      String testAddress = "address";
+      String prefix = ActiveMQDefaultConfiguration.getInternalNamingPrefix().replace('.', delimiterChar);
+      String baseName = prefix + testAddress + delimiter;
+      String testResourceAddressName = baseName + ResourceNames.ADDRESS.replace('.', delimiterChar) + ResourceNames.RETROACTIVE_SUFFIX;
+      assertEquals(testAddress.toString(), ResourceNames.decomposeRetroactiveResourceAddressName(prefix, delimiter, testResourceAddressName));
+   }
+
+   @TestTemplate
    public void testIsRetroactiveResource() {
       assertTrue(ResourceNames.isRetroactiveResource(prefix, SimpleString.of(testResourceAddressName)));
       assertTrue(ResourceNames.isRetroactiveResource(prefix, SimpleString.of(testResourceMulticastQueueName)));


### PR DESCRIPTION
The current retroactive address name parsing uses indexOf which can get confused when the address name itself uses part of the retroactive naming convention. This commit fixes that problem by using strictly position-based logic based on lengths of known Strings.