### PR TITLE
ARTEMIS-6076 Prevent auto delete for non-empty addresses

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/postoffice/impl/PostOfficeImpl.java
@@ -1068,7 +1068,13 @@ public class PostOfficeImpl implements PostOffice, NotificationListener, Binding
    @Override
    public boolean isAddressBound(final SimpleString address) throws Exception {
       Collection<Binding> bindings = getDirectBindings(address);
-      return bindings != null && !bindings.isEmpty();
+      PagingStore pagingStore = pagingManager.getPageStore(address);
+      return (bindings != null && !bindings.isEmpty()) ||
+         // When an address has no direct bindings but the address size is > 0, it means queues on other addresses
+         // have one or more message references pointing to this address (e.g., queues bound to wildcard addresses).
+         // The address must be considered bound because these message references keep it in use, preventing
+         // operations like auto-deletion that should only occur when the address is truly unused.
+         (pagingStore != null && pagingStore.getAddressSize() > 0);
    }
 
    @Override

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoDeleteAddressTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/AutoDeleteAddressTest.java
@@ -18,18 +18,16 @@ package org.apache.activemq.artemis.tests.integration.client;
 
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.TimeUnit;
 
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
 import org.apache.activemq.artemis.api.core.client.ClientConsumer;
+import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
@@ -122,13 +120,11 @@ public class AutoDeleteAddressTest extends ActiveMQTestBase {
       String wildcardAddress = prefix + ".#";
       String queue = RandomUtil.randomUUIDString();
       final int MESSAGE_COUNT = 10;
-      final CountDownLatch latch = new CountDownLatch(MESSAGE_COUNT);
 
       server.createQueue(QueueConfiguration.of(queue).setAddress(wildcardAddress).setRoutingType(RoutingType.ANYCAST).setAutoCreated(true));
 
       ClientSession consumerSession = cf.createSession();
       ClientConsumer consumer = consumerSession.createConsumer(queue);
-      consumer.setMessageHandler(message -> latch.countDown());
       consumerSession.start();
 
       ClientSession producerSession = cf.createSession();
@@ -143,7 +139,19 @@ public class AutoDeleteAddressTest extends ActiveMQTestBase {
       }
       producerSession.close();
 
-      assertTrue(latch.await(2, TimeUnit.SECONDS));
+      PostOfficeTestAccessor.sweepAndReapAddresses((PostOfficeImpl) server.getPostOffice());
+
+      for (String address : addresses) {
+         assertNotNull(server.getAddressInfo(SimpleString.of(address)));
+         Wait.assertTrue(() -> Arrays.asList(server.getPagingManager().getStoreNames()).contains(SimpleString.of(address)), 2000, 100);
+      }
+
+      for (int i = 0; i < MESSAGE_COUNT; i++) {
+         ClientMessage message = consumer.receive(3000);
+         assertNotNull(message);
+         message.acknowledge();
+      }
+      consumer.close();
 
       for (String address : addresses) {
          assertNotNull(server.getAddressInfo(SimpleString.of(address)));

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/client/TransientQueueTest.java
@@ -78,7 +78,7 @@ public class TransientQueueTest extends SingleServerTestBase {
 
       ServerLocator locator2 = createLocator();
       ClientSessionFactory sf2 = locator2.createSessionFactory();
-      ClientSession session2 = sf2.createSession(false, false);
+      ClientSession session2 = sf2.createSession(true, true);
 
       // At this point this has no effect, other than making sure the queue exists...
       // the JMS implementation will certainly create the queue again when dealing with


### PR DESCRIPTION
When an address has no direct bindings but the address size is > 0, it means queues on other addresses have one or more message references pointing to this address (e.g., queues bound to wildcard addresses).