### PR TITLE
ARTEMIS-4692 Allow export of specific queues

### DIFF
--- a/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/xml/XmlDataExporter.java
+++ b/artemis-cli/src/main/java/org/apache/activemq/artemis/cli/commands/tools/xml/XmlDataExporter.java
@@ -85,6 +85,9 @@ public final class XmlDataExporter extends DBOption {
    @Option(names = "undefined-prefix", description = "In case a queue does not exist, this will define the prefix to be used on the message export. Default: 'UndefinedQueue_'")
    private String undefinedPrefix = "UndefinedQueue_";
 
+   @Option(names = "--queue", description = "Only export the specified queue(s). Repeatable. When omitted, all queues are exported.")
+   private List<String> queues;
+
    // an inner map of message refs hashed by the queue ID to which they belong and then hashed by their record ID
    private final Map<Long, Map<Long, ReferenceDescribe>> messageRefs = new HashMap<>();
 
@@ -112,6 +115,20 @@ public final class XmlDataExporter extends DBOption {
    public XmlDataExporter setUndefinedPrefix(String undefinedPrefix) {
       this.undefinedPrefix = undefinedPrefix;
       return this;
+   }
+
+   public List<String> getQueues() {
+      return queues;
+   }
+
+   public XmlDataExporter setQueues(List<String> queues) {
+      this.queues = queues;
+      return this;
+   }
+
+   // when no queue filter is set (null/empty) everything is exported, preserving the default behavior
+   private boolean includeQueue(String queueName) {
+      return queues == null || queues.isEmpty() || queues.contains(queueName);
    }
 
    @Override
@@ -164,6 +181,7 @@ public final class XmlDataExporter extends DBOption {
    private void writeXMLData() throws Exception {
       long start = System.currentTimeMillis();
       getBindings();
+      warnUnknownQueues();
       processMessageJournal();
       printDataAsXML();
       logger.debug("\n\nProcessing took: {}ms", (System.currentTimeMillis() - start));
@@ -328,6 +346,25 @@ public final class XmlDataExporter extends DBOption {
       bindingsJournal.stop();
    }
 
+   /**
+    * Warn about any queue name passed via {@code --queue} that doesn't exist among the real bindings, so a typo doesn't
+    * silently result in an empty export. Must run after {@link #getBindings()} but before any synthetic
+    * {@code undefinedPrefix} bindings are created.
+    */
+   private void warnUnknownQueues() {
+      if (queues == null || queues.isEmpty()) {
+         return;
+      }
+      Set<String> existing = queueBindings.values().stream()
+         .map(binding -> binding.getQueueConfiguration().getName().toString())
+         .collect(Collectors.toSet());
+      for (String queue : queues) {
+         if (!existing.contains(queue)) {
+            getActionContext().err.println("Queue '" + queue + "' was not found; nothing will be exported for it.");
+         }
+      }
+   }
+
    private void printDataAsXML() {
       try {
 
@@ -349,9 +386,20 @@ public final class XmlDataExporter extends DBOption {
    }
 
    private void printBindingsAsXML() throws XMLStreamException {
+      // when a queue filter is active only export the addresses that host at least one of the requested queues
+      Set<String> includedAddresses = (queues == null || queues.isEmpty()) ? null :
+         queueBindings.values().stream()
+            .map(PersistentQueueBindingEncoding::getQueueConfiguration)
+            .filter(queueConfig -> includeQueue(queueConfig.getName().toString()))
+            .map(queueConfig -> queueConfig.getAddress().toString())
+            .collect(Collectors.toSet());
+
       xmlWriter.writeStartElement(XmlDataConstants.BINDINGS_PARENT);
       for (Map.Entry<Long, PersistentAddressBindingEncoding> addressBindingEncodingEntry : addressBindings.entrySet()) {
          PersistentAddressBindingEncoding bindingEncoding = addressBindings.get(addressBindingEncodingEntry.getKey());
+         if (includedAddresses != null && !includedAddresses.contains(bindingEncoding.getName().toString())) {
+            continue;
+         }
          xmlWriter.writeEmptyElement(XmlDataConstants.ADDRESS_BINDINGS_CHILD);
          String routingTypes = bindingEncoding.getRoutingTypes().stream().
             map(Enum::toString).collect(Collectors.joining(","));
@@ -362,6 +410,9 @@ public final class XmlDataExporter extends DBOption {
       }
       for (Map.Entry<Long, PersistentQueueBindingEncoding> queueBindingEncodingEntry : queueBindings.entrySet()) {
          QueueConfiguration queueConfig = queueBindings.get(queueBindingEncodingEntry.getKey()).getQueueConfiguration();
+         if (!includeQueue(queueConfig.getName().toString())) {
+            continue;
+         }
          xmlWriter.writeEmptyElement(XmlDataConstants.QUEUE_BINDINGS_CHILD);
          xmlWriter.writeAttribute(XmlDataConstants.QUEUE_BINDING_ADDRESS, queueConfig.getAddress().toString());
          xmlWriter.writeAttribute(XmlDataConstants.QUEUE_BINDING_FILTER_STRING, queueConfig.getFilterString() == null ? "" : queueConfig.getFilterString().toString());
@@ -384,7 +435,12 @@ public final class XmlDataExporter extends DBOption {
       // Order here is important.  We must process the messages from the journal before we process those from the page
       // files in order to get the messages in the right order.
       for (Map.Entry<Long, Message> messageMapEntry : messages.entrySet()) {
-         printSingleMessageAsXML(messageMapEntry.getValue().toCore(), extractQueueNames(messageRefs.get(messageMapEntry.getKey())));
+         List<String> queueNames = extractQueueNames(messageRefs.get(messageMapEntry.getKey()));
+         // when a queue filter is active a message with no matching queue is dropped entirely
+         if (queueNames.isEmpty()) {
+            continue;
+         }
+         printSingleMessageAsXML(messageMapEntry.getValue().toCore(), queueNames);
          msgs++;
          if (logInterval > 0) {
             if (msgs % logInterval == 0) {
@@ -457,7 +513,9 @@ public final class XmlDataExporter extends DBOption {
                               PersistentQueueBindingEncoding queueBinding = queueBindings.get(queueID);
                               if (queueBinding != null) {
                                  SimpleString queueName = queueBinding.getQueueConfiguration().getName();
-                                 queueNames.add(queueName.toString());
+                                 if (includeQueue(queueName.toString())) {
+                                    queueNames.add(queueName.toString());
+                                 }
                               }
                            }
                         }
@@ -482,13 +540,17 @@ public final class XmlDataExporter extends DBOption {
    }
 
    private List<String> extractQueueNames(Map<Long, DescribeJournal.ReferenceDescribe> refMap) {
-      List<String> queues = new ArrayList<>();
+      List<String> queueList = new ArrayList<>();
       for (DescribeJournal.ReferenceDescribe ref : refMap.values()) {
          String queueName;
 
          long id = ref.refEncoding.queueID;
          PersistentQueueBindingEncoding persistentQueueBindingEncoding = queueBindings.get(id);
          if (persistentQueueBindingEncoding == null) {
+            // an unknown queue ID has no name that could match a --queue filter, so there's nothing to export for it
+            if (queues != null && !queues.isEmpty()) {
+               continue;
+            }
             String name = undefinedPrefix + id;
             queueBindings.put(id, new PersistentQueueBindingEncoding(QueueConfiguration.of(name).setAddress(name)));
             queueName = String.valueOf(name);
@@ -497,9 +559,11 @@ public final class XmlDataExporter extends DBOption {
             queueName = String.valueOf(persistentQueueBindingEncoding.getQueueConfiguration().getName());
          }
 
-         queues.add(queueName);
+         if (includeQueue(queueName)) {
+            queueList.add(queueName);
+         }
       }
-      return queues;
+      return queueList;
    }
 
    /**

--- a/docs/user-manual/data-tools.adoc
+++ b/docs/user-manual/data-tools.adoc
@@ -158,6 +158,7 @@ SYNOPSIS
                 [--bindings <binding>] [--jdbc] [--verbose]
                 [--jdbc-message-table-name <jdbcMessages>]
                 [--jdbc-node-manager-table-name <jdbcNodeManager>] [--output <output>]
+                [--queue <queue>]
         artemis data imp [--legacy-prefixes] [--password <password>]
                 [--transaction] [--verbose] [--port <port>] [--user <user>] [--sort]
                 --input <input> [--host <host>]
@@ -345,6 +346,9 @@ COMMANDS
             manager table
 
             With --output option, Output name for the file
+
+            With --queue option, Only export the specified queue(s). Repeatable.
+            When omitted, all queues are exported.
 
         imp
             Import all message-data using an XML that could be interpreted by

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/XmlImportExportTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/persistence/XmlImportExportTest.java
@@ -37,6 +37,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.util.EnumSet;
+import java.util.List;
 import java.util.UUID;
 
 import org.apache.activemq.artemis.api.core.Message;
@@ -67,6 +68,7 @@ import org.apache.activemq.artemis.jms.server.impl.JMSServerManagerImpl;
 import org.apache.activemq.artemis.tests.unit.util.InVMContext;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.tests.util.CFUtil;
+import org.apache.activemq.artemis.utils.CompositeAddress;
 import org.apache.activemq.artemis.utils.RandomUtil;
 import org.apache.activemq.artemis.tests.util.Wait;
 import org.apache.activemq.artemis.utils.UUIDGenerator;
@@ -723,6 +725,113 @@ public class XmlImportExportTest extends ActiveMQTestBase {
       consumer = session.createConsumer("myQueue2");
       msg = consumer.receive(CONSUMER_TIMEOUT);
       assertNotNull(msg);
+   }
+
+   @Test
+   public void testExportSpecificQueue() throws Exception {
+      ClientSession session = basicSetUp();
+
+      // queueA1 and queueA2 share addressA; queueB lives on its own address
+      session.createQueue(QueueConfiguration.of("queueA1").setAddress("addressA").setRoutingType(RoutingType.ANYCAST));
+      session.createQueue(QueueConfiguration.of("queueA2").setAddress("addressA").setRoutingType(RoutingType.ANYCAST));
+      session.createQueue(QueueConfiguration.of("queueB").setAddress("addressB").setRoutingType(RoutingType.ANYCAST));
+
+      // FQQN addressing routes each message to exactly one queue
+      sendDurableTextMessage(session, CompositeAddress.toFullyQualified("addressA", "queueA1"), "A1");
+      sendDurableTextMessage(session, CompositeAddress.toFullyQualified("addressA", "queueA2"), "A2");
+      sendDurableTextMessage(session, CompositeAddress.toFullyQualified("addressB", "queueB"), "B");
+
+      session.close();
+      locator.close();
+      server.stop();
+
+      ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
+      XmlDataExporter xmlDataExporter = new XmlDataExporter();
+      xmlDataExporter.setQueues(List.of("queueA1"));
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
+      String xml = new String(xmlOutputStream.toByteArray());
+      if (logger.isDebugEnabled()) {
+         logger.debug(xml);
+      }
+
+      // only the requested queue and the address that hosts it are exported
+      assertTrue(xml.contains("queueA1"), "expected queueA1 in export");
+      assertTrue(xml.contains("addressA"), "expected addressA in export");
+      assertFalse(xml.contains("queueA2"), "queueA2 should not be exported");
+      assertFalse(xml.contains("queueB"), "queueB should not be exported");
+      assertFalse(xml.contains("addressB"), "addressB should not be exported");
+
+      clearDataRecreateServerDirs();
+      server.start();
+      forceLong();
+      locator = createInVMNonHALocator();
+      factory = createSessionFactory(locator);
+      session = factory.createSession(false, true, true);
+
+      ByteArrayInputStream xmlInputStream = new ByteArrayInputStream(xmlOutputStream.toByteArray());
+      XmlDataImporter xmlDataImporter = new XmlDataImporter();
+      xmlDataImporter.validate(xmlInputStream);
+      xmlInputStream.reset();
+      xmlDataImporter.process(xmlInputStream, session);
+
+      // round-trip: only queueA1 was recreated, carrying only its own message
+      assertNotNull(server.locateQueue("queueA1"));
+      assertNull(server.locateQueue("queueA2"));
+      assertNull(server.locateQueue("queueB"));
+
+      ClientConsumer consumer = session.createConsumer("queueA1");
+      session.start();
+      ClientMessage msg = consumer.receive(CONSUMER_TIMEOUT);
+      assertNotNull(msg);
+      assertEquals("A1", msg.getBodyBuffer().readString());
+      assertNull(consumer.receiveImmediate());
+      consumer.close();
+   }
+
+   @Test
+   public void testExportUnknownQueueWarns() throws Exception {
+      ClientSession session = basicSetUp();
+
+      session.createQueue(QueueConfiguration.of("realQueue"));
+      ClientProducer producer = session.createProducer("realQueue");
+      producer.send(session.createMessage(true));
+
+      session.close();
+      locator.close();
+      server.stop();
+
+      ByteArrayOutputStream xmlOutputStream = new ByteArrayOutputStream();
+      XmlDataExporter xmlDataExporter = new XmlDataExporter();
+      // filtering on a queue that doesn't exist must not throw and must export nothing for it
+      xmlDataExporter.setQueues(List.of("ghostQueue"));
+      xmlDataExporter.process(xmlOutputStream, server.getConfiguration().getBindingsDirectory(), server.getConfiguration().getJournalDirectory(), server.getConfiguration().getPagingDirectory(), server.getConfiguration().getLargeMessagesDirectory());
+      String xml = new String(xmlOutputStream.toByteArray());
+      assertNull(xmlDataExporter.getLastError());
+      assertFalse(xml.contains("realQueue"), "no real queue data should be exported when filtering an unknown queue");
+
+      // the produced XML must still be valid and importable; it simply won't recreate any queue
+      clearDataRecreateServerDirs();
+      server.start();
+      forceLong();
+      locator = createInVMNonHALocator();
+      factory = createSessionFactory(locator);
+      session = factory.createSession(false, true, true);
+
+      ByteArrayInputStream xmlInputStream = new ByteArrayInputStream(xmlOutputStream.toByteArray());
+      XmlDataImporter xmlDataImporter = new XmlDataImporter();
+      xmlDataImporter.validate(xmlInputStream);
+      xmlInputStream.reset();
+      xmlDataImporter.process(xmlInputStream, session);
+
+      assertNull(server.locateQueue("realQueue"));
+   }
+
+   private void sendDurableTextMessage(ClientSession session, String address, String body) throws Exception {
+      ClientProducer producer = session.createProducer(address);
+      ClientMessage message = session.createMessage(Message.TEXT_TYPE, true);
+      message.getBodyBuffer().writeString(body);
+      producer.send(message);
+      producer.close();
    }
 
    @Test


### PR DESCRIPTION
Motivation:
  
`data exp` currently exports every queue, address binding, and message found in a broker's journal or paging store. In practice, operators often only need data from a specific queue and most commonly the Dead Letter Queue (DLQ). Today, that requires exporting everything and manually filtering the resulting XML afterward.

Modification:

Added a repeatable `--queue` option to the `data exp` command (XmlDataExporter).

When set, the exporter emits only the named queue bindings, the address
bindings that host them, and only the messages routed to those queues (each
message's `<queues>` list is trimmed to the matching queues). A `--queue` value
that matches no binding is reported on stderr so a typo doesn't silently
produce an empty export. When the option is omitted the behaviour is unchanged
(all queues are exported), and the filtered output remains valid, importable XML.

Result:

Fixes: [ARTEMIS-4692](https://issues.apache.org/jira/browse/ARTEMIS-4692)
