### PR TITLE
ARTEMIS-5995 Remove activemq-broker dependency from integration tests

### DIFF
--- a/tests/integration-tests/pom.xml
+++ b/tests/integration-tests/pom.xml
@@ -369,20 +369,6 @@
          <scope>test</scope>
       </dependency>
 
-      <!-- need this for org.apache.activemq.filter.JAXPXPathEvaluator for Xpath selectors with OpenWire JMS clients-->
-      <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-broker</artifactId>
-         <version>${activemq5-version}</version>
-         <scope>test</scope>
-         <exclusions>
-            <exclusion>
-               <groupId>com.fasterxml.jackson.core</groupId>
-               <artifactId>jackson-databind</artifactId>
-            </exclusion>
-         </exclusions>
-      </dependency>
-
       <dependency>
          <groupId>org.codehaus.woodstox</groupId>
          <artifactId>woodstox-core-asl</artifactId>

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/JMSXPathSelectorTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/multiprotocol/JMSXPathSelectorTest.java
@@ -28,6 +28,7 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 import javax.jms.TextMessage;
+import javax.xml.parsers.DocumentBuilder;
 import java.net.URI;
 
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
@@ -36,11 +37,25 @@ import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.impl.AddressInfo;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
+import org.apache.activemq.filter.XPathExpression;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 public class JMSXPathSelectorTest extends MultiprotocolJMSClientTestSupport {
 
    private static final String NORMAL_QUEUE_NAME = "NORMAL";
+
+   @BeforeEach
+   @Override
+   public void setUp() throws Exception {
+      super.setUp();
+
+      // Set dummy XPathEvaluator to avoid activemq-broker dependency.
+      // OpenWire JMS client initializes it to parse XPATH selectors,
+      // but the actual evaluation happens server-side.
+      System.setProperty("org.apache.activemq.XPathEvaluatorClassName",
+         DummyXPathEvaluator.class.getName());
+   }
 
    @Override
    protected URI getBrokerQpidJMSConnectionURI() {
@@ -152,6 +167,17 @@ public class JMSXPathSelectorTest extends MultiprotocolJMSClientTestSupport {
          TextMessage message2 = producerSession.createTextMessage();
          message2.setText(goodBody);
          p.send(queue1, message2, deliveryMode, priority, timeToLive);
+      }
+   }
+
+   protected static class DummyXPathEvaluator implements XPathExpression.XPathEvaluator {
+      public DummyXPathEvaluator(String xpathExpression, DocumentBuilder builder) {
+      }
+
+      @Override
+      public boolean evaluate(org.apache.activemq.command.Message message) {
+         assert false : "DummyXPathEvaluator.evaluate() should never be called";
+         return false;
       }
    }
 }


### PR DESCRIPTION
The integration-tests module currently requires a dependency on the activemq-broker artifact solely because JMSXPathSelectorTest needs the default XPathEvaluator class used by the OpenWire JMS client. This dependency is unnecessary since the actual XPath selector evaluation happens server-side, not client-side.