### PR TITLE
ARTEMIS-6145 Remove unused activemq-stomp dependency

### DIFF
--- a/tests/activemq5-unit-tests/pom.xml
+++ b/tests/activemq5-unit-tests/pom.xml
@@ -86,12 +86,6 @@
       </dependency>
 
       <dependency>
-         <groupId>org.apache.activemq</groupId>
-         <artifactId>activemq-stomp</artifactId>
-         <version>${activemq5-version}</version>
-      </dependency>
-
-      <dependency>
          <groupId>junit</groupId>
          <artifactId>junit</artifactId>
          <scope>compile</scope>


### PR DESCRIPTION
The activemq-stomp artifact is declared as a dependency in activemq5-unit-tests but no code in the module imports or uses any class from it. Removing it to keep the dependency tree clean.