### PR TITLE
ARTEMIS-6066 deadlock with Core federation consumer

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/client/impl/ClientSessionFactoryImpl.java
@@ -786,7 +786,6 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
                sessionsToClose = new HashSet<>(sessions);
             }
             callFailoverListeners(FailoverEventType.FAILOVER_FAILED);
-            callSessionFailureListeners(me, true, false, scaleDownTargetNodeID);
          }
       } finally {
          localFailoverLock.unlock();
@@ -795,7 +794,10 @@ public class ClientSessionFactoryImpl implements ClientSessionFactoryInternal, C
       // This needs to be outside the failover lock to prevent deadlock
       if (connection != null) {
          callSessionFailureListeners(me, true, true);
+      } else {
+         callSessionFailureListeners(me, true, false, scaleDownTargetNodeID);
       }
+
       if (sessionsToClose != null) {
          // If connection is null it means we didn't succeed in failing over or reconnecting
          // so we close all the sessions, so they will throw exceptions when attempted to be used


### PR DESCRIPTION
I was unable to reproduce the deadlock with a test so static analysis will have to suffice here. The solution has the benefit of being alongside another bit of code that is explicitly identified as necessary to prevent deadlocks.