### PR TITLE
ARTEMIS-6119 Stomp subscriber cannot receive compressed messages

### DIFF
--- a/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
+++ b/artemis-protocols/artemis-stomp-protocol/src/main/java/org/apache/activemq/artemis/core/protocol/stomp/VersionedStompFrameHandler.java
@@ -16,19 +16,16 @@
  */
 package org.apache.activemq.artemis.core.protocol.stomp;
 
-import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Objects;
 import java.util.concurrent.ScheduledExecutorService;
 
 import org.apache.activemq.artemis.api.core.ActiveMQBuffer;
-import org.apache.activemq.artemis.api.core.ActiveMQBuffers;
 import org.apache.activemq.artemis.api.core.ActiveMQException;
 import org.apache.activemq.artemis.api.core.ICoreMessage;
 import org.apache.activemq.artemis.api.core.Message;
 import org.apache.activemq.artemis.api.core.RoutingType;
 import org.apache.activemq.artemis.api.core.SimpleString;
-import org.apache.activemq.artemis.core.message.LargeBodyReader;
 import org.apache.activemq.artemis.core.message.impl.CoreMessage;
 import org.apache.activemq.artemis.core.protocol.stomp.Stomp.Headers;
 import org.apache.activemq.artemis.core.protocol.stomp.v10.StompFrameHandlerV10;
@@ -335,11 +332,7 @@ public abstract class VersionedStompFrameHandler {
          frame.addHeader(Stomp.Headers.Message.SUBSCRIPTION, subscription.getID());
       }
 
-      if (serverMessage.isLargeMessage()) {
-         populateFrameBodyFromLargeMessage(frame, serverMessage);
-      } else {
-         populateFrameBodyFromMessage(frame, serverMessage);
-      }
+      populateFrameBodyFromMessage(frame, serverMessage);
 
       frame.addHeader(Stomp.Headers.Message.MESSAGE_ID, new StringBuilder(41).append(consumer.getID()).append(StompSession.MESSAGE_ID_SEPARATOR).append(serverMessage.getMessageID()).toString());
       StompUtils.copyStandardHeadersFromMessageToFrame(serverMessage, frame, deliveryCount);
@@ -348,7 +341,7 @@ public abstract class VersionedStompFrameHandler {
    }
 
    private void populateFrameBodyFromMessage(StompFrame frame, ICoreMessage serverMessage) {
-      final ActiveMQBuffer buffer = serverMessage.getReadOnlyBodyBuffer();
+      final ActiveMQBuffer buffer = serverMessage.getDataBuffer();
       final int bodyLength = buffer.readableBytes();
 
       if (bodyLength > 0) {
@@ -368,38 +361,6 @@ public abstract class VersionedStompFrameHandler {
          }
       } else {
          frame.setByteBody(EMPTY_BODY);
-      }
-   }
-
-   private void populateFrameBodyFromLargeMessage(StompFrame frame, ICoreMessage serverMessage) throws ActiveMQException {
-      try (LargeBodyReader reader = serverMessage.getLargeBodyReader()) {
-         reader.open();
-
-         final int bodyLength = (int) reader.getSize();
-
-         if (bodyLength > 0) {
-            final byte[] bodyBytes = new byte[bodyLength];
-            final ByteBuffer bodyBuffer = ByteBuffer.wrap(bodyBytes);
-
-            reader.readInto(bodyBuffer);
-
-            if (serverMessage.containsProperty(Stomp.Headers.CONTENT_LENGTH) || serverMessage.getType() == Message.BYTES_TYPE) {
-               frame.addHeader(Headers.CONTENT_LENGTH, String.valueOf(bodyLength));
-               frame.setByteBody(bodyBytes);
-            } else {
-               final ActiveMQBuffer buffer = ActiveMQBuffers.wrappedBuffer(bodyBuffer);
-
-               buffer.writerIndex(bodyLength);
-
-               final SimpleString text = buffer.readNullableSimpleString();
-
-               if (text != null) {
-                  frame.setByteBody(text.toString().getBytes(StandardCharsets.UTF_8));
-               }
-            }
-         } else {
-            frame.setByteBody(EMPTY_BODY);
-         }
       }
    }
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/stomp/StompTest.java
@@ -339,6 +339,33 @@ public class StompTest extends StompTestBase {
    }
 
    @Test
+   public void testReceiveCompressedMessage() throws Exception {
+      String DATA = RandomUtil.randomAlphaNumericString(1024 * 1024);
+      String queue = getQueuePrefix() + getQueueName();
+
+      server.createQueue(QueueConfiguration.of(queue).setDurable(true).setRoutingType(RoutingType.ANYCAST), true);
+
+      try (ServerLocator locator = ActiveMQClient.createServerLocator("tcp://" + hostname + ":" + port + "?compressLargeMessage=true");
+           ClientSessionFactory sf = locator.createSessionFactory();
+           ClientSession session = sf.createSession(false, true, true);
+           ClientProducer producer = session.createProducer()) {
+
+         ClientMessage message = session.createMessage(true);
+         message.getBodyBuffer().writeNullableSimpleString(SimpleString.of(DATA));
+         producer.send(queue, message);
+      }
+
+      conn.connect(defUser, defPass);
+
+      subscribe(conn, null, Stomp.Headers.Subscribe.AckModeValues.AUTO);
+
+      ClientStompFrame frame = conn.receiveFrame(10000);
+      assertEquals(DATA, frame.getBody());
+
+      conn.disconnect();
+   }
+
+   @Test
    public void sendEmptyCoreMessage() throws Exception {
       conn.connect(defUser, defPass);
       subscribe(conn, null, Stomp.Headers.Subscribe.AckModeValues.AUTO);


### PR DESCRIPTION
If a Stomp subscriber tries to receive a message that has been compressed by a Core client it will fail (because no inflation of the compressed body takes place)

This change would use the Core message `getDataBuffer()` to manage this along with handling of "regular" large messages in the  `VersionedStompFrameHandler` (basically moving the Large body read step from there to use the existing one on the Core message)

All tests pass, though I have limited experience with the Stomp protocol so if anything seems off just let me know