### PR TITLE
ARTEMIS-5847 Jolokia server detector broken

### DIFF
--- a/artemis-console/pom.xml
+++ b/artemis-console/pom.xml
@@ -57,6 +57,30 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-json</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-server-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-server-detector</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-service-jmx</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-service-jsr160</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jolokia</groupId>
+      <artifactId>jolokia-service-serializer</artifactId>
+    </dependency>
   </dependencies>
 
   <build>
@@ -94,6 +118,12 @@
                 <exclude>WEB-INF/lib/error_prone_annotations-*.jar</exclude>
                 <exclude>WEB-INF/lib/j2objc-annotations-*.jar</exclude>
                 <exclude>WEB-INF/classes/log4j2.properties</exclude>
+                <exclude>WEB-INF/lib/jolokia-json-*.jar</exclude>
+                <exclude>WEB-INF/lib/jolokia-server-core-*.jar</exclude>
+                <exclude>WEB-INF/lib/jolokia-server-detector-*.jar</exclude>
+                <exclude>WEB-INF/lib/jolokia-service-jmx-*.jar</exclude>
+                <exclude>WEB-INF/lib/jolokia-service-jsr160-*.jar</exclude>
+                <exclude>WEB-INF/lib/jolokia-service-serializer-*.jar</exclude>
               </excludes>
             </overlay>
           </overlays>

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -943,6 +943,14 @@
             <type>pom</type>
             <scope>import</scope>
          </dependency>
+
+         <dependency>
+            <groupId>org.jolokia</groupId>
+            <artifactId>jolokia-bom</artifactId>
+            <version>${jolokia.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
       </dependencies>
    </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -204,6 +204,8 @@
 
       <jackson.version>2.20.1</jackson.version>
 
+      <jolokia.version>2.4.3</jolokia.version>
+
       <activemq.version.versionName>${project.version}</activemq.version.versionName>
       <activemq.version.majorVersion>1</activemq.version.majorVersion>
       <activemq.version.minorVersion>0</activemq.version.minorVersion>


### PR DESCRIPTION
Due to the Maven coordinate changes for the new Artemis TLP the corresponding Jolokia server detector shipped in artemis-console-war 1.5.0 is broken. We should force an update to 2.4.3 in the broker to fix this.

Later when artemis-console-war has upgraded on its own this change can be reverted.