### PR TITLE
ARTEMIS-6094: Support YAML broker properties with native anchor/alias expansion

### DIFF
--- a/artemis-features/src/main/resources/features.xml
+++ b/artemis-features/src/main/resources/features.xml
@@ -82,6 +82,8 @@
 		<!--bundle dependency="true">mvn:io.micrometer/micrometer-core/${version.micrometer}</bundle-->
 		<bundle dependency="true">mvn:com.nimbusds/nimbus-jose-jwt/${nimbus.jwt.version}</bundle>
 
+		<bundle dependency="true">mvn:org.snakeyaml/snakeyaml-engine/${snakeyaml-engine.version}</bundle>
+
 		<bundle>mvn:org.apache.activemq/activemq-artemis-native/${activemq-artemis-native-version}</bundle>
 		<bundle>mvn:org.apache.artemis/artemis-lockmanager-api/${pom.version}</bundle>
 		<bundle>mvn:org.apache.artemis/artemis-server-osgi/${pom.version}</bundle>

--- a/artemis-pom/pom.xml
+++ b/artemis-pom/pom.xml
@@ -937,6 +937,13 @@
          </dependency>
 
          <dependency>
+            <groupId>org.snakeyaml</groupId>
+            <artifactId>snakeyaml-engine</artifactId>
+            <version>${snakeyaml-engine.version}</version>
+            <!-- Apache 2.0 License -->
+         </dependency>
+
+         <dependency>
             <groupId>com.fasterxml.jackson</groupId>
             <artifactId>jackson-bom</artifactId>
             <version>${jackson.version}</version>

--- a/artemis-server/pom.xml
+++ b/artemis-server/pom.xml
@@ -145,6 +145,10 @@
          <artifactId>commons-beanutils</artifactId>
       </dependency>
       <dependency>
+         <groupId>org.snakeyaml</groupId>
+         <artifactId>snakeyaml-engine</artifactId>
+      </dependency>
+      <dependency>
          <groupId>org.apache.commons</groupId>
          <artifactId>commons-lang3</artifactId>
       </dependency>

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImpl.java
@@ -138,6 +138,9 @@ import org.apache.activemq.artemis.json.JsonObject;
 import org.apache.activemq.artemis.json.JsonObjectBuilder;
 import org.apache.activemq.artemis.json.JsonString;
 import org.apache.activemq.artemis.json.JsonValue;
+import org.snakeyaml.engine.v2.api.Load;
+import org.snakeyaml.engine.v2.api.LoadSettings;
+
 import org.apache.activemq.artemis.utils.ByteUtil;
 import org.apache.activemq.artemis.utils.ClassloadingUtil;
 import org.apache.activemq.artemis.utils.Env;
@@ -497,7 +500,7 @@ public class ConfigurationImpl extends javax.security.auth.login.Configuration i
    private File artemisInstance;
    private transient JsonObject jsonStatus = JsonLoader.createObjectBuilder().build();
    private final Set<String> keysToRedact = new HashSet<>();
-   private static final Pattern defaultPropertiesFileNamePattern = Pattern.compile(".*\\.(json|properties)");
+   private static final Pattern defaultPropertiesFileNamePattern = Pattern.compile(".*\\.(json|yaml|properties)");
 
    private JsonObject getJsonStatus() {
       if (jsonStatus == null) {
@@ -625,8 +628,11 @@ public class ConfigurationImpl extends javax.security.auth.login.Configuration i
       InsertionOrderedProperties brokerProperties = new InsertionOrderedProperties();
       try (CheckedInputStream checkedInputStream = new CheckedInputStream(new FileInputStream(file), new Adler32())) {
          try {
-            if (file.getName().endsWith(".json")) {
+            String fileName = file.getName();
+            if (fileName.endsWith(".json")) {
                brokerProperties.loadJson(configuration, checkedInputStream);
+            } else if (fileName.endsWith(".yaml")) {
+               brokerProperties.loadYaml(configuration, checkedInputStream);
             } else {
                brokerProperties.load(checkedInputStream);
             }
@@ -3880,6 +3886,49 @@ public class ConfigurationImpl extends javax.security.auth.login.Configuration i
          loadJsonObject(surroundString, "", jsonObject);
 
          return true;
+      }
+
+      public synchronized boolean loadYaml(ConfigurationImpl configuration, InputStream inputStream) {
+         LoadSettings settings = LoadSettings.builder()
+            .setMaxAliasesForCollections(50)
+            .setCodePointLimit(3 * 1024 * 1024)
+            .build();
+         Load yamlLoad = new Load(settings);
+         @SuppressWarnings("unchecked")
+         Map<String, Object> yamlMap = (Map<String, Object>) yamlLoad.loadFromInputStream(inputStream);
+         if (yamlMap == null) {
+            return false;
+         }
+         final String surroundString = determineSurroundString(configuration, yamlMap);
+         loadYamlMap(surroundString, "", yamlMap);
+         return true;
+      }
+
+      @SuppressWarnings("unchecked")
+      private void loadYamlMap(String keySurroundString, String parentKey, Map<String, Object> map) {
+         for (Map.Entry<String, Object> entry : map.entrySet()) {
+            String key = entry.getKey();
+            key = autoSurroundIfNecessary(key, keySurroundString);
+            String propertyKey = parentKey + key;
+            Object value = entry.getValue();
+            if (value instanceof Map) {
+               loadYamlMap(keySurroundString, propertyKey + ".", (Map<String, Object>) value);
+            } else if (value != null) {
+               put(propertyKey, String.valueOf(value));
+            }
+         }
+      }
+
+      private String determineSurroundString(ConfigurationImpl configuration, Map<String, Object> yamlMap) {
+         Object surroundValue = yamlMap.get(ActiveMQDefaultConfiguration.BROKER_PROPERTIES_KEY_SURROUND_PROPERTY);
+         if (surroundValue != null) {
+            return String.valueOf(surroundValue);
+         }
+         Object brokerSurroundValue = yamlMap.get("brokerPropertiesKeySurround");
+         if (brokerSurroundValue != null) {
+            return String.valueOf(brokerSurroundValue);
+         }
+         return configuration.getBrokerPropertiesKeySurround();
       }
 
       private void loadJsonObject(String keySurroundString, String parentKey, JsonObject jsonObject) {

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/config/impl/ConfigurationImplTest.java
@@ -2589,6 +2589,147 @@ public class ConfigurationImplTest extends AbstractConfigurationTestBase {
       assertEquals("$$", configuration.getBrokerPropertiesKeySurround());
    }
 
+   @Test
+   public void testYamlSecurityRolesWithAnchors() throws Exception {
+
+      File tmpFile = File.createTempFile("yaml-security-roles-test", ".yaml", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+         printWriter.write("""
+            securityRoles:
+              "TEMP.*":
+                role1: &base_perms
+                  createAddress: true
+                  send: true
+                  consume: true
+                  createNonDurableQueue: true
+                role2: *base_perms
+                role3: *base_perms
+            """);
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      assertTrue(configuration.getStatus().contains("\"errors\":[]"), configuration.getStatus());
+
+      Set<Role> roles = configuration.getSecurityRoles().get("TEMP.*");
+      assertNotNull(roles, "Expected security roles for TEMP.*");
+      assertEquals(3, roles.size(), "Expected 3 roles under TEMP.*");
+
+      for (String roleName : new String[]{"role1", "role2", "role3"}) {
+         Role role = roles.stream()
+            .filter(r -> r.getName().equals(roleName))
+            .findFirst()
+            .orElse(null);
+         assertNotNull(role, "Missing role: " + roleName);
+         assertTrue(role.isCreateAddress(), roleName + " should have createAddress");
+         assertTrue(role.isSend(), roleName + " should have send");
+         assertTrue(role.isConsume(), roleName + " should have consume");
+         assertTrue(role.isCreateNonDurableQueue(), roleName + " should have createNonDurableQueue");
+      }
+   }
+
+   @Test
+   public void testYamlPropertiesReaderFromFile() throws Exception {
+
+      File tmpFile = File.createTempFile("yaml-props-test", ".yaml", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+         printWriter.write("""
+            globalMaxSize: "25K"
+            gracefulShutdownEnabled: true
+            securityEnabled: false
+            """);
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      assertTrue(configuration.getStatus().contains("\"errors\":[]"), configuration.getStatus());
+      assertEquals(25 * 1024, configuration.getGlobalMaxSize());
+      assertTrue(configuration.isGracefulShutdownEnabled());
+      assertFalse(configuration.isSecurityEnabled());
+   }
+
+   @Test
+   public void testInvalidYamlPropertiesReaderFromFile() throws Exception {
+
+      File tmpFile = File.createTempFile("yaml-props-test", ".yaml", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+         printWriter.write("{ invalid yaml: [}");
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      assertFalse(configuration.getStatus().contains(".yaml\":{\"errors\":[]"), configuration.getStatus());
+   }
+
+   @Test
+   public void testYamlBillionLaughsRejected() throws Exception {
+
+      File tmpFile = File.createTempFile("yaml-bomb-test", ".yaml", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+         StringBuilder sb = new StringBuilder();
+         sb.append("a: &a [\"lol\"]\n");
+         for (int i = 1; i <= 60; i++) {
+            char prev = (char) ('a' + i - 1);
+            char curr = (char) ('a' + i);
+            sb.append(curr).append(": &").append(curr)
+               .append(" [*").append(prev).append(", *").append(prev)
+               .append(", *").append(prev).append("]\n");
+         }
+         printWriter.write(sb.toString());
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      assertTrue(configuration.getStatus().contains("loadError"), configuration.getStatus());
+   }
+
+   @Test
+   public void testYamlPropertiesKeySurround() throws Exception {
+
+      File tmpFile = File.createTempFile("yaml-surround-props-test", ".yaml", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+         printWriter.write("""
+            key.surround: "$$"
+            addressSettings:
+              $$a."with_quote".b$$:
+                maxDeliveryAttempts: 0
+            """);
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      assertEquals(0, configuration.getAddressSettings().get("a.\"with_quote\".b").getMaxDeliveryAttempts());
+   }
+
+   @Test
+   public void testYamlPropertiesAutoSurround() throws Exception {
+
+      File tmpFile = File.createTempFile("yaml-auto-surround-props-test", ".yaml", temporaryFolder);
+      try (FileOutputStream fileOutputStream = new FileOutputStream(tmpFile);
+           PrintWriter printWriter = new PrintWriter(fileOutputStream)) {
+         printWriter.write("""
+            addressSettings:
+              a.b.c:
+                maxDeliveryAttempts: 2
+            """);
+      }
+
+      ConfigurationImpl configuration = new ConfigurationImpl();
+      configuration.parseProperties(tmpFile.getAbsolutePath());
+
+      assertEquals(2, configuration.getAddressSettings().get("a.b.c").getMaxDeliveryAttempts());
+   }
+
    private JsonObject buildSimpleConfigJsonObject() {
       JsonObjectBuilder configObjectBuilder = JsonLoader.createObjectBuilder();
       {

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,7 @@
       <arquillian-weld-embedded.version>2.1.0.Final</arquillian-weld-embedded.version>
       <owb.version>2.0.28</owb.version>
       <arquillian.version>1.10.2.Final</arquillian.version>
+      <snakeyaml-engine.version>2.10</snakeyaml-engine.version>
       <servicemix.json-1.1.spec.version>2.9.0</servicemix.json-1.1.spec.version>
       <version.org.jacoco>0.8.14</version.org.jacoco>
       <version.org.jacoco.plugin>0.8.14</version.org.jacoco.plugin>


### PR DESCRIPTION
Add YAML (.yaml/.yml) as a broker properties file format alongside the existing .properties and .json formats. YAML files are parsed via SnakeYAML Engine (2.10), which natively resolves anchors and aliases at parse time, enabling role/config reuse without custom macro logic.

This allows configurations like:

```
  securityRoles:
    "TEMP.*":
      role1: &base_perms
        createAddress: true
        send: true
        consume: true
        createNonDurableQueue: true
      role2: *base_perms
      role3: *base_perms
```

Changes:
- Add snakeyaml-engine dependency root pom, artemis-pom, artemis-server
- Extend defaultPropertiesFileNamePattern to accept .yaml/.yml
- Add YAML dispatch branch in parseFileProperties()
- Implement loadYaml() on InsertionOrderedProperties with recursive map flattening and key.surround support mirrors loadJson()
- Add tests: anchor/alias security roles, basic YAML parsing, invalid YAML error handling