### PR TITLE
ARTEMIS-4197 mitigate races w/various config changes

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/AbstractPersistedAddressSetting.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/AbstractPersistedAddressSetting.java
@@ -18,10 +18,9 @@
 package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
-public abstract class AbstractPersistedAddressSetting implements EncodingSupport {
+public abstract class AbstractPersistedAddressSetting extends PersistedConfiguration {
 
    protected long storeId;
 
@@ -36,15 +35,6 @@ public abstract class AbstractPersistedAddressSetting implements EncodingSupport
    public AbstractPersistedAddressSetting(SimpleString addressMatch, AddressSettings setting) {
       this.addressMatch = addressMatch;
       this.setting = setting;
-   }
-
-   public long getStoreId() {
-      return storeId;
-   }
-
-   public AbstractPersistedAddressSetting setStoreId(long storeId) {
-      this.storeId = storeId;
-      return this;
    }
 
    public SimpleString getAddressMatch() {
@@ -63,5 +53,10 @@ public abstract class AbstractPersistedAddressSetting implements EncodingSupport
    public AbstractPersistedAddressSetting setSetting(AddressSettings setting) {
       this.setting = setting;
       return this;
+   }
+
+   @Override
+   public String getName() {
+      return addressMatch.toString();
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedAddressSetting.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedAddressSetting.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
 /**
@@ -63,4 +64,8 @@ public class PersistedAddressSetting extends AbstractPersistedAddressSetting imp
       return addressMatch.sizeof() + setting.getEncodeSize();
    }
 
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.ADDRESS_SETTING_RECORD;
+   }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedAddressSettingJSON.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedAddressSettingJSON.java
@@ -18,10 +18,10 @@ package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 
-public class PersistedAddressSettingJSON extends AbstractPersistedAddressSetting implements EncodingSupport {
+public class PersistedAddressSettingJSON extends AbstractPersistedAddressSetting {
 
    SimpleString jsonSetting;
 
@@ -67,5 +67,10 @@ public class PersistedAddressSettingJSON extends AbstractPersistedAddressSetting
    @Override
    public String toString() {
       return "PersistedAddressSettingJSON{" + "jsonSetting=" + jsonSetting + ", storeId=" + storeId + ", addressMatch=" + addressMatch + ", setting=" + setting + '}';
+   }
+
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.ADDRESS_SETTING_RECORD_JSON;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedBridgeConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedBridgeConfiguration.java
@@ -18,11 +18,10 @@ package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.config.BridgeConfiguration;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 
-public class PersistedBridgeConfiguration implements EncodingSupport {
+public class PersistedBridgeConfiguration extends PersistedConfiguration {
 
-   private long storeId;
    private BridgeConfiguration bridgeConfiguration;
 
    @Override
@@ -36,14 +35,6 @@ public class PersistedBridgeConfiguration implements EncodingSupport {
 
    public PersistedBridgeConfiguration() {
       bridgeConfiguration = new BridgeConfiguration();
-   }
-
-   public void setStoreId(long id) {
-      this.storeId = id;
-   }
-
-   public long getStoreId() {
-      return storeId;
    }
 
    @Override
@@ -61,8 +52,14 @@ public class PersistedBridgeConfiguration implements EncodingSupport {
       bridgeConfiguration.decode(buffer);
    }
 
+   @Override
    public String getName() {
       return bridgeConfiguration.getParentName();
+   }
+
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.BRIDGE_RECORD;
    }
 
    public BridgeConfiguration getBridgeConfiguration() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedConfiguration.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.persistence.config;
+
+import org.apache.activemq.artemis.core.journal.EncodingSupport;
+
+public abstract class PersistedConfiguration implements EncodingSupport {
+
+   protected long storeId;
+
+   public void setStoreId(long id) {
+      this.storeId = id;
+   }
+
+   public long getStoreId() {
+      return storeId;
+   }
+
+   /**
+    * Returns the name to be used as the key for the map used by the broker to track this configuration implementation.
+    *
+    * @return the name as a String
+    */
+   public abstract String getName();
+
+   public abstract byte getRecordType();
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedConnector.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedConnector.java
@@ -17,12 +17,10 @@
 package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.utils.BufferHelper;
 
-public class PersistedConnector implements EncodingSupport {
-
-   private long storeId;
+public class PersistedConnector extends PersistedConfiguration {
 
    private String url;
 
@@ -34,14 +32,6 @@ public class PersistedConnector implements EncodingSupport {
    public PersistedConnector(String name, String url) {
       this.name = name;
       this.url = url;
-   }
-
-   public void setStoreId(long id) {
-      this.storeId = id;
-   }
-
-   public long getStoreId() {
-      return storeId;
    }
 
    public void setUrl(String url) {
@@ -56,8 +46,14 @@ public class PersistedConnector implements EncodingSupport {
       this.name = name;
    }
 
+   @Override
    public String getName() {
       return name;
+   }
+
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.CONNECTOR_RECORD;
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedDivertConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedDivertConfiguration.java
@@ -18,11 +18,9 @@ package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.core.config.DivertConfiguration;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 
-public class PersistedDivertConfiguration implements EncodingSupport {
-
-   private long storeId;
+public class PersistedDivertConfiguration extends PersistedConfiguration {
 
    private DivertConfiguration divertConfiguration;
 
@@ -37,14 +35,6 @@ public class PersistedDivertConfiguration implements EncodingSupport {
 
    public PersistedDivertConfiguration() {
       divertConfiguration = new DivertConfiguration();
-   }
-
-   public void setStoreId(long id) {
-      this.storeId = id;
-   }
-
-   public long getStoreId() {
-      return storeId;
    }
 
    @Override
@@ -62,8 +52,14 @@ public class PersistedDivertConfiguration implements EncodingSupport {
       divertConfiguration.decode(buffer);
    }
 
+   @Override
    public String getName() {
       return divertConfiguration.getName();
+   }
+
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.DIVERT_RECORD;
    }
 
    public DivertConfiguration getDivertConfiguration() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedKeyValuePair.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedKeyValuePair.java
@@ -17,12 +17,10 @@
 package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.utils.BufferHelper;
 
-public class PersistedKeyValuePair implements EncodingSupport {
-
-   private long storeId;
+public class PersistedKeyValuePair extends PersistedConfiguration {
 
    private String mapId;
 
@@ -39,14 +37,6 @@ public class PersistedKeyValuePair implements EncodingSupport {
       this.value = value;
    }
 
-   public void setStoreId(long id) {
-      this.storeId = id;
-   }
-
-   public long getStoreId() {
-      return storeId;
-   }
-
    public String getMapId() {
       return mapId;
    }
@@ -57,6 +47,16 @@ public class PersistedKeyValuePair implements EncodingSupport {
 
    public String getValue() {
       return value;
+   }
+
+   @Override
+   public String getName() {
+      return mapId;
+   }
+
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.KEY_VALUE_PAIR_RECORD;
    }
 
    @Override
@@ -85,12 +85,9 @@ public class PersistedKeyValuePair implements EncodingSupport {
    @Override
    public String toString() {
       return "PersistedKeyValuePair [storeId=" + storeId +
-         ", mapId=" +
-         mapId +
-         ", key=" +
-         key +
-         ", value=" +
-         value +
+         ", mapId=" + mapId +
+         ", key=" + key +
+         ", value=" + value +
          "]";
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedRole.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedRole.java
@@ -21,13 +21,11 @@ import java.util.List;
 import java.util.Objects;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.utils.BufferHelper;
 import org.apache.activemq.artemis.utils.DataConstants;
 
-public class PersistedRole implements EncodingSupport {
-
-   private long storeId;
+public class PersistedRole extends PersistedConfiguration {
 
    private String username;
 
@@ -39,14 +37,6 @@ public class PersistedRole implements EncodingSupport {
    public PersistedRole(String username, List<String> roles) {
       this.username = Objects.requireNonNull(username);
       this.roles = Objects.requireNonNull(roles);
-   }
-
-   public void setStoreId(long id) {
-      this.storeId = id;
-   }
-
-   public long getStoreId() {
-      return storeId;
    }
 
    public String getUsername() {
@@ -104,5 +94,15 @@ public class PersistedRole implements EncodingSupport {
       result.append("]]");
 
       return result.toString();
+   }
+
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.ROLE_RECORD;
+   }
+
+   @Override
+   public String getName() {
+      return username;
    }
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedSecuritySetting.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedSecuritySetting.java
@@ -21,7 +21,7 @@ import java.util.Objects;
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
 import org.apache.activemq.artemis.api.core.JsonUtil;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.json.JsonObject;
 
 import static org.apache.activemq.artemis.core.security.Role.BROWSE_PERMISSION;
@@ -39,9 +39,7 @@ import static org.apache.activemq.artemis.core.security.Role.VIEW_PERMISSION;
 import static org.apache.activemq.artemis.utils.DataConstants.SIZE_INT;
 import static org.apache.activemq.artemis.utils.DataConstants.SIZE_NULL;
 
-public class PersistedSecuritySetting implements EncodingSupport {
-
-   private long storeId;
+public class PersistedSecuritySetting extends PersistedConfiguration {
 
    private SimpleString addressMatch;
 
@@ -81,9 +79,7 @@ public class PersistedSecuritySetting implements EncodingSupport {
                                    final String createNonDurableQueueRoles,
                                    final String deleteNonDurableQueueRoles,
                                    final String manageRoles,
-                                   final String browseRoles,
-                                   final String createAddressRoles,
-                                   final String deleteAddressRoles,
+                                   final String browseRoles, final String createAddressRoles, final String deleteAddressRoles,
                                    final String viewRoles,
                                    final String editRoles) {
       super();
@@ -118,13 +114,14 @@ public class PersistedSecuritySetting implements EncodingSupport {
            JsonUtil.arrayToString(o, EDIT_PERMISSION));
    }
 
-
-   public long getStoreId() {
-      return storeId;
+   @Override
+   public String getName() {
+      return addressMatch.toString();
    }
 
-   public void setStoreId(final long id) {
-      storeId = id;
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.SECURITY_SETTING_RECORD;
    }
 
    public SimpleString getAddressMatch() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedUser.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/config/PersistedUser.java
@@ -17,12 +17,10 @@
 package org.apache.activemq.artemis.core.persistence.config;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.core.journal.EncodingSupport;
+import org.apache.activemq.artemis.core.persistence.impl.journal.JournalRecordIds;
 import org.apache.activemq.artemis.utils.BufferHelper;
 
-public class PersistedUser implements EncodingSupport {
-
-   private long storeId;
+public class PersistedUser extends PersistedConfiguration {
 
    private String username;
 
@@ -36,12 +34,14 @@ public class PersistedUser implements EncodingSupport {
       this.password = password;
    }
 
-   public void setStoreId(long id) {
-      this.storeId = id;
+   @Override
+   public byte getRecordType() {
+      return JournalRecordIds.USER_RECORD;
    }
 
-   public long getStoreId() {
-      return storeId;
+   @Override
+   public String getName() {
+      return username;
    }
 
    public String getUsername() {

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/DescribeJournal.java
@@ -44,8 +44,13 @@ import org.apache.activemq.artemis.core.journal.impl.JournalImpl;
 import org.apache.activemq.artemis.core.journal.impl.JournalReaderCallback;
 import org.apache.activemq.artemis.core.paging.cursor.impl.PageSubscriptionCounterImpl;
 import org.apache.activemq.artemis.core.paging.impl.PageTransactionInfoImpl;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedAddressSettingJSON;
 import org.apache.activemq.artemis.core.persistence.config.PersistedBridgeConfiguration;
 import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
+import org.apache.activemq.artemis.core.persistence.config.PersistedRole;
+import org.apache.activemq.artemis.core.persistence.config.PersistedSecuritySetting;
+import org.apache.activemq.artemis.core.persistence.config.PersistedUser;
 import org.apache.activemq.artemis.core.persistence.impl.journal.BatchingIDGenerator.IDCounterEncoding;
 import org.apache.activemq.artemis.core.persistence.impl.journal.codec.AckRetry;
 import org.apache.activemq.artemis.core.persistence.impl.journal.codec.CursorAckRecordEncoding;
@@ -596,15 +601,10 @@ public final class DescribeJournal {
 
       switch (rec) {
          case DIVERT_RECORD:
-            PersistedDivertConfiguration persistedDivertConfiguration = new PersistedDivertConfiguration();
-            persistedDivertConfiguration.decode(buffer);
-            return persistedDivertConfiguration;
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedDivertConfiguration.class, id, buffer);
 
-         case BRIDGE_RECORD: {
-            PersistedBridgeConfiguration persistedBridgeConfiguration = new PersistedBridgeConfiguration();
-            persistedBridgeConfiguration.decode(buffer);
-            return persistedBridgeConfiguration;
-         }
+         case BRIDGE_RECORD:
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedBridgeConfiguration.class, id, buffer);
 
          case ADD_LARGE_MESSAGE_PENDING: {
             PendingLargeMessageEncoding lmEncoding = new PendingLargeMessageEncoding();
@@ -738,13 +738,13 @@ public final class DescribeJournal {
             return AbstractJournalStorageManager.newGroupEncoding(id, buffer);
 
          case ADDRESS_SETTING_RECORD:
-            return AbstractJournalStorageManager.newAddressEncoding(id, buffer);
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedAddressSetting.class, id, buffer);
 
          case ADDRESS_SETTING_RECORD_JSON:
-            return AbstractJournalStorageManager.newAddressJSONEncoding(id, buffer);
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedAddressSettingJSON.class, id, buffer);
 
          case SECURITY_SETTING_RECORD:
-            return AbstractJournalStorageManager.newSecurityRecord(id, buffer);
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedSecuritySetting.class, id, buffer);
 
          case ADDRESS_BINDING_RECORD:
             return AbstractJournalStorageManager.newAddressBindingEncoding(id, buffer);
@@ -753,10 +753,10 @@ public final class DescribeJournal {
             return AbstractJournalStorageManager.newAddressStatusEncoding(id, buffer);
 
          case USER_RECORD:
-            return AbstractJournalStorageManager.newUserEncoding(id, buffer);
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedUser.class, id, buffer);
 
          case ROLE_RECORD:
-            return AbstractJournalStorageManager.newRoleEncoding(id, buffer);
+            return AbstractJournalStorageManager.newPersistedConfigurationEncoding(PersistedRole.class, id, buffer);
 
          case ACK_RETRY:
             return AckRetry.getPersister().decode(buffer, null, null);


### PR DESCRIPTION
This commit mitigates a number of different potential race conditions involving configuration changes. Consider the storeAddressSetting method in o.a.a.a.c.p.i.j.AbstractJournalStorageManager. It mutates mapPersistedAddressSettings twice - once to delete an entry and once to put an entry. If another thread executes the recoverAddressSettings method in between these two operations it will not contain the record that is being stored. This same race condition exists for a number of different maps.

This commit mitigates the race condition by ensuring that the relevant map is mutated only once (i.e. via put).

This commit also refactors a number of methods to avoid duplicated code.

There are no tests associated with this change since there's no deterministic way to induce the race condition. It relies on static analysis and existing tests to validate the fix and detect regressions.