### PR TITLE
ARTEMIS-6073 add SECURITY.md

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,24 @@
+# Apache Artemis Security Policy
+
+Artemis is a project of the [Apache Software Foundation](https://apache.org) and follows the ASF [vulnerability handling process](https://apache.org/security/#vulnerability-handling).
+
+## Reporting a Vulnerability
+
+To report a new vulnerability you have discovered please follow the [ASF vulnerability reporting process](https://security.apache.org/report/).
+
+Be sure to check [Artemis' existing security advisories](https://artemis.apache.org/security-advisories) to ensure you're not reporting something that's already been resolved.
+
+## Supported Versions
+
+Security updates are provided for the following versions:
+
+| Version | Supported          |
+|---------|--------------------|
+| 2.x     | :white_check_mark: |
+| 1.x     | :x:                |
+
+We recommend always using the latest stable release to ensure you have the most recent security fixes.
+
+## Security Severity Rating system
+
+Apache Artemis uses [Apache's vulnerability severity rating system](https://security.apache.org/blog/severityrating/).


### PR DESCRIPTION
This replaces the default SECURITY.md provided by Apache. It adds some Artemis-specific context relevant for anyone looking to submit a security report.