### PR TITLE
ARTEMIS-5854 consumer mngmnt API not working

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConsumerView.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/ConsumerView.java
@@ -121,12 +121,11 @@ public class ConsumerView extends ActiveMQAbstractView<ServerConsumer> {
    }
 
    public static String checkConsumerStatus(ServerConsumer consumer, ActiveMQServer server) {
-      if (server.getRemotingService().getConnection((consumer).getConnectionID()) == null) {
+      if (server.getRemotingService() != null && server.getRemotingService().getConnection((consumer).getConnectionID()) == null) {
          return CONSUMER_STATUS_ORPHANED;
       } else {
          return CONSUMER_STATUS_OK;
       }
-
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ConsumerFilterPredicate.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/management/impl/view/predicate/ConsumerFilterPredicate.java
@@ -54,10 +54,12 @@ public class ConsumerFilterPredicate extends ActiveMQFilterPredicate<ServerConsu
             matches(server.getSessionByID(consumer.getSessionID()).getRemotingConnection().getTransportConnection().getRemoteAddress());
          case MESSAGES_IN_TRANSIT -> matches(consumer.getMessagesInTransit());
          case MESSAGES_IN_TRANSIT_SIZE -> matches(consumer.getMessagesInTransitSize());
-         case MESSAGES_DELIVERED -> matches(consumer.getDeliveringMessages());
+         case MESSAGES_DELIVERED -> matches(consumer.getMessagesDelivered());
          case MESSAGES_DELIVERED_SIZE -> matches(consumer.getMessagesDeliveredSize());
          case MESSAGES_ACKNOWLEDGED -> matches(consumer.getMessagesAcknowledged());
          case MESSAGES_ACKNOWLEDGED_AWAITING_COMMIT -> matches(consumer.getMessagesAcknowledgedAwaitingCommit());
+         case LAST_ACKNOWLEDGED_TIME -> matches(consumer.getLastAcknowledgedTime());
+         case LAST_DELIVERED_TIME -> matches(consumer.getLastDeliveredTime());
          default -> true;
       };
    }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/AddressViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/AddressViewTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class AddressViewTest extends ViewTest {
+
+   @Test
+   public void testDefaultViewNullOptions() {
+      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      addressView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultViewEmptyOptions() {
+      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      addressView.setOptions("");
+   }
+
+   @Test
+   public void testViewLegacySort() {
+      AddressView view = new AddressView(Mockito.mock(ActiveMQServer.class));
+      assertNotEquals("name", view.getDefaultOrderColumn());
+      view.setOptions(createLegacyJsonFilter("name", "EQUALS", "123", "name", "asc"));
+      assertEquals("name", view.getSortField());
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ConnectionViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ConnectionViewTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ConnectionViewTest extends ViewTest {
+
+   @Test
+   public void testDefaultViewNullOptions() {
+      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      connectionView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultViewEmptyOptions() {
+      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      connectionView.setOptions("");
+   }
+
+   @Test
+   public void testViewLegacySort() {
+      ConnectionView view = new ConnectionView(Mockito.mock(ActiveMQServer.class));
+      assertNotEquals("protocol", view.getDefaultOrderColumn());
+      view.setOptions(createLegacyJsonFilter("protocol", "EQUALS", "123", "protocol", "asc"));
+      assertEquals("protocol", view.getSortField());
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ConsumerViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ConsumerViewTest.java
@@ -1,0 +1,338 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+import org.apache.activemq.artemis.api.core.JsonUtil;
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.Queue;
+import org.apache.activemq.artemis.core.server.ServerConsumer;
+import org.apache.activemq.artemis.core.server.ServerSession;
+import org.apache.activemq.artemis.core.server.impl.ServerConsumerImpl;
+import org.apache.activemq.artemis.spi.core.protocol.RemotingConnection;
+import org.apache.activemq.artemis.spi.core.remoting.Connection;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ConsumerViewTest extends ViewTest {
+
+   private static final String MOCK_VALIDATED_USER = "myValidatedUser";
+   private static final String MOCK_USER = "myUser";
+   private static final String MOCK_PROTOCOL = "myProtocol";
+   private static final String MOCK_CLIENT_ID = "myClientId";
+   private static final String MOCK_LOCAL_ADDRESS = "myLocalAddress";
+   private static final String MOCK_REMOTE_ADDRESS = "myRemoteAddress";
+
+   @Test
+   public void testDefaultViewNullOptions() {
+      ConsumerView consumerView = new ConsumerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      consumerView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultViewEmptyOptions() {
+      ConsumerView consumerView = new ConsumerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      consumerView.setOptions("");
+   }
+
+   @Test
+   public void testViewLegacySort() {
+      ConsumerView view = new ConsumerView(Mockito.mock(ActiveMQServer.class));
+      assertNotEquals("user", view.getDefaultOrderColumn());
+      view.setOptions(createLegacyJsonFilter("user", "EQUALS", "123", "user", "asc"));
+      assertEquals("user", view.getSortField());
+   }
+
+   @Test
+   public void testFilterById() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.ID.getName(),
+                 sc -> Mockito.when(sc.getSequentialID()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getSequentialID()).thenReturn(456L),
+                 "123");
+   }
+
+   @Test
+   public void testFilterBySessionId() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.SESSION.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByUser() {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      createMockSessionInServer(server, "123", false);
+      createMockSessionInServer(server, "456", true);
+
+      testFilter(server,
+                 ConsumerField.USER.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 MOCK_USER);
+   }
+
+   @Test
+   public void testFilterByValidatedUser() {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      createMockSessionInServer(server, "123", false);
+      createMockSessionInServer(server, "456", true);
+
+      testFilter(server,
+                 ConsumerField.VALIDATED_USER.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 MOCK_VALIDATED_USER);
+   }
+
+   @Test
+   public void testFilterByAddress() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.ADDRESS.getName(),
+                 sc -> {
+                    Queue queue = Mockito.mock(Queue.class);
+                    Mockito.when(queue.getAddress()).thenReturn(SimpleString.of("123"));
+                    Mockito.when(sc.getQueue()).thenReturn(queue);
+                 },
+                 sc -> {
+                    Queue queue = Mockito.mock(Queue.class);
+                    Mockito.when(queue.getAddress()).thenReturn(SimpleString.of("456"));
+                    Mockito.when(sc.getQueue()).thenReturn(queue);
+                 },
+                 "123");
+   }
+
+   @Test
+   public void testFilterByQueue() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.QUEUE.getName(),
+                 sc -> {
+                    Queue queue = Mockito.mock(Queue.class);
+                    Mockito.when(queue.getName()).thenReturn(SimpleString.of("123"));
+                    Mockito.when(sc.getQueue()).thenReturn(queue);
+                 },
+                 sc -> {
+                    Queue queue = Mockito.mock(Queue.class);
+                    Mockito.when(queue.getName()).thenReturn(SimpleString.of("456"));
+                    Mockito.when(sc.getQueue()).thenReturn(queue);
+                 },
+                 "123");
+   }
+
+   @Test
+   public void testFilterByFilterString() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.FILTER.getName(),
+                 sc -> Mockito.when(sc.getFilterString()).thenReturn(SimpleString.of("123")),
+                 sc -> Mockito.when(sc.getFilterString()).thenReturn(SimpleString.of("456")),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByProtocol() {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      createMockSessionInServer(server, "123", false);
+      createMockSessionInServer(server, "456", true);
+
+      testFilter(server,
+                 ConsumerField.PROTOCOL.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 MOCK_PROTOCOL);
+   }
+
+   @Test
+   public void testFilterByClientId() {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      createMockSessionInServer(server, "123", false);
+      createMockSessionInServer(server, "456", true);
+
+      testFilter(server,
+                 ConsumerField.CLIENT_ID.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 MOCK_CLIENT_ID);
+   }
+
+   @Test
+   public void testFilterByLocalAddress() {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      createMockSessionInServer(server, "123", false);
+      createMockSessionInServer(server, "456", true);
+
+      testFilter(server,
+                 ConsumerField.LOCAL_ADDRESS.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 MOCK_LOCAL_ADDRESS);
+   }
+
+   @Test
+   public void testFilterByRemoteAddress() {
+      ActiveMQServer server = Mockito.mock(ActiveMQServer.class);
+
+      createMockSessionInServer(server, "123", false);
+      createMockSessionInServer(server, "456", true);
+
+      testFilter(server,
+                 ConsumerField.REMOTE_ADDRESS.getName(),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("123"),
+                 sc -> Mockito.when(sc.getSessionID()).thenReturn("456"),
+                 MOCK_REMOTE_ADDRESS);
+   }
+
+   @Test
+   public void testFilterByMessagesInTransit() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.MESSAGES_IN_TRANSIT.getName(),
+                 sc -> Mockito.when(sc.getMessagesInTransit()).thenReturn(123),
+                 sc -> Mockito.when(sc.getMessagesInTransit()).thenReturn(456),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByMessagesInTransitSize() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.MESSAGES_IN_TRANSIT_SIZE.getName(),
+                 sc -> Mockito.when(sc.getMessagesInTransitSize()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getMessagesInTransitSize()).thenReturn(456L),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByMessagesDelivered() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.MESSAGES_DELIVERED.getName(),
+                 sc -> Mockito.when(sc.getMessagesDelivered()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getMessagesDelivered()).thenReturn(456L),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByMessagesDeliveredSize() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.MESSAGES_DELIVERED_SIZE.getName(),
+                 sc -> Mockito.when(sc.getMessagesDeliveredSize()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getMessagesDeliveredSize()).thenReturn(456L),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByMessagesAcknowledged() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.MESSAGES_ACKNOWLEDGED.getName(),
+                 sc -> Mockito.when(sc.getMessagesAcknowledged()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getMessagesAcknowledged()).thenReturn(456L),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByMessagesAcknowledgedAwaitingCommit() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.MESSAGES_ACKNOWLEDGED_AWAITING_COMMIT.getName(),
+                 sc -> Mockito.when(sc.getMessagesAcknowledgedAwaitingCommit()).thenReturn(123),
+                 sc -> Mockito.when(sc.getMessagesAcknowledgedAwaitingCommit()).thenReturn(456),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByLastAcknowledgedTime() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.LAST_ACKNOWLEDGED_TIME.getName(),
+                 sc -> Mockito.when(sc.getLastAcknowledgedTime()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getLastAcknowledgedTime()).thenReturn(456L),
+                 "123");
+   }
+
+   @Test
+   public void testFilterByLastDeliveredTime() {
+      testFilter(Mockito.mock(ActiveMQServer.class),
+                 ConsumerField.LAST_DELIVERED_TIME.getName(),
+                 sc -> Mockito.when(sc.getLastDeliveredTime()).thenReturn(123L),
+                 sc -> Mockito.when(sc.getLastDeliveredTime()).thenReturn(456L),
+                 "123");
+   }
+
+   private void testFilter(ActiveMQServer server, String fieldName, java.util.function.Consumer<ServerConsumer> mockMatchingConsumer, java.util.function.Consumer<ServerConsumer> mockNonMatchingConsumer, String match) {
+      Collection<ServerConsumer> consumers = new ArrayList<>();
+
+      ServerConsumer matchingConsumer = Mockito.mock(ServerConsumerImpl.class);
+      mockMatchingConsumer.accept(matchingConsumer);
+      consumers.add(matchingConsumer);
+
+      ServerConsumer nonMatchingConsumer = Mockito.mock(ServerConsumerImpl.class);
+      mockNonMatchingConsumer.accept(nonMatchingConsumer);
+      consumers.add(nonMatchingConsumer);
+
+      ConsumerView consumerView = new ConsumerView(server);
+      consumerView.setOptions(createJsonFilter(fieldName, "EQUALS", match));
+      consumerView.setCollection(consumers);
+      assertEquals(1, JsonUtil.readJsonObject(consumerView.getResultsAsJson(-1, -1)).getInt("count"));
+
+      // test again with no options to verify both sessions are returned
+      consumerView = new ConsumerView(server);
+      consumerView.setOptions("");
+      consumerView.setCollection(consumers);
+      assertEquals(2, JsonUtil.readJsonObject(consumerView.getResultsAsJson(-1, -1)).getInt("count"));
+   }
+
+   /**
+    * Creates and configures the behavior of the mock objects to simulate a {@code ServerSession} managed by the
+    * {@code ActiveMQServer}.
+    * <p>
+    * This method consolidates all the code for the mock objects so that it's not spread out and duplicated in the
+    * individual tests.
+    *
+    * @param server          The ActiveMQServer instance where the session should be mocked.
+    * @param sessionId       The identifier of the session to be mocked.
+    * @param useRandomValues Indicates whether random values should be used for the mocked attributes.
+    */
+   private void createMockSessionInServer(ActiveMQServer server, String sessionId, boolean useRandomValues) {
+      ServerSession session = Mockito.mock(ServerSession.class);
+      RemotingConnection remotingConnection = Mockito.mock(RemotingConnection.class);
+      Connection transportConnection = Mockito.mock(Connection.class);
+
+      Mockito.when(server.getSessionByID(sessionId)).thenReturn(session);
+
+      Mockito.when(session.getValidatedUser()).thenReturn(useRandomValues ? RandomUtil.randomUUIDString() : MOCK_VALIDATED_USER);
+      Mockito.when(session.getUsername()).thenReturn(useRandomValues ? RandomUtil.randomUUIDString() : MOCK_USER);
+      Mockito.when(session.getRemotingConnection()).thenReturn(remotingConnection);
+
+      Mockito.when(remotingConnection.getProtocolName()).thenReturn(useRandomValues ? RandomUtil.randomUUIDString() : MOCK_PROTOCOL);
+      Mockito.when(remotingConnection.getClientID()).thenReturn(useRandomValues ? RandomUtil.randomUUIDString() : MOCK_CLIENT_ID);
+      Mockito.when(remotingConnection.getTransportConnection()).thenReturn(transportConnection);
+
+      Mockito.when(transportConnection.getLocalAddress()).thenReturn(useRandomValues ? RandomUtil.randomUUIDString() : MOCK_LOCAL_ADDRESS);
+      Mockito.when(transportConnection.getRemoteAddress()).thenReturn(useRandomValues ? RandomUtil.randomUUIDString() : MOCK_REMOTE_ADDRESS);
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ProducerViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ProducerViewTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class ProducerViewTest extends ViewTest {
+
+   @Test
+   public void testDefaultViewNullOptions() {
+      ProducerView producerView = new ProducerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      producerView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultViewEmptyOptions() {
+      ProducerView producerView = new ProducerView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      producerView.setOptions("");
+   }
+
+   @Test
+   public void testViewLegacySort() {
+      ProducerView view = new ProducerView(Mockito.mock(ActiveMQServer.class));
+      assertNotEquals("user", view.getDefaultOrderColumn());
+      view.setOptions(createLegacyJsonFilter("user", "EQUALS", "123", "user", "asc"));
+      assertEquals("user", view.getSortField());
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/QueueViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/QueueViewTest.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class QueueViewTest extends ViewTest {
+
+   @Test
+   public void testDefaultQueueViewNullOptions() {
+      QueueView queueView = new QueueView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      queueView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultQueueViewEmptyOptions() {
+      QueueView queueView = new QueueView(Mockito.mock(ActiveMQServer.class));
+      // sanity check to ensure this doesn't just blow up
+      queueView.setOptions("");
+   }
+
+   @Test
+   public void testQueueViewLegacySort() {
+      QueueView view = new QueueView(Mockito.mock(ActiveMQServer.class));
+      assertNotEquals("id", view.getDefaultOrderColumn());
+      view.setOptions(createLegacyJsonFilter("id", "EQUALS", "123", "id", "asc"));
+      assertEquals("id", view.getSortField());
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/SessionViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/SessionViewTest.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.management.impl.view;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+public class SessionViewTest extends ViewTest {
+
+   @Test
+   public void testDefaultSessionViewNullOptions() {
+      SessionView sessionView = new SessionView();
+      // sanity check to ensure this doesn't just blow up
+      sessionView.setOptions(null);
+   }
+
+   @Test
+   public void testDefaultSessionViewEmptyOptions() {
+      SessionView sessionView = new SessionView();
+      // sanity check to ensure this doesn't just blow up
+      sessionView.setOptions("");
+   }
+
+   @Test
+   public void testSessionViewLegacySort() {
+      SessionView view = new SessionView();
+      assertNotEquals("user", view.getDefaultOrderColumn());
+      view.setOptions(createLegacyJsonFilter("user", "EQUALS", "123", "user", "asc"));
+      assertEquals("user", view.getSortField());
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ViewTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/management/impl/view/ViewTest.java
@@ -17,149 +17,18 @@
 package org.apache.activemq.artemis.core.management.impl.view;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.api.core.JsonUtil;
+import org.apache.activemq.artemis.json.JsonObject;
 import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
 public class ViewTest {
-
-   @Test
-   public void testDefaultConnectionViewNullOptions() {
-      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      connectionView.setOptions(null);
-   }
-
-   @Test
-   public void testDefaultConnectionViewEmptyOptions() {
-      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      connectionView.setOptions("");
-   }
-
-   @Test
-   public void testConnectionViewLegacySort() {
-      ConnectionView connectionView = new ConnectionView(Mockito.mock(ActiveMQServer.class));
-      assertNotEquals("protocol", connectionView.getDefaultOrderColumn());
-      connectionView.setOptions("{\"field\":\"protocol\",\"operation\":\"EQUALS\",\"value\":\"CORE\",\"sortColumn\":\"protocol\",\"sortOrder\":\"asc\"}");
-      assertEquals("protocol", connectionView.getSortField());
-   }
-
-   @Test
-   public void testDefaultSessionViewNullOptions() {
-      SessionView sessionView = new SessionView();
-      // sanity check to ensure this doesn't just blow up
-      sessionView.setOptions(null);
-   }
-
-   @Test
-   public void testDefaultSessionViewEmptyOptions() {
-      SessionView sessionView = new SessionView();
-      // sanity check to ensure this doesn't just blow up
-      sessionView.setOptions("");
-   }
-
-   @Test
-   public void testSessionViewLegacySort() {
-      SessionView sessionView = new SessionView();
-      assertNotEquals("user", sessionView.getDefaultOrderColumn());
-      sessionView.setOptions("{\"field\":\"user\",\"operation\":\"EQUALS\",\"value\":\"123\",\"sortColumn\":\"user\",\"sortOrder\":\"asc\"}");
-      assertEquals("user", sessionView.getSortField());
-   }
-
-   @Test
-   public void testDefaultAddressViewNullOptions() {
-      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      addressView.setOptions(null);
-   }
-
-   @Test
-   public void testDefaultAddressViewEmptyOptions() {
-      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      addressView.setOptions("");
-   }
-
-   @Test
-   public void testAddressViewLegacySort() {
-      AddressView addressView = new AddressView(Mockito.mock(ActiveMQServer.class));
-      assertNotEquals("name", addressView.getDefaultOrderColumn());
-      addressView.setOptions("{\"field\":\"name\",\"operation\":\"EQUALS\",\"value\":\"123\",\"sortColumn\":\"name\",\"sortOrder\":\"asc\"}");
-      assertEquals("name", addressView.getSortField());
-   }
-
-   @Test
-   public void testDefaultQueueViewNullOptions() {
-      QueueView queueView = new QueueView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      queueView.setOptions(null);
-   }
-
-   @Test
-   public void testDefaultQueueViewEmptyOptions() {
-      QueueView queueView = new QueueView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      queueView.setOptions("");
-   }
-
-   @Test
-   public void testQueueViewLegacySort() {
-      QueueView view = new QueueView(Mockito.mock(ActiveMQServer.class));
-      assertNotEquals("id", view.getDefaultOrderColumn());
-      view.setOptions("{\"field\":\"id\",\"operation\":\"EQUALS\",\"value\":\"123\",\"sortColumn\":\"id\",\"sortOrder\":\"asc\"}");
-      assertEquals("id", view.getSortField());
-   }
-
-   @Test
-   public void testDefaultConsumerViewNullOptions() {
-      ConsumerView consumerView = new ConsumerView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      consumerView.setOptions(null);
-   }
-
-   @Test
-   public void testDefaultConsumerViewEmptyOptions() {
-      ConsumerView consumerView = new ConsumerView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      consumerView.setOptions("");
-   }
-
-   @Test
-   public void testConsumerViewLegacySort() {
-      ConsumerView view = new ConsumerView(Mockito.mock(ActiveMQServer.class));
-      assertNotEquals("user", view.getDefaultOrderColumn());
-      view.setOptions("{\"field\":\"user\",\"operation\":\"EQUALS\",\"value\":\"123\",\"sortColumn\":\"user\",\"sortOrder\":\"asc\"}");
-      assertEquals("user", view.getSortField());
-   }
-
-   @Test
-   public void testDefaultProducerViewNullOptions() {
-      ProducerView producerView = new ProducerView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      producerView.setOptions(null);
-   }
-
-   @Test
-   public void testDefaultProducerViewEmptyOptions() {
-      ProducerView producerView = new ProducerView(Mockito.mock(ActiveMQServer.class));
-      // sanity check to ensure this doesn't just blow up
-      producerView.setOptions("");
-   }
-
-   @Test
-   public void testProducerViewLegacySort() {
-      ProducerView view = new ProducerView(Mockito.mock(ActiveMQServer.class));
-      assertNotEquals("user", view.getDefaultOrderColumn());
-      view.setOptions("{\"field\":\"user\",\"operation\":\"EQUALS\",\"value\":\"123\",\"sortColumn\":\"user\",\"sortOrder\":\"asc\"}");
-      assertEquals("user", view.getSortField());
-   }
 
    @Test
    public void testPageSizeAndPageNumber() {
@@ -208,5 +77,26 @@ public class ViewTest {
 
       // past the last page
       assertEquals(0, myView.getPagedResult(11, 100).size());
+   }
+
+   protected String createJsonFilter(String fieldName, String operationName, String value) {
+      Map<String, Object> filterMap = new HashMap<>();
+      filterMap.put("field", fieldName);
+      filterMap.put("operation", operationName);
+      filterMap.put("value", value);
+      JsonObject jsonFilterObject = JsonUtil.toJsonObject(filterMap);
+      return jsonFilterObject.toString();
+   }
+
+   protected String createLegacyJsonFilter(String fieldName, String operationName, String value, String sortColumn, String sortOrder) {
+      Map<String, Object> filterMap = new HashMap<>();
+      filterMap.put("field", fieldName);
+      filterMap.put("operation", operationName);
+      filterMap.put("value", value);
+      // in newer versions this is "sortField"
+      filterMap.put("sortColumn", sortColumn);
+      filterMap.put("sortOrder", sortOrder);
+      JsonObject jsonFilterObject = JsonUtil.toJsonObject(filterMap);
+      return jsonFilterObject.toString();
    }
 }


### PR DESCRIPTION
This commit does the following:

 - Allows `lastDeliveredTime` and `lastAcknowledgedTime` to be filtered via the management API.
 - Adds unit tests for all such attributes to verify they are filterable.
 - Looks up the correct value on the server when filtering on `messagesDelivered`.
 - Breaks up `ViewTest` into corresponding classes so all attributes can be unit tested eventually.