### PR TITLE
ARTEMIS-6099 Add log message when configuration reload is complete

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/ActiveMQServerLogger.java
@@ -323,6 +323,9 @@ public interface ActiveMQServerLogger {
    @LogMessage(id = 221086, value = "Cannot route {}", level = LogMessage.Level.INFO)
    void cannotRouteClientConnection(Connection connection);
 
+   @LogMessage(id = 221087, value = "Configuration reload completed", level = LogMessage.Level.INFO)
+   void configurationReloadCompleted();
+
    @LogMessage(id = 222000, value = "ActiveMQServer is being finalized and has not been stopped. Please remember to stop the server before letting it go out of scope", level = LogMessage.Level.WARN)
    void serverFinalisedWIthoutBeingSTopped();
 

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -4887,6 +4887,8 @@ public class ActiveMQServerImpl implements ActiveMQServer {
 
          ActiveMQServerLogger.LOGGER.reloadingConfiguration("protocol services");
          updateProtocolServices();
+
+         ActiveMQServerLogger.LOGGER.configurationReloadCompleted();
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/jms/RedeployTest.java
@@ -79,6 +79,7 @@ import org.apache.activemq.artemis.core.settings.impl.AddressFullMessagePolicy;
 import org.apache.activemq.artemis.core.settings.impl.AddressSettings;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.jms.client.ActiveMQDestination;
+import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
 import org.apache.activemq.artemis.protocol.amqp.connect.AMQPBrokerConnection;
 import org.apache.activemq.artemis.tests.unit.core.postoffice.impl.fakes.FakeQueue;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
@@ -2349,4 +2350,19 @@ public class RedeployTest extends ActiveMQTestBase {
           org.apache.activemq.artemis.core.server.Queue::getName).map(SimpleString::toString).collect(Collectors.toList());
    }
 
+   @Test
+   public void testReloadCompletion() throws Exception {
+      final EmbeddedActiveMQ embeddedActiveMQ = createEmbeddedActiveMQServer("reload-queue-filter.xml");
+      embeddedActiveMQ.start();
+      try {
+         try (AssertionLoggerHandler loggerHandler = new AssertionLoggerHandler()) {
+            deployBrokerConfig(embeddedActiveMQ, "reload-queue-filter.xml");
+
+            Wait.assertTrue(() -> loggerHandler.findText("AMQ221087", "Configuration reload completed"), 2000, 100);
+            assertEquals(1, loggerHandler.countText("Configuration reload completed"));
+         }
+      } finally {
+         embeddedActiveMQ.stop();
+      }
+   }
 }


### PR DESCRIPTION
Summary:
Adds a new INFO-level log message (AMQ221087) that is emitted when the entire configuration reload operation completes.

Problem:
Currently, the broker logs individual configuration reload steps (AMQ221056) but does not log when the entire reload operation completes. This makes it difficult to determine when the broker is ready for status checks after a configuration reload.

Changes:
- Added a new log message: `AMQ221087: Configuration reload completed` in `ActiveMQServerLogger`
- Log is emitted in `ActiveMQServerImpl.reloadConfigurationFile()` after all reload operations finish 
- Added integration test: `RedeployTest.testReloadCompletion()` to verify the log message appears exactly once

Testing:
- 'testReloadCompletion()' validates the log message is emitted and passes successfully