### PR TITLE
ARTEMIS-5896 Bump ErrorProne to 2.48.0 & limit to JDK25+

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -168,6 +168,8 @@ jobs:
         run: |
           cd artemis
           mvn -s .github/maven-settings.xml clean verify -Prelease -Denforcer.skip -pl "artemis-unit-test-support,org.apache.artemis:artemis-junit-5"
+          CURRENT_ERRORPRONE_VERSION=$(grep -m 1 -Po '(?<=errorprone.version>)[^<]+' pom.xml)
+          mvn -s .github/maven-settings.xml dependency:get -Dartifact="com.google.errorprone:error_prone_core:${CURRENT_ERRORPRONE_VERSION}" -pl "."
 
       - name: Clean Up Before Caching
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -116,7 +116,7 @@ jobs:
         if: matrix.java != '25'
         run: |
           cd artemis
-          mvn -s .github/maven-settings.xml -DskipTests -Derrorprone -Pdev -Pjmh -Popenwire-tests -DskipActiveMQ5Tests -Pcompatibility-tests -DskipCompatibilityTests -Dshade-plugin-create-sources=true install
+          mvn -s .github/maven-settings.xml -DskipTests -Pdev -Pjmh -Popenwire-tests -DskipActiveMQ5Tests -Pcompatibility-tests -DskipCompatibilityTests -Dshade-plugin-create-sources=true install
 
       - name: Set Examples Version to Artemis Version
         run: |

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -28,6 +28,7 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 * https://issues.apache.org/jira/browse/ARTEMIS-5941[ARTEMIS-5941] - Route wildcard subscriptions direct to demand bindings for improved performance
 * https://issues.apache.org/jira/browse/ARTEMIS-5951[ARTEMIS-5951] - CTRL-C is now properly handled on 'artemis shell'
 * https://issues.apache.org/jira/browse/ARTEMIS-5607[ARTEMIS-5607] - It is now possible to disable JMX notifications
+* For developers, due to https://issues.apache.org/jira/browse/ARTEMIS-5896[ARTEMIS-5896] ErrorProne will only run when building with Java 25+.
 
 == Version 2.52.0
 

--- a/pom.xml
+++ b/pom.xml
@@ -113,7 +113,7 @@
       <jetty.version>12.1.7</jetty.version>
       <jetty-servlet-api.version>5.0.2</jetty-servlet-api.version>
       <jgroups.version>5.3.13.Final</jgroups.version>
-      <errorprone.version>2.42.0</errorprone.version>
+      <errorprone.version>2.48.0</errorprone.version>
       <maven.bundle.plugin.version>6.0.2</maven.bundle.plugin.version>
       <jib.maven.plugin.version>3.5.1</jib.maven.plugin.version>
       <versions.maven.plugin.version>2.16.1</versions.maven.plugin.version>
@@ -329,6 +329,7 @@
             <property>
                <name>errorprone</name>
             </property>
+            <jdk>[25,)</jdk>
          </activation>
          <build>
             <plugins>


### PR DESCRIPTION
Aside from the upgrade, this restricts ErrorProne to Java 25 and beyond. Technically speaking, it could run on 21, but that also requires a JDK parameter that is exclusively for 21. Restricting to 25 is the simplest solution without any meaningful down-sides.