### PR TITLE
ARTEMIS-6126 Fixing basedir resolution on testsuite

### DIFF
--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/BasedirSupport.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/BasedirSupport.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.activemq.artemis.utils;
+
+import java.io.File;
+import java.io.IOException;
+
+public class BasedirSupport {
+
+   public static String getBasedir() {
+      String basedir = System.getProperty("basedir");
+      if (basedir == null) {
+         try {
+            basedir = new File(".").getCanonicalPath();
+         } catch (IOException e) {
+            throw new RuntimeException("Failed to resolve canonical path for current directory", e);
+         }
+      }
+      return basedir;
+   }
+
+}

--- a/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/RealServerTestBase.java
+++ b/tests/artemis-test-support/src/main/java/org/apache/activemq/artemis/utils/RealServerTestBase.java
@@ -62,7 +62,7 @@ public class RealServerTestBase extends ActiveMQTestBase {
    private static final String JMX_SERVER_HOSTNAME = "localhost";
    private static final int JMX_SERVER_PORT = 10099;
 
-   public static final String basedir = System.getProperty("basedir");
+   public static final String basedir = BasedirSupport.getBasedir();
 
    public static final String ARTEMIS_HOME_PROPERTY = "artemis.distribution.output";
 

--- a/tests/e2e-tests/src/test/java/org/apache/activemq/artemis/tests/e2e/common/E2ETestBase.java
+++ b/tests/e2e-tests/src/test/java/org/apache/activemq/artemis/tests/e2e/common/E2ETestBase.java
@@ -19,10 +19,11 @@ package org.apache.activemq.artemis.tests.e2e.common;
 import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
 import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
+import org.apache.activemq.artemis.utils.BasedirSupport;
 
 public class E2ETestBase extends ActiveMQTestBase {
 
-   public static final String basedir = System.getProperty("basedir");
+   public static final String basedir = BasedirSupport.getBasedir();
 
    protected static final void recreateBrokerDirectory(final String homeInstance) {
       recreateDirectory(homeInstance + "/data");

--- a/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/upgradeTest/CompareUpgradeTest.java
+++ b/tests/smoke-tests/src/test/java/org/apache/activemq/artemis/tests/smoke/upgradeTest/CompareUpgradeTest.java
@@ -43,6 +43,7 @@ import java.util.stream.Stream;
 import org.apache.activemq.artemis.cli.commands.ActionContext;
 import org.apache.activemq.artemis.cli.commands.Create;
 import org.apache.activemq.artemis.cli.commands.Upgrade;
+import org.apache.activemq.artemis.utils.BasedirSupport;
 import org.apache.activemq.artemis.utils.FileUtil;
 import org.junit.jupiter.api.Test;
 import org.slf4j.Logger;
@@ -55,8 +56,7 @@ public class CompareUpgradeTest {
 
    private static final Logger logger = LoggerFactory.getLogger(MethodHandles.lookup().lookupClass());
 
-   public static final String basedir = System.getProperty("basedir");
-
+   public static final String basedir = BasedirSupport.getBasedir();
 
    @Test
    public void testCompareWindowsFreshInstance() throws Exception {


### PR DESCRIPTION
This is particularly important if running tests through the IDE