### PR TITLE
ARTEMIS-6118 Add a Model Context Protocol (MCP) server for Artemis

### DIFF
--- a/artemis-mcp-server/pom.xml
+++ b/artemis-mcp-server/pom.xml
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+  ~ Licensed to the Apache Software Foundation (ASF) under one or more
+  ~ contributor license agreements. See the NOTICE file distributed with
+  ~ this work for additional information regarding copyright ownership.
+  ~ The ASF licenses this file to You under the Apache License, Version 2.0
+  ~ (the "License"); you may not use this file except in compliance with
+  ~ the License. You may obtain a copy of the License at
+  ~
+  ~     http://www.apache.org/licenses/LICENSE-2.0
+  ~
+  ~ Unless required by applicable law or agreed to in writing, software
+  ~ distributed under the License is distributed on an "AS IS" BASIS,
+  ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  ~ See the License for the specific language governing permissions and
+  ~ limitations under the License.
+  -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
+
+   <parent>
+      <groupId>org.apache.artemis</groupId>
+      <artifactId>artemis-pom</artifactId>
+      <version>2.55.0-SNAPSHOT</version>
+      <relativePath>../artemis-pom/pom.xml</relativePath>
+   </parent>
+
+   <artifactId>artemis-mcp-server</artifactId>
+   <packaging>jar</packaging>
+   <name>Apache Artemis MCP Server</name>
+
+   <properties>
+      <mcp.sdk.version>2.0.0</mcp.sdk.version>
+   </properties>
+
+   <dependencyManagement>
+      <dependencies>
+         <dependency>
+            <groupId>io.modelcontextprotocol.sdk</groupId>
+            <artifactId>mcp-bom</artifactId>
+            <version>${mcp.sdk.version}</version>
+            <type>pom</type>
+            <scope>import</scope>
+         </dependency>
+      </dependencies>
+   </dependencyManagement>
+
+   <dependencies>
+      <dependency>
+         <groupId>io.modelcontextprotocol.sdk</groupId>
+         <artifactId>mcp</artifactId>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.artemis</groupId>
+         <artifactId>artemis-jms-client</artifactId>
+         <version>${project.version}</version>
+      </dependency>
+
+      <dependency>
+         <groupId>org.slf4j</groupId>
+         <artifactId>slf4j-simple</artifactId>
+         <scope>runtime</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.apache.artemis</groupId>
+         <artifactId>artemis-server</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+      <dependency>
+         <groupId>org.junit.jupiter</groupId>
+         <artifactId>junit-jupiter</artifactId>
+         <scope>test</scope>
+      </dependency>
+   </dependencies>
+</project>

--- a/artemis-mcp-server/readme.md
+++ b/artemis-mcp-server/readme.md
@@ -1,0 +1,88 @@
+# Artemis MCP Server (ARTEMIS-6118)
+
+Model Context Protocol (MCP) server exposing Apache ActiveMQ Artemis broker operations as tools
+for AI agents, over the STDIO transport.
+
+## Tools
+
+Read-only tools (always available):
+
+| Tool | Args | Description |
+|---|---|---|
+| `list_queues` | — | Names of all queues on the broker. |
+| `list_addresses` | — | Names of all addresses on the broker. |
+| `get_broker_overview` | — | Version, uptime, connection/consumer/message counts. |
+| `get_queue_stats` | `queue` | Message and consumer counters for one queue. |
+| `browse_messages` | `queue`, `limit?`, `selector?` | Browse a queue without consuming (non-destructive). |
+
+Admin tools (only registered when `mode=admin`):
+
+| Tool | Args | Description |
+|---|---|---|
+| `create_queue` | `name`, `address?`, `routingType?`, `durable?` | Create a queue. |
+| `create_address` | `name`, `routingType?` | Create an address. |
+| `delete_queue` | `name`, `confirm` | Delete a queue (destructive). |
+| `delete_address` | `name`, `confirm` | Delete an address (destructive). |
+| `purge_queue` | `queue`, `confirm` | Remove all messages from a queue (destructive). |
+| `delete_messages` | `queue`, `confirm`, `filter?` | Remove messages matching a filter (destructive). |
+| `move_messages` | `queue`, `target`, `confirm`, `filter?` | Move messages to another queue (destructive). |
+| `retry_dlq` | `queue`, `confirm` | Retry messages, redelivering to their original address. |
+| `send_message` | `target`, `body`, `properties?`, `durable?` | Send a text message to a queue or address. |
+| `consume_message` | `queue`, `confirm`, `limit?`, `selector?`, `timeoutMillis?` | Consume (remove) messages from a queue (destructive). |
+
+Destructive admin tools require `confirm: true`; the requirement is enforced both by the tool
+input schema and by the handler.
+
+## Configuration
+
+Resolved from system properties first, then environment variables, then defaults.
+
+| System property | Env var | Default |
+|---|---|---|
+| `artemis.mcp.brokerUrl` | `ARTEMIS_MCP_BROKER_URL` | `tcp://localhost:61616` |
+| `artemis.mcp.user` | `ARTEMIS_MCP_USER` | — |
+| `artemis.mcp.password` | `ARTEMIS_MCP_PASSWORD` | — |
+| `artemis.mcp.mode` | `ARTEMIS_MCP_MODE` | `read-only` |
+| `artemis.mcp.browseLimit` | `ARTEMIS_MCP_BROWSE_LIMIT` | `50` |
+
+## Build & test
+
+```bash
+mvn clean install
+```
+
+Integration tests run against an in-VM embedded broker, so no external broker is required.
+
+## Run
+
+The server speaks JSON-RPC over STDIO. Logs go to stderr (stdout is reserved for the protocol).
+
+```bash
+java -cp "target/classes:$(cat target/cp.txt)" \
+  org.apache.activemq.artemis.mcp.ArtemisMcpServer
+```
+
+## Design
+
+- Monitoring/management uses Artemis management messages sent to `activemq.management`
+  (single broker connection, no open JMX required).
+- Messaging uses the Core/JMS client; `browse_messages` uses a JMS `QueueBrowser`.
+- The MCP layer uses the MCP Java SDK (MIT / ASF Category A).
+
+## Reactor integration (for the PR)
+
+This module ships with a standalone POM for fast iteration. To contribute it to the
+`apache/activemq-artemis` reactor, replace the `<groupId>`/`<version>`/`<properties>` block in
+`pom.xml` with the reactor parent:
+
+```xml
+<parent>
+   <groupId>org.apache.artemis</groupId>
+   <artifactId>artemis-pom</artifactId>
+   <version>${project.version}</version>
+   <relativePath>../artemis-pom/pom.xml</relativePath>
+</parent>
+```
+
+Since the Artemis TLP migration the Maven groupId is `org.apache.artemis`
+(the old `org.apache.activemq` coordinates are relocation stubs).

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/ArtemisMcpServer.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/ArtemisMcpServer.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp;
+
+import java.util.concurrent.CountDownLatch;
+
+import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.server.McpServer;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServer;
+import io.modelcontextprotocol.server.transport.StdioServerTransportProvider;
+import io.modelcontextprotocol.spec.McpSchema.ServerCapabilities;
+import org.apache.activemq.artemis.mcp.admin.ArtemisAdminClient;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig;
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+import org.apache.activemq.artemis.mcp.management.ArtemisManagementClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisBrowseClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisMessagingClient;
+import org.apache.activemq.artemis.mcp.tools.ArtemisMcpTools;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public final class ArtemisMcpServer {
+
+   private static final Logger LOG = LoggerFactory.getLogger(ArtemisMcpServer.class);
+
+   private final ArtemisMcpConfig config;
+   private final ArtemisConnectionManager connectionManager;
+   private McpSyncServer server;
+
+   public ArtemisMcpServer(ArtemisMcpConfig config) {
+      this.config = config;
+      this.connectionManager = new ArtemisConnectionManager(config);
+   }
+
+   public McpSyncServer start() {
+      ArtemisManagementClient management = new ArtemisManagementClient(connectionManager);
+      ArtemisBrowseClient browse = new ArtemisBrowseClient(connectionManager);
+      ArtemisMessagingClient messaging = new ArtemisMessagingClient(connectionManager);
+      ArtemisAdminClient admin = new ArtemisAdminClient(connectionManager);
+      ArtemisMcpTools tools = new ArtemisMcpTools(config, management, browse, messaging, admin);
+
+      StdioServerTransportProvider transport = new StdioServerTransportProvider(McpJsonDefaults.getMapper());
+
+      this.server = McpServer.sync(transport)
+         .serverInfo("artemis-mcp-server", "1.0.0")
+         .instructions(config.isAdmin()
+            ? "Tools to inspect, monitor and administer an Apache ActiveMQ Artemis broker. "
+               + "Destructive tools require confirm=true."
+            : "Tools to inspect and monitor an Apache ActiveMQ Artemis broker. "
+               + "All tools in this build are read-only.")
+         .capabilities(ServerCapabilities.builder().tools(true).build())
+         .tools(tools.specifications().toArray(new SyncToolSpecification[0]))
+         .build();
+
+      LOG.info("Artemis MCP server started (mode={}, broker={})", config.mode(), config.brokerUrl());
+      return server;
+   }
+
+   public void stop() {
+      if (server != null) {
+         server.closeGracefully();
+      }
+      connectionManager.close();
+   }
+
+   public static void main(String[] args) throws InterruptedException {
+      ArtemisMcpConfig config = ArtemisMcpConfig.fromEnvironment();
+      ArtemisMcpServer mcpServer = new ArtemisMcpServer(config);
+
+      CountDownLatch shutdownLatch = new CountDownLatch(1);
+      Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+         mcpServer.stop();
+         shutdownLatch.countDown();
+      }, "artemis-mcp-shutdown"));
+
+      mcpServer.start();
+      shutdownLatch.await();
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/admin/ArtemisAdminClient.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/admin/ArtemisAdminClient.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.admin;
+
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+import org.apache.activemq.artemis.mcp.management.ManagementInvoker;
+
+public final class ArtemisAdminClient {
+
+   private final ManagementInvoker invoker;
+
+   public ArtemisAdminClient(ArtemisConnectionManager connectionManager) {
+      this.invoker = new ManagementInvoker(connectionManager);
+   }
+
+   public Object createQueue(String name, String address, String routingType, boolean durable) throws Exception {
+      String targetAddress = (address == null || address.isBlank()) ? name : address;
+      return invoker.operation(ResourceNames.BROKER, "createQueue",
+         targetAddress, routingType, name, null, durable, -1, false, true);
+   }
+
+   public void deleteQueue(String name) throws Exception {
+      invoker.operation(ResourceNames.BROKER, "destroyQueue", name);
+   }
+
+   public Object createAddress(String name, String routingType) throws Exception {
+      return invoker.operation(ResourceNames.BROKER, "createAddress", name, routingType);
+   }
+
+   public void deleteAddress(String name) throws Exception {
+      invoker.operation(ResourceNames.BROKER, "deleteAddress", name);
+   }
+
+   public int purgeQueue(String queueName) throws Exception {
+      return toInt(invoker.operation(ResourceNames.QUEUE + queueName, "removeAllMessages"));
+   }
+
+   public int deleteMessages(String queueName, String filter) throws Exception {
+      return toInt(invoker.operation(ResourceNames.QUEUE + queueName, "removeMessages", filter));
+   }
+
+   public int moveMessages(String queueName, String filter, String targetQueue) throws Exception {
+      return toInt(invoker.operation(ResourceNames.QUEUE + queueName, "moveMessages", filter, targetQueue));
+   }
+
+   public int retryMessages(String queueName) throws Exception {
+      return toInt(invoker.operation(ResourceNames.QUEUE + queueName, "retryMessages"));
+   }
+
+   private static int toInt(Object value) {
+      return value instanceof Number number ? number.intValue() : 0;
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/config/ArtemisMcpConfig.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/config/ArtemisMcpConfig.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.config;
+
+public final class ArtemisMcpConfig {
+
+   public enum Mode {
+      READ_ONLY,
+      ADMIN;
+
+      static Mode parse(String value) {
+         if (value == null || value.isBlank()) {
+            return READ_ONLY;
+         }
+         String normalized = value.trim().toUpperCase().replace('-', '_');
+         return Mode.valueOf(normalized);
+      }
+   }
+
+   private final String brokerUrl;
+   private final String user;
+   private final String password;
+   private final Mode mode;
+   private final int defaultBrowseLimit;
+
+   public ArtemisMcpConfig(String brokerUrl, String user, String password, Mode mode, int defaultBrowseLimit) {
+      this.brokerUrl = brokerUrl;
+      this.user = user;
+      this.password = password;
+      this.mode = mode;
+      this.defaultBrowseLimit = defaultBrowseLimit;
+   }
+
+   public static ArtemisMcpConfig fromEnvironment() {
+      String brokerUrl = resolve("artemis.mcp.brokerUrl", "ARTEMIS_MCP_BROKER_URL", "tcp://localhost:61616");
+      String user = resolve("artemis.mcp.user", "ARTEMIS_MCP_USER", null);
+      String password = resolve("artemis.mcp.password", "ARTEMIS_MCP_PASSWORD", null);
+      Mode mode = Mode.parse(resolve("artemis.mcp.mode", "ARTEMIS_MCP_MODE", null));
+      int browseLimit = parseInt(resolve("artemis.mcp.browseLimit", "ARTEMIS_MCP_BROWSE_LIMIT", "50"), 50);
+      return new ArtemisMcpConfig(brokerUrl, user, password, mode, browseLimit);
+   }
+
+   private static String resolve(String sysProp, String envVar, String defaultValue) {
+      String value = System.getProperty(sysProp);
+      if (value == null || value.isBlank()) {
+         value = System.getenv(envVar);
+      }
+      return (value == null || value.isBlank()) ? defaultValue : value;
+   }
+
+   private static int parseInt(String value, int defaultValue) {
+      try {
+         return value == null ? defaultValue : Integer.parseInt(value.trim());
+      } catch (NumberFormatException e) {
+         return defaultValue;
+      }
+   }
+
+   public String brokerUrl() {
+      return brokerUrl;
+   }
+
+   public String user() {
+      return user;
+   }
+
+   public String password() {
+      return password;
+   }
+
+   public Mode mode() {
+      return mode;
+   }
+
+   public boolean isAdmin() {
+      return mode == Mode.ADMIN;
+   }
+
+   public int defaultBrowseLimit() {
+      return defaultBrowseLimit;
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/connection/ArtemisConnectionManager.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/connection/ArtemisConnectionManager.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.connection;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig;
+
+public final class ArtemisConnectionManager implements AutoCloseable {
+
+   private final ArtemisMcpConfig config;
+   private volatile ActiveMQConnectionFactory factory;
+
+   public ArtemisConnectionManager(ArtemisMcpConfig config) {
+      this.config = config;
+   }
+
+   private ActiveMQConnectionFactory factory() {
+      ActiveMQConnectionFactory current = factory;
+      if (current == null) {
+         synchronized (this) {
+            current = factory;
+            if (current == null) {
+               current = new ActiveMQConnectionFactory(config.brokerUrl());
+               factory = current;
+            }
+         }
+      }
+      return current;
+   }
+
+   public Connection newStartedConnection() throws JMSException {
+      Connection connection;
+      if (config.user() != null) {
+         connection = factory().createConnection(config.user(), config.password());
+      } else {
+         connection = factory().createConnection();
+      }
+      try {
+         connection.start();
+      } catch (JMSException e) {
+         try {
+            connection.close();
+         } catch (JMSException ignored) {
+         }
+         throw e;
+      }
+      return connection;
+   }
+
+   @Override
+   public synchronized void close() {
+      if (factory != null) {
+         factory.close();
+         factory = null;
+      }
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/management/ArtemisManagementClient.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/management/ArtemisManagementClient.java
@@ -1,0 +1,84 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.management;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.api.core.management.ResourceNames;
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+
+public final class ArtemisManagementClient {
+
+   private final ManagementInvoker invoker;
+
+   public ArtemisManagementClient(ArtemisConnectionManager connectionManager) {
+      this.invoker = new ManagementInvoker(connectionManager);
+   }
+
+   public List<String> listQueues() throws Exception {
+      return toStringList(invoker.attribute(ResourceNames.BROKER, "queueNames"));
+   }
+
+   public List<String> listAddresses() throws Exception {
+      return toStringList(invoker.attribute(ResourceNames.BROKER, "addressNames"));
+   }
+
+   public Map<String, Object> queueStats(String queueName) throws Exception {
+      String resource = ResourceNames.QUEUE + queueName;
+      Map<String, Object> stats = new LinkedHashMap<>();
+      stats.put("name", queueName);
+      stats.put("address", invoker.attribute(resource, "address"));
+      stats.put("routingType", invoker.attribute(resource, "routingType"));
+      stats.put("durable", invoker.attribute(resource, "durable"));
+      stats.put("messageCount", invoker.attribute(resource, "messageCount"));
+      stats.put("consumerCount", invoker.attribute(resource, "consumerCount"));
+      stats.put("messagesAdded", invoker.attribute(resource, "messagesAdded"));
+      stats.put("messagesAcknowledged", invoker.attribute(resource, "messagesAcknowledged"));
+      stats.put("messagesExpired", invoker.attribute(resource, "messagesExpired"));
+      return stats;
+   }
+
+   public Map<String, Object> brokerOverview() throws Exception {
+      Map<String, Object> overview = new LinkedHashMap<>();
+      overview.put("version", invoker.attribute(ResourceNames.BROKER, "version"));
+      overview.put("nodeId", invoker.attribute(ResourceNames.BROKER, "nodeID"));
+      overview.put("uptime", invoker.attribute(ResourceNames.BROKER, "uptime"));
+      overview.put("active", invoker.attribute(ResourceNames.BROKER, "active"));
+      overview.put("totalConnectionCount", invoker.attribute(ResourceNames.BROKER, "totalConnectionCount"));
+      overview.put("totalConsumerCount", invoker.attribute(ResourceNames.BROKER, "totalConsumerCount"));
+      overview.put("totalMessageCount", invoker.attribute(ResourceNames.BROKER, "totalMessageCount"));
+      overview.put("addressMemoryUsage", invoker.attribute(ResourceNames.BROKER, "addressMemoryUsage"));
+      overview.put("queueCount", listQueues().size());
+      overview.put("addressCount", listAddresses().size());
+      return overview;
+   }
+
+   private static List<String> toStringList(Object result) {
+      List<String> names = new ArrayList<>();
+      if (result instanceof Object[] array) {
+         for (Object element : array) {
+            if (element != null) {
+               names.add(element.toString());
+            }
+         }
+      }
+      return names;
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/management/ManagementInvoker.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/management/ManagementInvoker.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.management;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueConnection;
+import javax.jms.QueueRequestor;
+import javax.jms.QueueSession;
+import javax.jms.Session;
+
+import org.apache.activemq.artemis.api.jms.management.JMSManagementHelper;
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+
+public final class ManagementInvoker {
+
+   public static final String MANAGEMENT_ADDRESS = "activemq.management";
+
+   private final ArtemisConnectionManager connectionManager;
+
+   public ManagementInvoker(ArtemisConnectionManager connectionManager) {
+      this.connectionManager = connectionManager;
+   }
+
+   public Object attribute(String resourceName, String attribute) throws Exception {
+      return request(message -> JMSManagementHelper.putAttribute(message, resourceName, attribute),
+         resourceName + "." + attribute);
+   }
+
+   public Object operation(String resourceName, String operationName, Object... parameters) throws Exception {
+      return request(message -> JMSManagementHelper.putOperationInvocation(message, resourceName, operationName, parameters),
+         resourceName + "#" + operationName);
+   }
+
+   @FunctionalInterface
+   private interface Preparer {
+      void prepare(Message message) throws Exception;
+   }
+
+   private Object request(Preparer preparer, String label) throws Exception {
+      try (Connection connection = connectionManager.newStartedConnection()) {
+         QueueSession session = ((QueueConnection) connection).createQueueSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue managementQueue = session.createQueue(MANAGEMENT_ADDRESS);
+         QueueRequestor requestor = new QueueRequestor(session, managementQueue);
+         try {
+            Message request = session.createMessage();
+            preparer.prepare(request);
+            Message reply = requestor.request(request);
+            if (!JMSManagementHelper.hasOperationSucceeded(reply)) {
+               throw new JMSException("Management call failed for " + label + ": "
+                  + JMSManagementHelper.getResult(reply));
+            }
+            return JMSManagementHelper.getResult(reply);
+         } finally {
+            requestor.close();
+         }
+      }
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/messaging/ArtemisBrowseClient.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/messaging/ArtemisBrowseClient.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.messaging;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.Queue;
+import javax.jms.QueueBrowser;
+import javax.jms.Session;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+
+public final class ArtemisBrowseClient {
+
+   private final ArtemisConnectionManager connectionManager;
+
+   public ArtemisBrowseClient(ArtemisConnectionManager connectionManager) {
+      this.connectionManager = connectionManager;
+   }
+
+   public List<Map<String, Object>> browse(String queueName, int limit, String selector) throws JMSException {
+      List<Map<String, Object>> messages = new ArrayList<>();
+      try (Connection connection = connectionManager.newStartedConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(queueName);
+         QueueBrowser browser = (selector == null || selector.isBlank())
+            ? session.createBrowser(queue)
+            : session.createBrowser(queue, selector);
+         try {
+            Enumeration<?> enumeration = browser.getEnumeration();
+            int count = 0;
+            while (enumeration.hasMoreElements() && count < limit) {
+               Message message = (Message) enumeration.nextElement();
+               messages.add(MessageView.describe(message));
+               count++;
+            }
+         } finally {
+            browser.close();
+         }
+      }
+      return messages;
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/messaging/ArtemisMessagingClient.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/messaging/ArtemisMessagingClient.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.messaging;
+
+import javax.jms.Connection;
+import javax.jms.DeliveryMode;
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.MessageConsumer;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+
+public final class ArtemisMessagingClient {
+
+   private final ArtemisConnectionManager connectionManager;
+
+   public ArtemisMessagingClient(ArtemisConnectionManager connectionManager) {
+      this.connectionManager = connectionManager;
+   }
+
+   public Map<String, Object> send(String target, String body, Map<String, Object> properties, boolean durable)
+      throws JMSException {
+      try (Connection connection = connectionManager.newStartedConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(target);
+         MessageProducer producer = session.createProducer(queue);
+         producer.setDeliveryMode(durable ? DeliveryMode.PERSISTENT : DeliveryMode.NON_PERSISTENT);
+         TextMessage message = session.createTextMessage(body);
+         if (properties != null) {
+            for (Map.Entry<String, Object> entry : properties.entrySet()) {
+               message.setObjectProperty(entry.getKey(), entry.getValue());
+            }
+         }
+         producer.send(message);
+         Map<String, Object> result = new LinkedHashMap<>();
+         result.put("status", "ok");
+         result.put("messageId", message.getJMSMessageID());
+         result.put("timestamp", message.getJMSTimestamp());
+         return result;
+      }
+   }
+
+   public List<Map<String, Object>> consume(String queueName, int limit, String selector, long timeoutMillis)
+      throws JMSException {
+      List<Map<String, Object>> messages = new ArrayList<>();
+      try (Connection connection = connectionManager.newStartedConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(queueName);
+         MessageConsumer consumer = (selector == null || selector.isBlank())
+            ? session.createConsumer(queue)
+            : session.createConsumer(queue, selector);
+         try {
+            for (int count = 0; count < limit; count++) {
+               Message message = consumer.receive(timeoutMillis);
+               if (message == null) {
+                  break;
+               }
+               messages.add(MessageView.describe(message));
+            }
+         } finally {
+            consumer.close();
+         }
+      }
+      return messages;
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/messaging/MessageView.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/messaging/MessageView.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.messaging;
+
+import javax.jms.JMSException;
+import javax.jms.Message;
+import javax.jms.TextMessage;
+import java.util.Enumeration;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+public final class MessageView {
+
+   private static final int BODY_PREVIEW_LIMIT = 512;
+
+   private MessageView() {
+   }
+
+   public static Map<String, Object> describe(Message message) throws JMSException {
+      Map<String, Object> view = new LinkedHashMap<>();
+      view.put("messageId", message.getJMSMessageID());
+      view.put("correlationId", message.getJMSCorrelationID());
+      view.put("timestamp", message.getJMSTimestamp());
+      view.put("priority", message.getJMSPriority());
+      view.put("redelivered", message.getJMSRedelivered());
+      view.put("type", message.getClass().getSimpleName());
+      if (message instanceof TextMessage textMessage) {
+         view.put("body", truncate(textMessage.getText()));
+      }
+      Map<String, Object> properties = new LinkedHashMap<>();
+      Enumeration<?> names = message.getPropertyNames();
+      while (names.hasMoreElements()) {
+         String name = (String) names.nextElement();
+         properties.put(name, message.getObjectProperty(name));
+      }
+      if (!properties.isEmpty()) {
+         view.put("properties", properties);
+      }
+      return view;
+   }
+
+   private static String truncate(String body) {
+      if (body == null) {
+         return null;
+      }
+      if (body.length() <= BODY_PREVIEW_LIMIT) {
+         return body;
+      }
+      return body.substring(0, BODY_PREVIEW_LIMIT) + "...[truncated]";
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/tools/ArtemisMcpTools.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/tools/ArtemisMcpTools.java
@@ -1,0 +1,387 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.tools;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.BiFunction;
+
+import io.modelcontextprotocol.json.McpJsonDefaults;
+import io.modelcontextprotocol.json.McpJsonMapper;
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.apache.activemq.artemis.mcp.admin.ArtemisAdminClient;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig;
+import org.apache.activemq.artemis.mcp.management.ArtemisManagementClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisBrowseClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisMessagingClient;
+import org.apache.activemq.artemis.mcp.util.Json;
+
+public final class ArtemisMcpTools {
+
+   private static final McpJsonMapper MAPPER = McpJsonDefaults.getMapper();
+
+   private static final String EMPTY_OBJECT_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{},\"additionalProperties\":false}";
+
+   private static final String QUEUE_ARG_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Queue name.\"}},"
+         + "\"required\":[\"queue\"],\"additionalProperties\":false}";
+
+   private static final String BROWSE_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Queue name to browse.\"},"
+         + "\"limit\":{\"type\":\"integer\",\"minimum\":1,\"description\":\"Max messages to return.\"},"
+         + "\"selector\":{\"type\":\"string\",\"description\":\"Optional JMS message selector.\"}},"
+         + "\"required\":[\"queue\"],\"additionalProperties\":false}";
+
+   private static final String CREATE_QUEUE_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"name\":{\"type\":\"string\",\"description\":\"Queue name.\"},"
+         + "\"address\":{\"type\":\"string\",\"description\":\"Address (defaults to the queue name).\"},"
+         + "\"routingType\":{\"type\":\"string\",\"enum\":[\"ANYCAST\",\"MULTICAST\"],\"description\":\"Routing type (default ANYCAST).\"},"
+         + "\"durable\":{\"type\":\"boolean\",\"description\":\"Durable queue (default true).\"}},"
+         + "\"required\":[\"name\"],\"additionalProperties\":false}";
+
+   private static final String CREATE_ADDRESS_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"name\":{\"type\":\"string\",\"description\":\"Address name.\"},"
+         + "\"routingType\":{\"type\":\"string\",\"enum\":[\"ANYCAST\",\"MULTICAST\"],\"description\":\"Routing type (default ANYCAST).\"}},"
+         + "\"required\":[\"name\"],\"additionalProperties\":false}";
+
+   private static final String DELETE_NAMED_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"name\":{\"type\":\"string\",\"description\":\"Resource name to delete.\"},"
+         + "\"confirm\":{\"type\":\"boolean\",\"description\":\"Must be true to perform this destructive operation.\"}},"
+         + "\"required\":[\"name\",\"confirm\"],\"additionalProperties\":false}";
+
+   private static final String PURGE_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Queue name.\"},"
+         + "\"confirm\":{\"type\":\"boolean\",\"description\":\"Must be true to perform this destructive operation.\"}},"
+         + "\"required\":[\"queue\",\"confirm\"],\"additionalProperties\":false}";
+
+   private static final String DELETE_MESSAGES_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Queue name.\"},"
+         + "\"filter\":{\"type\":\"string\",\"description\":\"JMS filter; blank removes all messages.\"},"
+         + "\"confirm\":{\"type\":\"boolean\",\"description\":\"Must be true to perform this destructive operation.\"}},"
+         + "\"required\":[\"queue\",\"confirm\"],\"additionalProperties\":false}";
+
+   private static final String MOVE_MESSAGES_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Source queue name.\"},"
+         + "\"target\":{\"type\":\"string\",\"description\":\"Target queue name.\"},"
+         + "\"filter\":{\"type\":\"string\",\"description\":\"JMS filter; blank moves all messages.\"},"
+         + "\"confirm\":{\"type\":\"boolean\",\"description\":\"Must be true to perform this destructive operation.\"}},"
+         + "\"required\":[\"queue\",\"target\",\"confirm\"],\"additionalProperties\":false}";
+
+   private static final String RETRY_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Queue name (typically a DLQ).\"},"
+         + "\"confirm\":{\"type\":\"boolean\",\"description\":\"Must be true to perform this operation.\"}},"
+         + "\"required\":[\"queue\",\"confirm\"],\"additionalProperties\":false}";
+
+   private static final String SEND_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"target\":{\"type\":\"string\",\"description\":\"Queue or address to send to.\"},"
+         + "\"body\":{\"type\":\"string\",\"description\":\"Text message body.\"},"
+         + "\"properties\":{\"type\":\"object\",\"description\":\"Optional message properties.\"},"
+         + "\"durable\":{\"type\":\"boolean\",\"description\":\"Persistent delivery (default true).\"}},"
+         + "\"required\":[\"target\",\"body\"],\"additionalProperties\":false}";
+
+   private static final String CONSUME_SCHEMA =
+      "{\"type\":\"object\",\"properties\":{"
+         + "\"queue\":{\"type\":\"string\",\"description\":\"Queue name to consume from.\"},"
+         + "\"limit\":{\"type\":\"integer\",\"minimum\":1,\"description\":\"Max messages to consume.\"},"
+         + "\"selector\":{\"type\":\"string\",\"description\":\"Optional JMS message selector.\"},"
+         + "\"timeoutMillis\":{\"type\":\"integer\",\"minimum\":0,\"description\":\"Receive timeout per message (default 2000).\"},"
+         + "\"confirm\":{\"type\":\"boolean\",\"description\":\"Must be true; consuming removes messages.\"}},"
+         + "\"required\":[\"queue\",\"confirm\"],\"additionalProperties\":false}";
+
+   private final ArtemisMcpConfig config;
+   private final ArtemisManagementClient management;
+   private final ArtemisBrowseClient browse;
+   private final ArtemisMessagingClient messaging;
+   private final ArtemisAdminClient admin;
+
+   public ArtemisMcpTools(ArtemisMcpConfig config,
+                          ArtemisManagementClient management,
+                          ArtemisBrowseClient browse,
+                          ArtemisMessagingClient messaging,
+                          ArtemisAdminClient admin) {
+      this.config = config;
+      this.management = management;
+      this.browse = browse;
+      this.messaging = messaging;
+      this.admin = admin;
+   }
+
+   public List<SyncToolSpecification> specifications() {
+      List<SyncToolSpecification> tools = new ArrayList<>(readOnlySpecifications());
+      if (config.isAdmin()) {
+         tools.addAll(adminSpecifications());
+      }
+      return tools;
+   }
+
+   private List<SyncToolSpecification> readOnlySpecifications() {
+      List<SyncToolSpecification> tools = new ArrayList<>();
+      tools.add(tool("list_queues",
+         "List the names of all queues on the broker.",
+         EMPTY_OBJECT_SCHEMA,
+         (exchange, request) -> ok(management.listQueues())));
+      tools.add(tool("list_addresses",
+         "List the names of all addresses on the broker.",
+         EMPTY_OBJECT_SCHEMA,
+         (exchange, request) -> ok(management.listAddresses())));
+      tools.add(tool("get_broker_overview",
+         "Get a high-level overview of the broker: version, uptime, connection/consumer/message counts.",
+         EMPTY_OBJECT_SCHEMA,
+         (exchange, request) -> ok(management.brokerOverview())));
+      tools.add(tool("get_queue_stats",
+         "Get message and consumer counters for a single queue.",
+         QUEUE_ARG_SCHEMA,
+         (exchange, request) -> ok(management.queueStats(requireString(request, "queue")))));
+      tools.add(tool("browse_messages",
+         "Browse messages on a queue without consuming them (non-destructive).",
+         BROWSE_SCHEMA,
+         (exchange, request) -> {
+            String queue = requireString(request, "queue");
+            int limit = optionalInt(request, "limit", config.defaultBrowseLimit());
+            String selector = optionalString(request, "selector");
+            return ok(browse.browse(queue, limit, selector));
+         }));
+      return tools;
+   }
+
+   private List<SyncToolSpecification> adminSpecifications() {
+      List<SyncToolSpecification> tools = new ArrayList<>();
+      tools.add(tool("create_queue",
+         "Create a queue on the broker.",
+         CREATE_QUEUE_SCHEMA,
+         (exchange, request) -> {
+            String name = requireString(request, "name");
+            String address = optionalString(request, "address");
+            String routingType = optionalString(request, "routingType", "ANYCAST");
+            boolean durable = optionalBool(request, "durable", true);
+            admin.createQueue(name, address, routingType, durable);
+            return result("created", name);
+         }));
+      tools.add(tool("create_address",
+         "Create an address on the broker.",
+         CREATE_ADDRESS_SCHEMA,
+         (exchange, request) -> {
+            String name = requireString(request, "name");
+            String routingType = optionalString(request, "routingType", "ANYCAST");
+            admin.createAddress(name, routingType);
+            return result("created", name);
+         }));
+      tools.add(tool("delete_queue",
+         "Delete a queue (destructive; requires confirm=true).",
+         DELETE_NAMED_SCHEMA,
+         (exchange, request) -> {
+            String name = requireConfirmed(request, "name");
+            admin.deleteQueue(name);
+            return result("deleted", name);
+         }));
+      tools.add(tool("delete_address",
+         "Delete an address (destructive; requires confirm=true).",
+         DELETE_NAMED_SCHEMA,
+         (exchange, request) -> {
+            String name = requireConfirmed(request, "name");
+            admin.deleteAddress(name);
+            return result("deleted", name);
+         }));
+      tools.add(tool("purge_queue",
+         "Remove all messages from a queue (destructive; requires confirm=true).",
+         PURGE_SCHEMA,
+         (exchange, request) -> {
+            String queue = requireConfirmed(request, "queue");
+            return count("removed", admin.purgeQueue(queue));
+         }));
+      tools.add(tool("delete_messages",
+         "Remove messages matching a filter from a queue (destructive; requires confirm=true).",
+         DELETE_MESSAGES_SCHEMA,
+         (exchange, request) -> {
+            String queue = requireConfirmed(request, "queue");
+            String filter = optionalString(request, "filter");
+            return count("removed", admin.deleteMessages(queue, filter));
+         }));
+      tools.add(tool("move_messages",
+         "Move messages from one queue to another (destructive; requires confirm=true).",
+         MOVE_MESSAGES_SCHEMA,
+         (exchange, request) -> {
+            String queue = requireConfirmed(request, "queue");
+            String target = requireString(request, "target");
+            String filter = optionalString(request, "filter");
+            return count("moved", admin.moveMessages(queue, filter, target));
+         }));
+      tools.add(tool("retry_dlq",
+         "Retry messages on a queue, redelivering them to their original address (requires confirm=true).",
+         RETRY_SCHEMA,
+         (exchange, request) -> {
+            String queue = requireConfirmed(request, "queue");
+            return count("retried", admin.retryMessages(queue));
+         }));
+      tools.add(tool("send_message",
+         "Send a text message to a queue or address.",
+         SEND_SCHEMA,
+         (exchange, request) -> {
+            String target = requireString(request, "target");
+            String body = requireString(request, "body");
+            Map<String, Object> properties = optionalMap(request, "properties");
+            boolean durable = optionalBool(request, "durable", true);
+            return ok(messaging.send(target, body, properties, durable));
+         }));
+      tools.add(tool("consume_message",
+         "Consume (remove) messages from a queue (destructive; requires confirm=true).",
+         CONSUME_SCHEMA,
+         (exchange, request) -> {
+            String queue = requireConfirmed(request, "queue");
+            int limit = optionalInt(request, "limit", 1);
+            String selector = optionalString(request, "selector");
+            long timeout = optionalLong(request, "timeoutMillis", 2000);
+            return ok(messaging.consume(queue, limit, selector, timeout));
+         }));
+      return tools;
+   }
+
+   @FunctionalInterface
+   private interface ThrowingHandler {
+      Object handle(McpSyncServerExchange exchange, CallToolRequest request) throws Exception;
+   }
+
+   private SyncToolSpecification tool(String name, String description, String schema, ThrowingHandler handler) {
+      Tool tool = Tool.builder()
+         .name(name)
+         .description(description)
+         .inputSchema(MAPPER, schema)
+         .build();
+      BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> callHandler = (exchange, request) -> {
+         try {
+            Object result = handler.handle(exchange, request);
+            return (result instanceof CallToolResult callToolResult) ? callToolResult : ok(result);
+         } catch (Exception e) {
+            return error(name + " failed: " + e.getMessage());
+         }
+      };
+      return SyncToolSpecification.builder().tool(tool).callHandler(callHandler).build();
+   }
+
+   private static CallToolResult ok(Object value) {
+      return CallToolResult.builder().addTextContent(Json.write(value)).build();
+   }
+
+   private static CallToolResult error(String message) {
+      return CallToolResult.builder().addTextContent(message).isError(true).build();
+   }
+
+   private static Map<String, Object> result(String key, Object value) {
+      Map<String, Object> map = new LinkedHashMap<>();
+      map.put("status", "ok");
+      map.put(key, value);
+      return map;
+   }
+
+   private static Map<String, Object> count(String key, int value) {
+      Map<String, Object> map = new LinkedHashMap<>();
+      map.put("status", "ok");
+      map.put(key, value);
+      return map;
+   }
+
+   private static String requireConfirmed(CallToolRequest request, String key) {
+      if (!Boolean.TRUE.equals(arguments(request).get("confirm"))) {
+         throw new IllegalStateException("destructive operation refused: set confirm=true to proceed");
+      }
+      return requireString(request, key);
+   }
+
+   private static String requireString(CallToolRequest request, String key) {
+      Object value = arguments(request).get(key);
+      if (value == null || value.toString().isBlank()) {
+         throw new IllegalArgumentException("Missing required argument: " + key);
+      }
+      return value.toString();
+   }
+
+   private static String optionalString(CallToolRequest request, String key) {
+      return optionalString(request, key, null);
+   }
+
+   private static String optionalString(CallToolRequest request, String key, String defaultValue) {
+      Object value = arguments(request).get(key);
+      return (value == null || value.toString().isBlank()) ? defaultValue : value.toString();
+   }
+
+   private static int optionalInt(CallToolRequest request, String key, int defaultValue) {
+      Object value = arguments(request).get(key);
+      if (value instanceof Number number) {
+         return number.intValue();
+      }
+      if (value != null) {
+         try {
+            return Integer.parseInt(value.toString().trim());
+         } catch (NumberFormatException ignored) {
+         }
+      }
+      return defaultValue;
+   }
+
+   private static long optionalLong(CallToolRequest request, String key, long defaultValue) {
+      Object value = arguments(request).get(key);
+      if (value instanceof Number number) {
+         return number.longValue();
+      }
+      if (value != null) {
+         try {
+            return Long.parseLong(value.toString().trim());
+         } catch (NumberFormatException ignored) {
+         }
+      }
+      return defaultValue;
+   }
+
+   @SuppressWarnings("unchecked")
+   private static Map<String, Object> optionalMap(CallToolRequest request, String key) {
+      Object value = arguments(request).get(key);
+      return value instanceof Map ? (Map<String, Object>) value : null;
+   }
+
+   private static boolean optionalBool(CallToolRequest request, String key, boolean defaultValue) {
+      Object value = arguments(request).get(key);
+      if (value instanceof Boolean bool) {
+         return bool;
+      }
+      if (value != null) {
+         return Boolean.parseBoolean(value.toString().trim());
+      }
+      return defaultValue;
+   }
+
+   private static Map<String, Object> arguments(CallToolRequest request) {
+      Map<String, Object> arguments = request.arguments();
+      return arguments == null ? Map.of() : arguments;
+   }
+}

--- a/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/util/Json.java
+++ b/artemis-mcp-server/src/main/java/org/apache/activemq/artemis/mcp/util/Json.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.util;
+
+import java.util.Map;
+
+public final class Json {
+
+   private Json() {
+   }
+
+   public static String write(Object value) {
+      StringBuilder sb = new StringBuilder();
+      writeValue(sb, value);
+      return sb.toString();
+   }
+
+   private static void writeValue(StringBuilder sb, Object value) {
+      if (value == null) {
+         sb.append("null");
+      } else if (value instanceof String s) {
+         writeString(sb, s);
+      } else if (value instanceof Boolean || value instanceof Number) {
+         sb.append(value);
+      } else if (value instanceof Map<?, ?> map) {
+         writeObject(sb, map);
+      } else if (value instanceof Iterable<?> iterable) {
+         writeArray(sb, iterable);
+      } else if (value instanceof Object[] array) {
+         writeArray(sb, java.util.Arrays.asList(array));
+      } else {
+         writeString(sb, value.toString());
+      }
+   }
+
+   private static void writeObject(StringBuilder sb, Map<?, ?> map) {
+      sb.append('{');
+      boolean first = true;
+      for (Map.Entry<?, ?> entry : map.entrySet()) {
+         if (!first) {
+            sb.append(',');
+         }
+         first = false;
+         writeString(sb, String.valueOf(entry.getKey()));
+         sb.append(':');
+         writeValue(sb, entry.getValue());
+      }
+      sb.append('}');
+   }
+
+   private static void writeArray(StringBuilder sb, Iterable<?> iterable) {
+      sb.append('[');
+      boolean first = true;
+      for (Object element : iterable) {
+         if (!first) {
+            sb.append(',');
+         }
+         first = false;
+         writeValue(sb, element);
+      }
+      sb.append(']');
+   }
+
+   private static void writeString(StringBuilder sb, String s) {
+      sb.append('"');
+      for (int i = 0; i < s.length(); i++) {
+         char c = s.charAt(i);
+         switch (c) {
+            case '"' -> sb.append("\\\"");
+            case '\\' -> sb.append("\\\\");
+            case '\n' -> sb.append("\\n");
+            case '\r' -> sb.append("\\r");
+            case '\t' -> sb.append("\\t");
+            case '\b' -> sb.append("\\b");
+            case '\f' -> sb.append("\\f");
+            default -> {
+               if (c < 0x20) {
+                  sb.append(String.format("\\u%04x", (int) c));
+               } else {
+                  sb.append(c);
+               }
+            }
+         }
+      }
+      sb.append('"');
+   }
+}

--- a/artemis-mcp-server/src/main/resources/simplelogger.properties
+++ b/artemis-mcp-server/src/main/resources/simplelogger.properties
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements. See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License. You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+org.slf4j.simpleLogger.logFile=System.err
+org.slf4j.simpleLogger.defaultLogLevel=info
+org.slf4j.simpleLogger.showDateTime=true
+org.slf4j.simpleLogger.showThreadName=true
+org.slf4j.simpleLogger.log.org.apache.activemq.audit=warn

--- a/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/AdminToolsIntegrationTest.java
+++ b/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/AdminToolsIntegrationTest.java
@@ -1,0 +1,216 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.jms.Connection;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import javax.jms.TextMessage;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.mcp.admin.ArtemisAdminClient;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig.Mode;
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+import org.apache.activemq.artemis.mcp.management.ArtemisManagementClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisBrowseClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisMessagingClient;
+import org.apache.activemq.artemis.mcp.tools.ArtemisMcpTools;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class AdminToolsIntegrationTest {
+
+   private static final String BROKER_URL = "tcp://localhost:61717";
+
+   private EmbeddedActiveMQ broker;
+   private ArtemisConnectionManager connectionManager;
+   private ArtemisManagementClient management;
+   private ArtemisAdminClient admin;
+   private ArtemisMcpTools adminTools;
+
+   @BeforeAll
+   public void startBroker() throws Exception {
+      Configuration configuration = new ConfigurationImpl()
+         .setPersistenceEnabled(false)
+         .setSecurityEnabled(false)
+         .setJMXManagementEnabled(false)
+         .addAcceptorConfiguration("tcp", BROKER_URL);
+      broker = new EmbeddedActiveMQ();
+      broker.setConfiguration(configuration);
+      broker.start();
+
+      ArtemisMcpConfig config = new ArtemisMcpConfig(BROKER_URL, null, null, Mode.ADMIN, 50);
+      connectionManager = new ArtemisConnectionManager(config);
+      management = new ArtemisManagementClient(connectionManager);
+      admin = new ArtemisAdminClient(connectionManager);
+      ArtemisBrowseClient browse = new ArtemisBrowseClient(connectionManager);
+      ArtemisMessagingClient messaging = new ArtemisMessagingClient(connectionManager);
+      adminTools = new ArtemisMcpTools(config, management, browse, messaging, admin);
+   }
+
+   @AfterAll
+   public void stop() throws Exception {
+      if (connectionManager != null) {
+         connectionManager.close();
+      }
+      if (broker != null) {
+         broker.stop();
+      }
+   }
+
+   @Test
+   public void adminToolsExposedOnlyInAdminMode() {
+      ArtemisMcpConfig readOnly = new ArtemisMcpConfig(BROKER_URL, null, null, Mode.READ_ONLY, 50);
+      ArtemisMcpTools readOnlyTools = new ArtemisMcpTools(readOnly, management,
+         new ArtemisBrowseClient(connectionManager),
+         new ArtemisMessagingClient(connectionManager), admin);
+      assertEquals(5, readOnlyTools.specifications().size());
+      assertEquals(15, adminTools.specifications().size());
+   }
+
+   @Test
+   public void createQueueToolCreatesQueue() throws Exception {
+      CallToolResult result = invoke("create_queue", Map.of("name", "admin.create.q"));
+      assertFalse(isError(result));
+      assertTrue(management.listQueues().contains("admin.create.q"));
+   }
+
+   @Test
+   public void purgeRemovesAllMessages() throws Exception {
+      admin.createQueue("admin.purge.q", null, "ANYCAST", true);
+      send("admin.purge.q", 4, null);
+      CallToolResult result = invoke("purge_queue", Map.of("queue", "admin.purge.q", "confirm", true));
+      assertFalse(isError(result));
+      assertTrue(textOf(result).contains("\"removed\":4"));
+      assertEquals(0L, ((Number) management.queueStats("admin.purge.q").get("messageCount")).longValue());
+   }
+
+   @Test
+   public void destructiveOperationRefusedWithoutConfirm() throws Exception {
+      admin.createQueue("admin.guard.q", null, "ANYCAST", true);
+      send("admin.guard.q", 2, null);
+      CallToolResult result = invoke("purge_queue", Map.of("queue", "admin.guard.q"));
+      assertTrue(isError(result));
+      assertEquals(2L, ((Number) management.queueStats("admin.guard.q").get("messageCount")).longValue());
+   }
+
+   @Test
+   public void moveMessagesBetweenQueues() throws Exception {
+      admin.createQueue("admin.move.src", null, "ANYCAST", true);
+      admin.createQueue("admin.move.dst", null, "ANYCAST", true);
+      send("admin.move.src", 3, null);
+      CallToolResult result = invoke("move_messages",
+         Map.of("queue", "admin.move.src", "target", "admin.move.dst", "confirm", true));
+      assertFalse(isError(result));
+      assertTrue(textOf(result).contains("\"moved\":3"));
+      assertEquals(3L, ((Number) management.queueStats("admin.move.dst").get("messageCount")).longValue());
+   }
+
+   @Test
+   public void deleteMessagesByFilter() throws Exception {
+      admin.createQueue("admin.del.q", null, "ANYCAST", true);
+      send("admin.del.q", 2, "a");
+      send("admin.del.q", 3, "b");
+      CallToolResult result = invoke("delete_messages",
+         Map.of("queue", "admin.del.q", "filter", "kind='a'", "confirm", true));
+      assertFalse(isError(result));
+      assertTrue(textOf(result).contains("\"removed\":2"));
+      assertEquals(3L, ((Number) management.queueStats("admin.del.q").get("messageCount")).longValue());
+   }
+
+   @Test
+   public void deleteQueueToolRemovesQueue() throws Exception {
+      admin.createQueue("admin.delete.q", null, "ANYCAST", true);
+      CallToolResult result = invoke("delete_queue", Map.of("name", "admin.delete.q", "confirm", true));
+      assertFalse(isError(result));
+      assertFalse(management.listQueues().contains("admin.delete.q"));
+   }
+
+   @Test
+   public void sendThenConsumeRoundTrip() throws Exception {
+      admin.createQueue("admin.msg.q", null, "ANYCAST", true);
+      CallToolResult sent = invoke("send_message",
+         Map.of("target", "admin.msg.q", "body", "hello-mcp", "properties", Map.of("kind", "x")));
+      assertFalse(isError(sent));
+      assertTrue(textOf(sent).contains("\"messageId\""));
+
+      CallToolResult consumed = invoke("consume_message",
+         Map.of("queue", "admin.msg.q", "limit", 5, "confirm", true));
+      assertFalse(isError(consumed));
+      assertTrue(textOf(consumed).contains("hello-mcp"));
+      assertEquals(0L, ((Number) management.queueStats("admin.msg.q").get("messageCount")).longValue());
+   }
+
+   @Test
+   public void consumeRefusedWithoutConfirm() throws Exception {
+      admin.createQueue("admin.consume.guard.q", null, "ANYCAST", true);
+      send("admin.consume.guard.q", 1, null);
+      CallToolResult result = invoke("consume_message", Map.of("queue", "admin.consume.guard.q"));
+      assertTrue(isError(result));
+      assertEquals(1L, ((Number) management.queueStats("admin.consume.guard.q").get("messageCount")).longValue());
+   }
+
+   private void send(String queueName, int count, String kind) throws Exception {
+      try (Connection connection = connectionManager.newStartedConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(queueName);
+         MessageProducer producer = session.createProducer(queue);
+         for (int i = 0; i < count; i++) {
+            TextMessage message = session.createTextMessage("m-" + i);
+            if (kind != null) {
+               message.setStringProperty("kind", kind);
+            }
+            producer.send(message);
+         }
+      }
+   }
+
+   private CallToolResult invoke(String toolName, Map<String, Object> arguments) {
+      SyncToolSpecification spec = adminTools.specifications().stream()
+         .filter(s -> s.tool().name().equals(toolName))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("tool not found: " + toolName));
+      return spec.callHandler().apply(null, new CallToolRequest(toolName, arguments));
+   }
+
+   private static boolean isError(CallToolResult result) {
+      return Boolean.TRUE.equals(result.isError());
+   }
+
+   private static String textOf(CallToolResult result) {
+      return result.content().stream()
+         .filter(c -> c instanceof TextContent)
+         .map(c -> ((TextContent) c).text())
+         .reduce("", String::concat);
+   }
+}

--- a/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/ArtemisMcpIntegrationTest.java
+++ b/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/ArtemisMcpIntegrationTest.java
@@ -1,0 +1,168 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import javax.jms.Connection;
+import javax.jms.MessageProducer;
+import javax.jms.Queue;
+import javax.jms.Session;
+import java.util.List;
+import java.util.Map;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import org.apache.activemq.artemis.core.config.Configuration;
+import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.embedded.EmbeddedActiveMQ;
+import org.apache.activemq.artemis.mcp.admin.ArtemisAdminClient;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig;
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig.Mode;
+import org.apache.activemq.artemis.mcp.connection.ArtemisConnectionManager;
+import org.apache.activemq.artemis.mcp.management.ArtemisManagementClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisBrowseClient;
+import org.apache.activemq.artemis.mcp.messaging.ArtemisMessagingClient;
+import org.apache.activemq.artemis.mcp.tools.ArtemisMcpTools;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+public class ArtemisMcpIntegrationTest {
+
+   private static final String BROKER_URL = "tcp://localhost:61716";
+   private static final String TEST_QUEUE = "mcp.test.queue";
+   private static final int MESSAGE_COUNT = 5;
+
+   private EmbeddedActiveMQ broker;
+   private ArtemisConnectionManager connectionManager;
+   private ArtemisManagementClient management;
+   private ArtemisBrowseClient browse;
+   private ArtemisMcpTools tools;
+
+   @BeforeAll
+   public void startBrokerAndSeed() throws Exception {
+      Configuration configuration = new ConfigurationImpl()
+         .setPersistenceEnabled(false)
+         .setSecurityEnabled(false)
+         .setJMXManagementEnabled(false)
+         .addAcceptorConfiguration("tcp", BROKER_URL);
+      broker = new EmbeddedActiveMQ();
+      broker.setConfiguration(configuration);
+      broker.start();
+
+      ArtemisMcpConfig config = new ArtemisMcpConfig(BROKER_URL, null, null, Mode.READ_ONLY, 50);
+      connectionManager = new ArtemisConnectionManager(config);
+      management = new ArtemisManagementClient(connectionManager);
+      browse = new ArtemisBrowseClient(connectionManager);
+      tools = new ArtemisMcpTools(config, management, browse,
+         new ArtemisMessagingClient(connectionManager), new ArtemisAdminClient(connectionManager));
+
+      seedMessages();
+   }
+
+   @AfterAll
+   public void stop() throws Exception {
+      if (connectionManager != null) {
+         connectionManager.close();
+      }
+      if (broker != null) {
+         broker.stop();
+      }
+   }
+
+   private void seedMessages() throws Exception {
+      try (Connection connection = connectionManager.newStartedConnection()) {
+         Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+         Queue queue = session.createQueue(TEST_QUEUE);
+         MessageProducer producer = session.createProducer(queue);
+         for (int i = 0; i < MESSAGE_COUNT; i++) {
+            producer.send(session.createTextMessage("message-" + i));
+         }
+      }
+   }
+
+   @Test
+   public void listQueuesIncludesTestQueue() throws Exception {
+      assertTrue(management.listQueues().contains(TEST_QUEUE),
+         "expected listQueues to include " + TEST_QUEUE);
+   }
+
+   @Test
+   public void queueStatsReportSeededCount() throws Exception {
+      Map<String, Object> stats = management.queueStats(TEST_QUEUE);
+      assertEquals((long) MESSAGE_COUNT, ((Number) stats.get("messageCount")).longValue());
+      assertEquals(TEST_QUEUE, stats.get("name"));
+   }
+
+   @Test
+   public void brokerOverviewReportsVersion() throws Exception {
+      Map<String, Object> overview = management.brokerOverview();
+      assertNotNull(overview.get("version"));
+      assertTrue(((Number) overview.get("totalMessageCount")).longValue() >= MESSAGE_COUNT);
+   }
+
+   @Test
+   public void browseReturnsMessagesWithoutConsuming() throws Exception {
+      List<Map<String, Object>> first = browse.browse(TEST_QUEUE, 10, null);
+      assertEquals(MESSAGE_COUNT, first.size());
+      assertEquals("message-0", first.get(0).get("body"));
+      assertEquals(MESSAGE_COUNT, browse.browse(TEST_QUEUE, 10, null).size());
+   }
+
+   @Test
+   public void listQueuesToolReturnsJsonResult() {
+      CallToolResult result = invoke("list_queues", Map.of());
+      assertFalse(Boolean.TRUE.equals(result.isError()));
+      assertTrue(textOf(result).contains(TEST_QUEUE));
+   }
+
+   @Test
+   public void getQueueStatsToolUsesArgument() {
+      CallToolResult result = invoke("get_queue_stats", Map.of("queue", TEST_QUEUE));
+      assertFalse(Boolean.TRUE.equals(result.isError()));
+      assertTrue(textOf(result).contains("\"messageCount\":" + MESSAGE_COUNT));
+   }
+
+   @Test
+   public void missingRequiredArgumentReportsError() {
+      CallToolResult result = invoke("get_queue_stats", Map.of());
+      assertTrue(Boolean.TRUE.equals(result.isError()));
+   }
+
+   private CallToolResult invoke(String toolName, Map<String, Object> arguments) {
+      SyncToolSpecification spec = tools.specifications().stream()
+         .filter(s -> s.tool().name().equals(toolName))
+         .findFirst()
+         .orElseThrow(() -> new AssertionError("tool not found: " + toolName));
+      return spec.callHandler().apply(null, new CallToolRequest(toolName, arguments));
+   }
+
+   private static String textOf(CallToolResult result) {
+      return result.content().stream()
+         .filter(c -> c instanceof TextContent)
+         .map(c -> ((TextContent) c).text())
+         .reduce("", String::concat);
+   }
+}

--- a/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/config/ArtemisMcpConfigTest.java
+++ b/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/config/ArtemisMcpConfigTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.config;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.activemq.artemis.mcp.config.ArtemisMcpConfig.Mode;
+import org.junit.jupiter.api.Test;
+
+public class ArtemisMcpConfigTest {
+
+   @Test
+   public void defaultsToReadOnly() {
+      ArtemisMcpConfig config = new ArtemisMcpConfig("tcp://localhost:61616", null, null, Mode.READ_ONLY, 50);
+      assertEquals(Mode.READ_ONLY, config.mode());
+      assertFalse(config.isAdmin());
+   }
+
+   @Test
+   public void adminModeIsExplicit() {
+      ArtemisMcpConfig config = new ArtemisMcpConfig("tcp://localhost:61616", null, null, Mode.ADMIN, 50);
+      assertTrue(config.isAdmin());
+   }
+
+   @Test
+   public void modeParsingIsLenient() {
+      assertEquals(Mode.READ_ONLY, Mode.parse(null));
+      assertEquals(Mode.READ_ONLY, Mode.parse(""));
+      assertEquals(Mode.READ_ONLY, Mode.parse("read-only"));
+      assertEquals(Mode.READ_ONLY, Mode.parse("READ_ONLY"));
+      assertEquals(Mode.ADMIN, Mode.parse("admin"));
+   }
+
+   @Test
+   public void fromEnvironmentUsesSystemProperties() {
+      String prevUrl = System.getProperty("artemis.mcp.brokerUrl");
+      String prevMode = System.getProperty("artemis.mcp.mode");
+      try {
+         System.setProperty("artemis.mcp.brokerUrl", "tcp://example:61616");
+         System.setProperty("artemis.mcp.mode", "admin");
+         ArtemisMcpConfig config = ArtemisMcpConfig.fromEnvironment();
+         assertEquals("tcp://example:61616", config.brokerUrl());
+         assertTrue(config.isAdmin());
+      } finally {
+         restore("artemis.mcp.brokerUrl", prevUrl);
+         restore("artemis.mcp.mode", prevMode);
+      }
+   }
+
+   private static void restore(String key, String value) {
+      if (value == null) {
+         System.clearProperty(key);
+      } else {
+         System.setProperty(key, value);
+      }
+   }
+}

--- a/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/util/JsonTest.java
+++ b/artemis-mcp-server/src/test/java/org/apache/activemq/artemis/mcp/util/JsonTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.mcp.util;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+public class JsonTest {
+
+   @Test
+   public void writesPrimitives() {
+      assertEquals("null", Json.write(null));
+      assertEquals("42", Json.write(42));
+      assertEquals("true", Json.write(true));
+      assertEquals("\"hi\"", Json.write("hi"));
+   }
+
+   @Test
+   public void escapesStrings() {
+      assertEquals("\"a\\\"b\\n\"", Json.write("a\"b\n"));
+   }
+
+   @Test
+   public void writesNestedStructures() {
+      Map<String, Object> map = new LinkedHashMap<>();
+      map.put("name", "q1");
+      map.put("count", 3);
+      map.put("tags", List.of("a", "b"));
+      assertEquals("{\"name\":\"q1\",\"count\":3,\"tags\":[\"a\",\"b\"]}", Json.write(map));
+   }
+
+   @Test
+   public void writesArrays() {
+      assertEquals("[\"x\",\"y\"]", Json.write(new Object[] {"x", "y"}));
+   }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -53,6 +53,7 @@
       <module>artemis-jms-client</module>
       <module>artemis-jms-client-all</module>
       <module>artemis-jms-client-osgi</module>
+      <module>artemis-mcp-server</module>
       <module>artemis-jakarta-client</module>
       <module>artemis-jakarta-client-all</module>
       <module>artemis-jakarta-client-osgi</module>


### PR DESCRIPTION
> **Early WIP / proposal — not a merge candidate.**
> This is a reference implementation opened to make the proposal concrete and
> easy to evaluate. There is **no dev@ consensus yet**: a `[DISCUSS]` thread on
> dev@activemq.apache.org has not been started. The design, scope and even
> whether this belongs in the main repo are open questions for that discussion,
> and this PR may change substantially or be closed as a result. Please treat it
> as a discussion starter rather than something to review for merge.

## What

Adds a new `artemis-mcp-server` reactor module: a Model Context Protocol (MCP)
server that exposes broker operations as MCP tools over the STDIO transport, so
AI agents can inspect, monitor and administer an Artemis broker through a
standard protocol.

JIRA: https://issues.apache.org/jira/browse/ARTEMIS-6118

## Tools (15)

Read-only (always available):
`list_queues`, `list_addresses`, `get_broker_overview`, `get_queue_stats`, `browse_messages`

Admin (registered only when `mode=admin`):
`create_queue`, `create_address`, `delete_queue`*, `delete_address`*, `purge_queue`*,
`delete_messages`*, `move_messages`*, `retry_dlq`*, `send_message`, `consume_message`*

(*) destructive — require `confirm=true`, enforced by both the tool input schema and the handler.

## Design

- Read-only mode is the DEFAULT; admin tools are not registered unless `mode=admin`.
- Monitoring/management uses Artemis management messages to `activemq.management`
  (single broker connection, no open JMX required).
- Messaging uses the Core/JMS client (browse = `QueueBrowser`, send = producer,
  consume = consumer).
- MCP layer uses the MCP Java SDK (MIT / ASF Category A).

## Testing

- 24 unit + integration tests against an embedded broker; green via `mvn install`.
- Builds inside the reactor; Artemis checkstyle clean.
- Verified end-to-end against an Apache Artemis broker running in Docker via real
  JSON-RPC `tools/call` (create/list/stats/browse/send/consume/purge/move/delete),
  including confirm-gating on destructive tools.

## Open questions for dev@ (not yet discussed)

- Is an MCP server in scope for the project at all, and should it live in the main
  repo, in examples, or as a separate addon?
- New dependency footprint: the MCP Java SDK pulls in Jackson 3.x,
  json-schema-validator, snakeyaml-engine and reactor-core (all ASF Category A).
- Logging binding, docs (`docs/`) and a binary-distribution LICENSE/NOTICE entry
  for the MIT SDK to be settled once the direction is agreed.
