### PR TITLE
ARTEMIS-1759 classloader leaks in Core and JMS Client

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -155,8 +155,6 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
 
    private volatile boolean closed;
 
-   public final Exception createTrace;
-
    public static final Set<CloseRunnable> CLOSE_RUNNABLES = Collections.synchronizedSet(new HashSet<>());
 
    private final ConfirmationWindowWarning confirmationWindowWarning;
@@ -207,8 +205,6 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
                           final List<Interceptor> incomingInterceptors,
                           final List<Interceptor> outgoingInterceptors,
                           final TransportConfiguration[] connectorConfigs) {
-      createTrace = new Exception();
-
       this.serverLocator = serverLocator;
 
       this.clientProtocolManager = serverLocator.newProtocolManager();
@@ -997,7 +993,7 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
             return true;
          }
       } catch (InterruptedException ignore) {
-         throw new ActiveMQInterruptedException(createTrace);
+         throw new ActiveMQInterruptedException(ignore);
       }
       return false;
    }

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ServerLocatorImpl.java
@@ -182,8 +182,6 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
       return factories;
    }
 
-   private final Exception traceException = new Exception();
-
    private ServerLocatorConfig config = new ServerLocatorConfig();
 
    private String passwordCodec;
@@ -334,8 +332,6 @@ public final class ServerLocatorImpl implements ServerLocatorInternal, Discovery
                              final boolean useHA,
                              final DiscoveryGroupConfiguration discoveryGroupConfiguration,
                              final TransportConfiguration[] transportConfigs) {
-      traceException.fillInStackTrace();
-
       this.topology = Objects.requireNonNullElseGet(topology, () -> new Topology(this));
 
       this.ha = useHA;

--- a/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
+++ b/artemis-jms-client/src/main/java/org/apache/activemq/artemis/jms/client/ActiveMQConnection.java
@@ -128,8 +128,6 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
 
    private ClientSession initialSession;
 
-   private final Exception creationStack;
-
    private ActiveMQConnectionFactory factoryReference;
 
    private final ConnectionFactoryOptions options;
@@ -168,8 +166,6 @@ public class ActiveMQConnection extends ActiveMQConnectionForContextImpl impleme
       this.cacheDestinations = cacheDestinations;
 
       this.enable1xPrefixes = enable1xPrefixes;
-
-      creationStack = new Exception();
    }
 
    /**


### PR DESCRIPTION
Remove fields that hold stack-traces in a few classes. These are mostly unused and when they are used it is only for logging. The upside of having additional logging is not worth the risk of leaks and eventual OOME.