### PR TITLE
ARTEMIS-6043 updating divert w/mngmnt API can persist invalid config

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/DivertConfiguration.java
@@ -66,6 +66,17 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
    public DivertConfiguration() {
    }
 
+   public DivertConfiguration(DivertConfiguration config) {
+      this.name = config.getName();
+      this.routingName = config.getRoutingName();
+      this.address = config.getAddress();
+      this.forwardingAddress = config.getForwardingAddress();
+      this.exclusive = config.isExclusive();
+      this.filterString = config.getFilterString();
+      this.transformerConfiguration = config.getTransformerConfiguration();
+      this.routingType = config.getRoutingType();
+   }
+
    /**
     * Set the value of a parameter based on its "key" {@code String}. Valid key names and corresponding {@code static}
     * {@code final} are:
@@ -108,7 +119,7 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
                setTransformerConfiguration(transformerConfiguration);
             }
          } else if (key.equals(ROUTING_TYPE)) {
-            setRoutingType(ComponentConfigurationRoutingType.valueOf(value));
+            setRoutingType(value == null ? null : ComponentConfigurationRoutingType.valueOf(value));
          }
       }
       return this;
@@ -227,7 +238,9 @@ public class DivertConfiguration implements Serializable, EncodingSupport {
          builder.add(TRANSFORMER_CONFIGURATION, tc.createJsonObjectBuilder());
       }
 
-      if (getRoutingType() != null) {
+      if (getRoutingType() == null) {
+         builder.add(ROUTING_TYPE, JsonValue.NULL);
+      } else {
          builder.add(ROUTING_TYPE, getRoutingType().name());
       }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/StorageManager.java
@@ -30,6 +30,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.OperationConsistencyLevel;
 import org.apache.activemq.artemis.core.io.SequentialFile;
@@ -390,6 +391,8 @@ public interface StorageManager extends MapStorageManager, IDGenerator, ActiveMQ
    void deleteDivertConfiguration(String divertName) throws Exception;
 
    List<PersistedDivertConfiguration> recoverDivertConfigurations();
+
+   DivertConfiguration getDivertConfiguration(String name);
 
    void storeBridgeConfiguration(PersistedBridgeConfiguration persistedBridgeConfiguration) throws Exception;
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/journal/AbstractJournalStorageManager.java
@@ -46,6 +46,7 @@ import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.filter.Filter;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
@@ -843,6 +844,16 @@ public abstract class AbstractJournalStorageManager extends CriticalComponentImp
    @Override
    public List<PersistedDivertConfiguration> recoverDivertConfigurations() {
       return new ArrayList<>(mapPersistedDivertConfigurations.values());
+   }
+
+   @Override
+   public DivertConfiguration getDivertConfiguration(String name) {
+      PersistedDivertConfiguration persistedDivertConfiguration = mapPersistedDivertConfigurations.get(name);
+      if (persistedDivertConfiguration != null) {
+         return new DivertConfiguration(persistedDivertConfiguration.getDivertConfiguration());
+      } else {
+         return null;
+      }
    }
 
    @Override

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/persistence/impl/nullpm/NullStorageManager.java
@@ -32,6 +32,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.IOCriticalErrorListener;
 import org.apache.activemq.artemis.core.io.OperationConsistencyLevel;
@@ -495,6 +496,11 @@ public class NullStorageManager implements StorageManager {
 
    @Override
    public List<PersistedDivertConfiguration> recoverDivertConfigurations() {
+      return null;
+   }
+
+   @Override
+   public DivertConfiguration getDivertConfiguration(String name) {
       return null;
    }
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -1544,4 +1544,7 @@ public interface ActiveMQServerLogger {
 
    @LogMessage(id = 224163, value = "Failed to clone SHA256 MessageDigest, falling back to getInstance", level = LogMessage.Level.INFO)
    void sha256CloneNotSupported(CloneNotSupportedException cns);
+
+   @LogMessage(id = 224164, value = "Failed to recover stored configuration for divert named '{}': {}. To repair this record create a new divert with the same name via the management API.", level = LogMessage.Level.WARN)
+   void failedToRecoverStoredDivertConfiguration(String divertName, String divert);
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -3069,38 +3069,59 @@ public class ActiveMQServerImpl implements ActiveMQServer {
          return null;
       }
 
-      final Divert divert = divertBinding.getDivert();
+      // The divert config may be in defined in the broker config (e.g. XML) or stored in the journal. If it's in the
+      // journal we want to make sure it's updated propertly otherwise we just update what's in memory.
+      DivertConfiguration onStorageDivert = storageManager.getDivertConfiguration(config.getName());
+      final Divert inMemoryDivert = divertBinding.getDivert();
 
       Filter filter = FilterImpl.createFilter(config.getFilterString());
       if (filter == null) {
-         divert.setFilter(null);
+         inMemoryDivert.setFilter(null);
+         if (onStorageDivert != null) {
+            onStorageDivert.setFilterString(null);
+         }
       } else {
-         if (!filter.equals(divert.getFilter())) {
-            divert.setFilter(filter);
+         if (!filter.equals(inMemoryDivert.getFilter())) {
+            inMemoryDivert.setFilter(filter);
+            if (onStorageDivert != null) {
+               onStorageDivert.setFilterString(config.getFilterString());
+            }
          }
       }
 
       if (config.getTransformerConfiguration() != null) {
-         getServiceRegistry().removeDivertTransformer(divert.getUniqueName().toString());
+         getServiceRegistry().removeDivertTransformer(inMemoryDivert.getUniqueName().toString());
          Transformer transformer = getServiceRegistry().getDivertTransformer(
             config.getName(), config.getTransformerConfiguration());
-         divert.setTransformer(transformer);
+         inMemoryDivert.setTransformer(transformer);
+         if (onStorageDivert != null) {
+            onStorageDivert.setTransformerConfiguration(config.getTransformerConfiguration());
+         }
       }
 
       if (config.getForwardingAddress() != null) {
          SimpleString forwardAddress = SimpleString.of(config.getForwardingAddress());
-         if (!forwardAddress.equals(divert.getForwardAddress())) {
-            divert.setForwardAddress(forwardAddress);
+         if (!forwardAddress.equals(inMemoryDivert.getForwardAddress())) {
+            inMemoryDivert.setForwardAddress(forwardAddress);
+            if (onStorageDivert != null) {
+               onStorageDivert.setForwardingAddress(config.getForwardingAddress());
+            }
          }
       }
 
-      if (config.getRoutingType() != null && divert.getRoutingType() != config.getRoutingType()) {
-         divert.setRoutingType(config.getRoutingType());
+      if (config.getRoutingType() != null && inMemoryDivert.getRoutingType() != config.getRoutingType()) {
+         inMemoryDivert.setRoutingType(config.getRoutingType());
+         if (onStorageDivert != null) {
+            onStorageDivert.setRoutingType(config.getRoutingType());
+         }
       }
 
-      storageManager.storeDivertConfiguration(new PersistedDivertConfiguration(config));
+      if (onStorageDivert != null) {
+         // this will replace the existing divert record in the journal using delete + add
+         storageManager.storeDivertConfiguration(new PersistedDivertConfiguration(onStorageDivert));
+      }
 
-      return divert;
+      return inMemoryDivert;
    }
 
    @Override
@@ -4465,15 +4486,20 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       if (storageManager.recoverDivertConfigurations() != null) {
 
          for (PersistedDivertConfiguration persistedDivertConfiguration : storageManager.recoverDivertConfigurations()) {
-            //has it been removed from config
-            boolean deleted = configuration.getDivertConfigurations().stream().noneMatch(divertConfiguration -> divertConfiguration.getName().equals(persistedDivertConfiguration.getName()));
-            // if it has remove it if configured to do so
-            if (deleted) {
-               if (addressSettingsRepository.getMatch(persistedDivertConfiguration.getDivertConfiguration().getAddress()).getConfigDeleteDiverts() == DeletionPolicy.FORCE) {
-                  storageManager.deleteDivertConfiguration(persistedDivertConfiguration.getName());
-               } else {
-                  deployDivert(persistedDivertConfiguration.getDivertConfiguration());
+            try {
+               //has it been removed from config
+               boolean deleted = configuration.getDivertConfigurations().stream().noneMatch(divertConfiguration -> divertConfiguration.getName().equals(persistedDivertConfiguration.getName()));
+               // if it has remove it if configured to do so
+               if (deleted) {
+                  if (addressSettingsRepository.getMatch(persistedDivertConfiguration.getDivertConfiguration().getAddress()).getConfigDeleteDiverts() == DeletionPolicy.FORCE) {
+                     storageManager.deleteDivertConfiguration(persistedDivertConfiguration.getName());
+                  } else {
+                     deployDivert(persistedDivertConfiguration.getDivertConfiguration());
+                  }
                }
+            } catch (Exception e) {
+               logger.debug(e.getMessage(), e);
+               ActiveMQServerLogger.LOGGER.failedToRecoverStoredDivertConfiguration(persistedDivertConfiguration.getName(), String.valueOf(persistedDivertConfiguration.getDivertConfiguration()));
             }
          }
       }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/transaction/impl/TransactionImplTest.java
@@ -33,6 +33,7 @@ import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.Pair;
 import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.OperationConsistencyLevel;
 import org.apache.activemq.artemis.core.io.SequentialFile;
@@ -743,6 +744,11 @@ public class TransactionImplTest extends ServerTestBase {
 
       @Override
       public List<PersistedDivertConfiguration> recoverDivertConfigurations() {
+         return null;
+      }
+
+      @Override
+      public DivertConfiguration getDivertConfiguration(String name) {
          return null;
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/SendAckFailTest.java
@@ -44,6 +44,7 @@ import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
 import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
 import org.apache.activemq.artemis.core.config.impl.SecurityConfiguration;
 import org.apache.activemq.artemis.core.io.IOCallback;
 import org.apache.activemq.artemis.core.io.OperationConsistencyLevel;
@@ -745,6 +746,11 @@ public class SendAckFailTest extends SpawnedTestBase {
 
       @Override
       public List<PersistedDivertConfiguration> recoverDivertConfigurations() {
+         return null;
+      }
+
+      @Override
+      public DivertConfiguration getDivertConfiguration(String name) {
          return null;
       }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/DivertManagementTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/management/DivertManagementTest.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.tests.integration.management;
+
+import org.apache.activemq.artemis.api.core.SimpleString;
+import org.apache.activemq.artemis.api.core.management.ActiveMQServerControl;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.DivertConfiguration;
+import org.apache.activemq.artemis.core.persistence.config.PersistedDivertConfiguration;
+import org.apache.activemq.artemis.core.postoffice.Binding;
+import org.apache.activemq.artemis.core.postoffice.impl.DivertBinding;
+import org.apache.activemq.artemis.core.server.ActiveMQServer;
+import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.server.ComponentConfigurationRoutingType;
+import org.apache.activemq.artemis.core.server.Divert;
+import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
+import org.apache.activemq.artemis.utils.RandomUtil;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class DivertManagementTest extends ManagementTestBase {
+
+   private ActiveMQServer server;
+
+   @Override
+   @BeforeEach
+   public void setUp() throws Exception {
+      super.setUp();
+      Configuration conf = createDefaultNettyConfig().setJMXManagementEnabled(true);
+      server = addServer(ActiveMQServers.newActiveMQServer(conf, mbeanServer));
+      server.start();
+   }
+
+   @Test
+   public void testBadJournalRecord() throws Exception {
+      final String name = RandomUtil.randomUUIDString();
+      String routingName = RandomUtil.randomUUIDString();
+      String address = RandomUtil.randomUUIDString();
+      String forwardingAddress = RandomUtil.randomUUIDString();
+      ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.getType((byte) RandomUtil.randomMax(3));
+      boolean exclusive = RandomUtil.randomBoolean();
+
+      DivertConfiguration config = new DivertConfiguration()
+         .setName(name);
+
+      // store an invalid divert config (i.e. missing address)
+      server.getStorageManager().storeDivertConfiguration(new PersistedDivertConfiguration(config));
+
+      server.stop();
+      waitForServerToStop(server);
+
+      // start the broker and verify the invalid divert config failed to load
+      try (AssertionLoggerHandler loggerHandler = new AssertionLoggerHandler()) {
+         server.start();
+         waitForServerToStart(server);
+         assertTrue(loggerHandler.findText("AMQ224164", name));
+      }
+      assertNull(server.getPostOffice().getBinding(SimpleString.of(name)));
+
+      // create a new divert with the same name
+      ActiveMQServerControl serverControl = ManagementControlHelper.createActiveMQServerControl(mbeanServer);
+      config.setAddress(address)
+         .setRoutingType(routingType)
+         .setRoutingName(routingName)
+         .setForwardingAddress(forwardingAddress)
+         .setExclusive(exclusive);
+
+      serverControl.createDivert(config.toJSON());
+
+      // verify divert was created
+      assertInstanceOf(DivertBinding.class, server.getPostOffice().getBinding(SimpleString.of(name)));
+      assertEquals(1, server.getPostOffice().getBindingsForAddress(SimpleString.of(address)).size());
+
+      server.stop();
+      waitForServerToStop(server);
+
+      // start the broker and verify that the invalid divert config is no longer there
+      try (AssertionLoggerHandler loggerHandler = new AssertionLoggerHandler()) {
+         server.start();
+         waitForServerToStart(server);
+         assertFalse(loggerHandler.findText("AMQ224164"));
+      }
+
+      Binding binding = server.getPostOffice().getBinding(SimpleString.of(name));
+      assertInstanceOf(DivertBinding.class, binding);
+      assertEquals(1, server.getPostOffice().getBindingsForAddress(SimpleString.of(address)).size());
+
+      Divert divert = ((DivertBinding) binding).getDivert();
+      assertEquals(name, divert.getUniqueName().toString());
+      assertEquals(address, divert.getAddress().toString());
+      assertEquals(routingType, divert.getRoutingType());
+      assertEquals(routingName, divert.getRoutingName().toString());
+      assertEquals(forwardingAddress, divert.getForwardAddress().toString());
+      assertEquals(exclusive, divert.isExclusive());
+   }
+
+   @Test
+   public void testPersistentUpdate() throws Exception {
+      String name = RandomUtil.randomUUIDString();
+      String routingName = RandomUtil.randomUUIDString();
+      String address = RandomUtil.randomUUIDString();
+      String forwardingAddress = RandomUtil.randomUUIDString();
+      ComponentConfigurationRoutingType routingType = ComponentConfigurationRoutingType.getType((byte) RandomUtil.randomMax(3));
+      boolean exclusive = RandomUtil.randomBoolean();
+
+      ActiveMQServerControl serverControl = ManagementControlHelper.createActiveMQServerControl(mbeanServer);
+      DivertConfiguration config = new DivertConfiguration()
+         .setName(name)
+         .setAddress(address)
+         .setRoutingType(routingType)
+         .setRoutingName(routingName)
+         .setForwardingAddress(forwardingAddress)
+         .setExclusive(exclusive);
+
+      serverControl.createDivert(config.toJSON());
+
+      String updatedForwardingAddress = RandomUtil.randomUUIDString();
+      serverControl.updateDivert(new DivertConfiguration()
+                                    .setName(name)
+                                    .setForwardingAddress(updatedForwardingAddress)
+                                    .setRoutingType(null) // must set to null to avoid updating since the default is non-null
+                                    .toJSON());
+
+      server.stop();
+      waitForServerToStop(server);
+      server.start();
+      waitForServerToStart(server);
+
+      Binding binding = server.getPostOffice().getBinding(SimpleString.of(name));
+      assertInstanceOf(DivertBinding.class, binding);
+      assertEquals(1, server.getPostOffice().getBindingsForAddress(SimpleString.of(address)).size());
+
+      Divert divert = ((DivertBinding) binding).getDivert();
+      assertEquals(name, divert.getUniqueName().toString());
+      assertEquals(address, divert.getAddress().toString());
+      assertEquals(routingType, divert.getRoutingType());
+      assertEquals(routingName, divert.getRoutingName().toString());
+      assertEquals(updatedForwardingAddress, divert.getForwardAddress().toString());
+      assertEquals(exclusive, divert.isExclusive());
+   }
+}


### PR DESCRIPTION
This commit fixes two related issues:
 - Ensures the broker can still start if recovering a persisted divert configuration fails
 - Ensures the broker does not persist an invalid divert configuration