### PR TITLE
ARTEMIS-5806 don't rollback TX when throwing XAER_NOTA

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -51,7 +51,7 @@ import org.apache.activemq.artemis.spi.core.remoting.Connection;
 /**
  * Logger Codes 220000 - 228999
  */
-@LogBundle(projectCode = "AMQ", regexID = "22[0-8][0-9]{3}", retiredIDs = {221026, 221052, 222003, 222012, 222015, 222020, 222021, 222022, 222024, 222027, 222028, 222029, 222048, 222052, 222058, 222064, 222071, 222078, 222079, 222083, 222084, 222088, 222090, 222102, 222105, 222110, 222128, 222134, 222135, 222152, 222159, 222163, 222167, 222170, 222171, 222182, 222190, 222192, 222193, 222204, 222252, 222255, 222257, 222259, 222260, 222276, 222277, 222288, 224001, 224002, 224003, 224005, 224013, 224031, 224035, 224070, 224100, 224121})
+@LogBundle(projectCode = "AMQ", regexID = "22[0-8][0-9]{3}", retiredIDs = {221026, 221052, 222003, 222012, 222015, 222020, 222021, 222022, 222024, 222027, 222028, 222029, 222048, 222052, 222058, 222064, 222071, 222078, 222079, 222083, 222084, 222088, 222090, 222102, 222105, 222110, 222128, 222134, 222135, 222152, 222159, 222163, 222167, 222170, 222171, 222182, 222190, 222192, 222193, 222204, 222249, 222252, 222255, 222257, 222259, 222260, 222276, 222277, 222288, 224001, 224002, 224003, 224005, 224013, 224031, 224035, 224070, 224100, 224121})
 public interface ActiveMQServerLogger {
 
    // Note: logger ID 224127 uses "org.apache.activemq.artemis.core.server.Queue" for its logger category, rather than ActiveMQServerLogger.class.getPackage().getName()
@@ -939,9 +939,6 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 222248, value = "Unable to remove consumer", level = LogMessage.Level.WARN)
    void unableToRemoveConsumer(Throwable e);
-
-   @LogMessage(id = 222249, value = "Unable to rollback on TX timed out", level = LogMessage.Level.WARN)
-   void unableToRollbackOnTxTimedOut(Exception e);
 
    @LogMessage(id = 222250, value = "Unable to delete heuristic completion from storage manager", level = LogMessage.Level.WARN)
    void unableToDeleteHeuristicCompletion(Exception e);

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ServerSessionImpl.java
@@ -1619,16 +1619,6 @@ public class ServerSessionImpl extends CriticalComponentImpl implements ServerSe
                // checked heuristic rolled back transactions
                throw new ActiveMQXAException(XAException.XA_HEURRB, "transaction has ben heuristically rolled back: " + xid);
             } else {
-               logger.trace("xarollback into {}, xid={} forcing a rollback regular", theTx, xid);
-
-               try {
-                  // This could have happened because the TX timed out, at this point we would be better on rolling back
-                  // this session as a way to prevent consumers from holding their messages
-                  this.rollback(false);
-               } catch (Exception e) {
-                  ActiveMQServerLogger.LOGGER.unableToRollbackOnTxTimedOut(e);
-               }
-
                throw new ActiveMQXAException(XAException.XAER_NOTA, "Cannot find xid in resource manager: " + xid);
             }
          } else {


### PR DESCRIPTION
Currently the broker will rollback the current transaction associated with a session when it is unable to find the XID passed when rolling back. This is a pseudo optimization for the case where the current transaction has timed out and the client may be holding on to messages.

However, this is a mistake because the current transaction may still be valid. One such use-case involves XA transaction recovery in a Java EE server where a dedicated recovery process may attempt to rollback a transaction that no longer exists (e.g. due to timeout, broker restart, etc.) while a valid transaction is still active and associated with the Session.