### PR TITLE
ARTEMIS-6141 Fix non-portable kill -SIGINT

### DIFF
--- a/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/interruptlm/LargeMessageInterruptTest.java
+++ b/tests/soak-tests/src/test/java/org/apache/activemq/artemis/tests/soak/interruptlm/LargeMessageInterruptTest.java
@@ -86,7 +86,7 @@ public class LargeMessageInterruptTest extends SoakTestBase {
    }
 
    private void killProcess(Process process) throws Exception {
-      Runtime.getRuntime().exec("kill -SIGINT " + process.pid());
+      process.destroy();
    }
 
    @Test


### PR DESCRIPTION
LargeMessageInterruptTest.killProcess() relies on Runtime.exec("kill -SIGINT ...") to send a graceful shutdown signal. The -SIGINT flag is a non-standard signal specification that some kill implementations silently ignore while reporting success (exit code 0), causing the broker process to stay alive and the test to time out. Observed on Fedora 43 where /usr/bin/kill does not handle -SIGINT.

Replace with Process.destroy() which sends SIGTERM directly via JVM syscall, with no dependency on external binaries or their flag parsing behavior.