### PR TITLE
ARTEMIS-6008 Prevent CriticalAnalyzer from killing the broker while failing over

### DIFF
--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -856,6 +856,14 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       threadDump();
    }
 
+   private boolean suppressCriticalAnalyzerWhileActivating(Object criticalComponent) {
+      if (!isActive()) {
+         takingLongToStart(criticalComponent);
+         return true;
+      }
+      return false;
+   }
+
    protected void initializeCriticalAnalyzer() throws Exception {
 
       // Some tests will play crazy frequenceistop/start
@@ -884,9 +892,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       final CriticalAnalyzerPolicy criticalAnalyzerPolicy = configuration.getCriticalAnalyzerPolicy();
       CriticalAction criticalAction = switch (criticalAnalyzerPolicy) {
          case HALT -> criticalComponent -> {
-            if (ActiveMQServerImpl.this.state == SERVER_STATE.STARTING) {
-               takingLongToStart(criticalComponent);
-            } else {
+            if (!suppressCriticalAnalyzerWhileActivating(criticalComponent)) {
                checkCriticalAnalyzerLogging();
                ActiveMQServerLogger.LOGGER.criticalSystemHalt(criticalComponent);
 
@@ -897,9 +903,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
          };
          case SHUTDOWN -> criticalComponent -> {
-            if (ActiveMQServerImpl.this.state == SERVER_STATE.STARTING) {
-               takingLongToStart(criticalComponent);
-            } else {
+            if (!suppressCriticalAnalyzerWhileActivating(criticalComponent)) {
                checkCriticalAnalyzerLogging();
                ActiveMQServerLogger.LOGGER.criticalSystemShutdown(criticalComponent);
 
@@ -922,9 +926,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
          };
          case LOG -> criticalComponent -> {
-            if (ActiveMQServerImpl.this.state == SERVER_STATE.STARTING) {
-               takingLongToStart(criticalComponent);
-            } else {
+            if (!suppressCriticalAnalyzerWhileActivating(criticalComponent)) {
                checkCriticalAnalyzerLogging();
                ActiveMQServerLogger.LOGGER.criticalSystemLog(criticalComponent);
                threadDump();
@@ -3558,7 +3560,6 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       if (state == SERVER_STATE.STOPPED || state == SERVER_STATE.STOPPING) {
          return;
       }
-
       loadProtocolServices();
 
       pagingManager.reloadStores();

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerImpl.java
@@ -856,14 +856,6 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       threadDump();
    }
 
-   private boolean suppressCriticalAnalyzerWhileActivating(Object criticalComponent) {
-      if (!isActive()) {
-         takingLongToStart(criticalComponent);
-         return true;
-      }
-      return false;
-   }
-
    protected void initializeCriticalAnalyzer() throws Exception {
 
       // Some tests will play crazy frequenceistop/start
@@ -892,7 +884,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       final CriticalAnalyzerPolicy criticalAnalyzerPolicy = configuration.getCriticalAnalyzerPolicy();
       CriticalAction criticalAction = switch (criticalAnalyzerPolicy) {
          case HALT -> criticalComponent -> {
-            if (!suppressCriticalAnalyzerWhileActivating(criticalComponent)) {
+            if (!isActive()) {
+               takingLongToStart(criticalComponent);
+            } else {
                checkCriticalAnalyzerLogging();
                ActiveMQServerLogger.LOGGER.criticalSystemHalt(criticalComponent);
 
@@ -903,7 +897,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
          };
          case SHUTDOWN -> criticalComponent -> {
-            if (!suppressCriticalAnalyzerWhileActivating(criticalComponent)) {
+            if (!isActive()) {
+               takingLongToStart(criticalComponent);
+            } else {
                checkCriticalAnalyzerLogging();
                ActiveMQServerLogger.LOGGER.criticalSystemShutdown(criticalComponent);
 
@@ -926,7 +922,9 @@ public class ActiveMQServerImpl implements ActiveMQServer {
             }
          };
          case LOG -> criticalComponent -> {
-            if (!suppressCriticalAnalyzerWhileActivating(criticalComponent)) {
+            if (!isActive()) {
+               takingLongToStart(criticalComponent);
+            } else {
                checkCriticalAnalyzerLogging();
                ActiveMQServerLogger.LOGGER.criticalSystemLog(criticalComponent);
                threadDump();
@@ -3560,6 +3558,7 @@ public class ActiveMQServerImpl implements ActiveMQServer {
       if (state == SERVER_STATE.STOPPED || state == SERVER_STATE.STOPPING) {
          return;
       }
+
       loadProtocolServices();
 
       pagingManager.reloadStores();

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerStartupTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerStartupTest.java
@@ -16,17 +16,19 @@
  */
 package org.apache.activemq.artemis.core.server.impl;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
-import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
 import org.apache.activemq.artemis.tests.util.ServerTestBase;
+import org.apache.activemq.artemis.utils.ReusableLatch;
 import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerAccessor;
 import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerPolicy;
 import org.apache.activemq.artemis.utils.critical.CriticalComponentImpl;
 import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Field;
 
 public class ActiveMQServerStartupTest extends ServerTestBase {
 
@@ -56,11 +58,16 @@ public class ActiveMQServerStartupTest extends ServerTestBase {
          ActiveMQServerImpl server = new ActiveMQServerImpl(configuration);
          addServer(server);
          server.start();
-         // this will be faking a condition
-         server.setState(ActiveMQServer.SERVER_STATE.STARTING);
+
+         Field field = ActiveMQServerImpl.class.getDeclaredField("activationLatch");
+         field.setAccessible(true);
+         ReusableLatch activationLatch = (ReusableLatch) field.get(server);
+         // fake server not being active by holding the activation latch the same way start() does
+         activationLatch.setCount(1);
+
          CriticalAnalyzerAccessor.fireActions(server.getCriticalAnalyzer(), new CriticalComponentImpl(server.getCriticalAnalyzer(), 2));
+         assertFalse(server.isActive());
          assertTrue(loggerHandler.findText("AMQ224116"));
-         assertEquals(ActiveMQServer.SERVER_STATE.STARTING, server.getState()); // should not be changed
          server.stop();
       }
    }

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerStartupTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/server/impl/ActiveMQServerStartupTest.java
@@ -20,15 +20,17 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.apache.activemq.artemis.core.config.impl.ConfigurationImpl;
+import org.apache.activemq.artemis.core.server.ActivateCallback;
 import org.apache.activemq.artemis.logs.AssertionLoggerHandler;
 import org.apache.activemq.artemis.tests.util.ServerTestBase;
-import org.apache.activemq.artemis.utils.ReusableLatch;
+import org.apache.activemq.artemis.utils.Wait;
 import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerAccessor;
 import org.apache.activemq.artemis.utils.critical.CriticalAnalyzerPolicy;
 import org.apache.activemq.artemis.utils.critical.CriticalComponentImpl;
 import org.junit.jupiter.api.Test;
 
-import java.lang.reflect.Field;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
 
 public class ActiveMQServerStartupTest extends ServerTestBase {
 
@@ -57,17 +59,29 @@ public class ActiveMQServerStartupTest extends ServerTestBase {
          configuration.setPersistenceEnabled(false);
          ActiveMQServerImpl server = new ActiveMQServerImpl(configuration);
          addServer(server);
-         server.start();
-
-         Field field = ActiveMQServerImpl.class.getDeclaredField("activationLatch");
-         field.setAccessible(true);
-         ReusableLatch activationLatch = (ReusableLatch) field.get(server);
-         // fake server not being active by holding the activation latch the same way start() does
-         activationLatch.setCount(1);
-
+         CountDownLatch latch = new CountDownLatch(1);
+         server.registerActivateCallback(new ActivateCallback() {
+            @Override
+            public void preActivate() {
+               try {
+                  latch.await();
+               } catch (InterruptedException e) {
+                  throw new RuntimeException(e);
+               }
+            }
+         });
+         CompletableFuture.runAsync(() -> {
+            try {
+               server.start();
+            } catch (Exception e) {
+               e.printStackTrace();
+            }
+         });
+         Wait.waitFor(() -> server.getCriticalAnalyzer() != null);
          CriticalAnalyzerAccessor.fireActions(server.getCriticalAnalyzer(), new CriticalComponentImpl(server.getCriticalAnalyzer(), 2));
-         assertFalse(server.isActive());
          assertTrue(loggerHandler.findText("AMQ224116"));
+         assertFalse(server.isActive()); // should not be changed
+         latch.countDown();
          server.stop();
       }
    }


### PR DESCRIPTION
[issues.apache.org/jira/browse/ARTEMIS-3664](https://issues.apache.org/jira/browse/ARTEMIS-3664) fixed an issue with Critical Analyzer killing the broker during slow startup.

However, during live/backup pair failover when the backup node is in the STARTED state, the Critical Analyzer would still evaluate the node as unhealthy under large journal/slow network disk conditions and kill it.

This change proposes to switch the Critical Analyzer to LOG mode while the backup node is activating. 	

I have debated between adding a new ServerState and adding a boolean flag (as done in this PR). Finally, I have decided to go with the flag as this change is a minor bug fix and should not warrant a significantly wider change of adding a new ServerState, however I would gladly do that if asked by the maintainers.