### PR TITLE
ARTEMIS-6031 Handle credit starvation affecting Core bridge

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AbstractProducerCreditsImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/AbstractProducerCreditsImpl.java
@@ -162,7 +162,7 @@ public abstract class AbstractProducerCreditsImpl implements ClientProducerCredi
       int toRequest = -1;
 
       synchronized (this) {
-         if (getBalance() + arriving < needed) {
+         if (getBalance() + arriving <= needed) {
             toRequest = needed - arriving;
 
             if (logger.isTraceEnabled()) {
@@ -170,7 +170,7 @@ public abstract class AbstractProducerCreditsImpl implements ClientProducerCredi
             }
          } else {
             if (logger.isTraceEnabled()) {
-               logger.trace("CheckCredits did not need it, balance={}, arriving={},  needed={}, getbalance + arriving < needed={}", getBalance(), arriving, needed, (boolean)(getBalance() + arriving < needed));
+               logger.trace("CheckCredits did not need it, balance={}, arriving={},  needed={}, getbalance + arriving <= needed={}", getBalance(), arriving, needed, (boolean)(getBalance() + arriving <= needed));
             }
          }
       }

--- a/artemis-core-client/src/test/java/org/apache/activemq/artemis/core/client/impl/AsynchronousProducerCreditsImplTest.java
+++ b/artemis-core-client/src/test/java/org/apache/activemq/artemis/core/client/impl/AsynchronousProducerCreditsImplTest.java
@@ -17,9 +17,15 @@
 
 package org.apache.activemq.artemis.core.client.impl;
 
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.Timeout;
 import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class AsynchronousProducerCreditsImplTest {
 
@@ -30,6 +36,48 @@ public class AsynchronousProducerCreditsImplTest {
       AsynchronousProducerCreditsImpl producerCredits = new AsynchronousProducerCreditsImpl(session, null, 0, Mockito.mock(ClientProducerFlowCallback.class));
       producerCredits.receiveCredits(0);
       Mockito.verify(session).sendProducerCreditsMessage(0, null);
+   }
+
+   @Test
+   @Timeout(10)
+   public void testCreditsRequestedWhenMessageSizeExactlyEqualsBalance() throws Exception {
+      ClientSessionInternal mockClientSession = Mockito.mock(ClientSessionInternal.class);
+
+      AtomicInteger creditsRequested = new AtomicInteger(0);
+      AtomicBoolean blocked = new AtomicBoolean(false);
+
+      int producerWindowSize = 1000;
+
+      Mockito.doAnswer(inv -> {
+         creditsRequested.addAndGet(inv.getArgument(0));
+         return null;
+      }).when(mockClientSession).sendProducerCreditsMessage(Mockito.anyInt(), Mockito.any());
+
+      AsynchronousProducerCreditsImpl producerCredits = new AsynchronousProducerCreditsImpl(mockClientSession, null, producerWindowSize, new ClientProducerFlowCallback() {
+
+         @Override
+         public void onCreditsFlow(boolean isBlocked, ClientProducerCredits credits) {
+            blocked.set(isBlocked);
+         }
+
+         @Override
+         public void onCreditsFail(ClientProducerCredits credits) {
+         }
+
+      });
+
+      int internalWindowSize = producerWindowSize / 2;
+      // drain balance to just above internalWindowSize
+      producerCredits.actualAcquire(internalWindowSize - 100);
+
+      int messageSize = producerCredits.getBalance();
+      producerCredits.acquireCredits(messageSize);
+
+      assertTrue(creditsRequested.get() > 0, "credits must be requested when message size exactly equals balance");
+
+      producerCredits.receiveCredits(creditsRequested.get());
+      assertTrue(producerCredits.getBalance() > 0);
+      assertFalse(blocked.get());
    }
 
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/cluster/bridge/BridgeTest.java
@@ -271,6 +271,100 @@ public class BridgeTest extends ActiveMQTestBase {
    }
 
    @TestTemplate
+   public void testBridgeHandlesReachingZeroCredits() throws Exception {
+      final int numMessages = 10;
+
+      final String testAddress = "testAddress";
+      final String queueName0 = "queue0";
+      final String forwardAddress = "forwardAddress";
+      final String queueName1 = "queue1";
+
+      final String bridgeName = "bridge0";
+
+      final int flowControlSize = 1024 * 10;
+      final AtomicInteger messageForwardSize = new AtomicInteger(0);
+
+      //This is used to capture the actual message size that the bridge will send
+      Transformer transformer = message -> {
+         messageForwardSize.addAndGet(message.getEncodeSize());
+         return message;
+      };
+
+      Map<String, Object> server0Params = new HashMap<>();
+      Map<String, Object> server1Params = new HashMap<>();
+
+      addTargetParameters(server1Params);
+
+      server0 = createClusteredServerWithParams(isNetty(), 0, true, server0Params);
+      server1 = createClusteredServerWithParams(isNetty(), 1, true, server1Params);
+
+      server0.getServiceRegistry().addBridgeTransformer(bridgeName, transformer);
+      TransportConfiguration server0tc = new TransportConfiguration(getConnector(), server0Params);
+      TransportConfiguration server1tc = new TransportConfiguration(getConnector(), server1Params);
+
+      server0.getConfiguration().setConnectorConfigurations(Map.of(server1tc.getName(), server1tc));
+
+      server0.start();
+      server1.start();
+
+      server0.createQueue(QueueConfiguration.of(queueName0).setAddress(testAddress));
+      server1.createQueue(QueueConfiguration.of(queueName1).setAddress(forwardAddress));
+
+      locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(server0tc, server1tc));
+
+      server0.deployBridge(new BridgeConfiguration()
+                              .setName(bridgeName)
+                              .setQueueName(queueName0)
+                              .setForwardingAddress(forwardAddress)
+                              .setProducerWindowSize(flowControlSize)
+                              .setStaticConnectors(List.of(server1tc.getName())));
+
+      ClientSessionFactory sf0 = addSessionFactory(locator.createSessionFactory(server0tc));
+      ClientSessionFactory sf1 = addSessionFactory(locator.createSessionFactory(server1tc));
+
+      ClientSession session0 = sf0.createSession(false, true, true);
+      ClientSession session1 = sf1.createSession(false, true, true);
+      session1.start();
+
+      ClientProducer producer0 = session0.createProducer(SimpleString.of(testAddress));
+      ClientConsumer consumer1 = session1.createConsumer(queueName1);
+
+      // send empty message to capture the size of a base message + bridge property
+      producer0.send(session0.createMessage(true));
+      Wait.assertTrue(() -> messageForwardSize.get() > 0);
+
+      // messageForwardSize is multiplied by two to account for previous and upcoming message
+      // the intention is to land on exactly 0 credits after the next message is sent
+      int sendSize = flowControlSize - (messageForwardSize.get() * 2);
+
+      for (int i = 0; i < numMessages; i++) {
+         ClientMessage message = session0.createMessage(true);
+         message.getBodyBuffer().writeBytes(new byte[sendSize]);
+         producer0.send(message);
+      }
+
+      for (int i = 0; i < numMessages + 1; i++) {
+         ClientMessage message = consumer1.receive(1000);
+         assertNotNull(message);
+         message.acknowledge();
+      }
+
+      assertNull(consumer1.receiveImmediate());
+
+      session0.close();
+      session1.close();
+      sf0.close();
+      sf1.close();
+
+      closeFields();
+
+      if (server0.getConfiguration().isPersistenceEnabled()) {
+         assertEquals(0, loadQueues(server0).size());
+      }
+
+   }
+
+   @TestTemplate
    public void testBlockedBridgeAndReconnect() throws Exception {
       long time = System.currentTimeMillis();
       Map<String, Object> server0Params = new HashMap<>();


### PR DESCRIPTION
This relates to #6020 

The fix in that case is still valid but turns out there was a similar thing that could happen in `AbstractProducerCreditsImpl` as well.

Big thanks to @mbengtsson for co-authoring this PR!