### PR TITLE
ARTEMIS-5949 Clarify manage permission in default broker.xml

### DIFF
--- a/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
+++ b/artemis-cli/src/main/resources/org/apache/activemq/artemis/cli/commands/etc/broker.xml
@@ -117,8 +117,15 @@ ${cluster-security.settings}${cluster.settings}${replicated.settings}${shared-st
             <permission type="consume" roles="${role}"/>
             <permission type="browse" roles="${role}"/>
             <permission type="send" roles="${role}"/>
-            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+         </security-setting>
+         <security-setting match="activemq.management.#">
             <permission type="manage" roles="${role}"/>
+            <permission type="createNonDurableQueue" roles="${role}"/>
+            <permission type="deleteNonDurableQueue" roles="${role}"/>
+            <permission type="createAddress" roles="${role}"/>
+            <permission type="deleteAddress" roles="${role}"/>
+            <permission type="consume" roles="${role}"/>
+            <permission type="send" roles="${role}"/>
          </security-setting>
       </security-settings>
 

--- a/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
+++ b/artemis-cli/src/test/java/org/apache/activemq/cli/test/ArtemisTest.java
@@ -44,7 +44,10 @@ import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.regex.Pattern;
+
+import org.apache.activemq.artemis.core.security.Role;
 
 import org.apache.activemq.artemis.api.config.ActiveMQDefaultConfiguration;
 import org.apache.activemq.artemis.api.core.ActiveMQIllegalStateException;
@@ -2378,6 +2381,46 @@ public class ArtemisTest extends CliTestBase {
       public String getPropertyTwo() {
          return propertyTwo;
       }
+   }
+
+   @Test
+   @Timeout(60)
+   public void testDefaultSecuritySettings() throws Exception {
+      FileConfiguration configuration = createFileConfiguration(getTestMethodName(),
+                                                                "--silent", "--no-web", "--no-autotune");
+
+      Map<String, Set<Role>> securityRoles = configuration.getSecurityRoles();
+
+      // wildcard match should have all permissions except manage
+      Set<Role> wildcardRoles = securityRoles.get("#");
+      assertNotNull(wildcardRoles, "Expected security-setting for '#'");
+      assertEquals(1, wildcardRoles.size());
+      Role wildcardRole = wildcardRoles.iterator().next();
+      assertEquals("amq", wildcardRole.getName());
+      assertTrue(wildcardRole.isSend());
+      assertTrue(wildcardRole.isConsume());
+      assertTrue(wildcardRole.isBrowse());
+      assertTrue(wildcardRole.isCreateDurableQueue());
+      assertTrue(wildcardRole.isDeleteDurableQueue());
+      assertTrue(wildcardRole.isCreateNonDurableQueue());
+      assertTrue(wildcardRole.isDeleteNonDurableQueue());
+      assertTrue(wildcardRole.isCreateAddress());
+      assertTrue(wildcardRole.isDeleteAddress());
+      assertFalse(wildcardRole.isManage(), "manage permission must not be on the wildcard '#' address");
+
+      // management address match should have manage plus supporting permissions
+      Set<Role> mgmtRoles = securityRoles.get("activemq.management.#");
+      assertNotNull(mgmtRoles, "Expected security-setting for 'activemq.management.#'");
+      assertEquals(1, mgmtRoles.size());
+      Role mgmtRole = mgmtRoles.iterator().next();
+      assertEquals("amq", mgmtRole.getName());
+      assertTrue(mgmtRole.isManage());
+      assertTrue(mgmtRole.isSend());
+      assertTrue(mgmtRole.isConsume());
+      assertTrue(mgmtRole.isCreateNonDurableQueue());
+      assertTrue(mgmtRole.isDeleteNonDurableQueue());
+      assertTrue(mgmtRole.isCreateAddress());
+      assertTrue(mgmtRole.isDeleteAddress());
    }
 
    private static File newFolder(File root, String subFolder) throws IOException {

--- a/artemis-features/src/main/resources/artemis.xml
+++ b/artemis-features/src/main/resources/artemis.xml
@@ -144,8 +144,15 @@ under the License.
             <permission type="consume" roles="manager"/>
             <permission type="browse" roles="manager"/>
             <permission type="send" roles="manager"/>
-            <!-- we need this otherwise ./artemis data imp wouldn't work -->
+         </security-setting>
+         <security-setting match="activemq.management.#">
             <permission type="manage" roles="manager"/>
+            <permission type="createNonDurableQueue" roles="manager"/>
+            <permission type="deleteNonDurableQueue" roles="manager"/>
+            <permission type="createAddress" roles="manager"/>
+            <permission type="deleteAddress" roles="manager"/>
+            <permission type="consume" roles="manager"/>
+            <permission type="send" roles="manager"/>
          </security-setting>
       </security-settings>
 

--- a/tests/smoke-tests/src/main/resources/servers/jmx-rbac-broker-security/broker.xml
+++ b/tests/smoke-tests/src/main/resources/servers/jmx-rbac-broker-security/broker.xml
@@ -70,7 +70,15 @@ under the License.
             <permission type="consume" roles="amq"/>
             <permission type="browse" roles="amq"/>
             <permission type="send" roles="amq"/>
+         </security-setting>
+         <security-setting match="activemq.management.#">
             <permission type="manage" roles="amq"/>
+            <permission type="createNonDurableQueue" roles="amq"/>
+            <permission type="deleteNonDurableQueue" roles="amq"/>
+            <permission type="createAddress" roles="amq"/>
+            <permission type="deleteAddress" roles="amq"/>
+            <permission type="consume" roles="amq"/>
+            <permission type="send" roles="amq"/>
          </security-setting>
 
          <!-- settings for jmx MBean access to management operations -->


### PR DESCRIPTION
Move the `manage` permission out of the wildcard `match="#"` security-setting and into a dedicated `match="activemq.management.#"` entry, along with the   supporting permissions required for management operations (createNonDurableQueue,   deleteNonDurableQueue, createAddress, deleteAddress, consume, send).

The old placement was imprecise: granting manage across all addresses is broader than necessary, since it is only meaningful on the management address. 
The stale comment explaining the wildcard manage entry is also removed.

Changes:
  -  `artemis-cli broker.xml` template 
  -  `artemis-features artemis.xml`
  -  jmx-rbac-broker-security smoke-test fixture (aligned to new default)
  -  ArtemisTest:add testDefaultSecuritySettings to assert the generated broker.xml has manage only on activemq.management.# and not on #
