### PR TITLE
ARTEMIS-6172 HTTP tunneling server async packets starve request replies

### DIFF
--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyConnector.java
@@ -200,6 +200,10 @@ public class NettyConnector extends AbstractConnector {
 
    private boolean httpEnabled;
 
+   private long httpMaxClientIdleTime;
+
+   private long httpClientIdleScanPeriod;
+
    private boolean httpRequiresSessionId;
 
    // if true, after the connection, the connector will send
@@ -366,6 +370,8 @@ public class NettyConnector extends AbstractConnector {
       httpEnabled = ConfigurationHelper.getBooleanProperty(TransportConstants.HTTP_ENABLED_PROP_NAME, TransportConstants.DEFAULT_HTTP_ENABLED, configuration);
       servletPath = ConfigurationHelper.getStringProperty(TransportConstants.SERVLET_PATH, TransportConstants.DEFAULT_SERVLET_PATH, configuration);
       if (httpEnabled) {
+         httpMaxClientIdleTime = ConfigurationHelper.getLongProperty(TransportConstants.HTTP_CLIENT_IDLE_PROP_NAME, TransportConstants.DEFAULT_HTTP_CLIENT_IDLE_TIME, configuration);
+         httpClientIdleScanPeriod = ConfigurationHelper.getLongProperty(TransportConstants.HTTP_CLIENT_IDLE_SCAN_PERIOD, TransportConstants.DEFAULT_HTTP_CLIENT_SCAN_PERIOD, configuration);
          httpRequiresSessionId = ConfigurationHelper.getBooleanProperty(TransportConstants.HTTP_REQUIRES_SESSION_ID, TransportConstants.DEFAULT_HTTP_REQUIRES_SESSION_ID, configuration);
          httpHeaders = new HashMap<>();
          for (Map.Entry<String, Object> header : configuration.entrySet()) {
@@ -374,6 +380,8 @@ public class NettyConnector extends AbstractConnector {
             }
          }
       } else {
+         httpMaxClientIdleTime = 0;
+         httpClientIdleScanPeriod = -1;
          httpRequiresSessionId = false;
          httpHeaders = Collections.emptyMap();
       }
@@ -1122,6 +1130,14 @@ public class NettyConnector extends AbstractConnector {
 
    public class HttpHandler extends ChannelDuplexHandler {
 
+      private Channel channel;
+
+      private long lastSendTime = 0;
+
+      private boolean waitingGet = false;
+
+      private HttpIdleTimer task;
+
       private final String url;
 
       private final FutureLatch handShakeFuture = new FutureLatch();
@@ -1143,6 +1159,26 @@ public class NettyConnector extends AbstractConnector {
       }
 
       @Override
+      public void channelActive(final ChannelHandlerContext ctx) throws Exception {
+         super.channelActive(ctx);
+         channel = ctx.channel();
+         if (httpClientIdleScanPeriod > 0) {
+            task = new HttpIdleTimer();
+            java.util.concurrent.Future<?> future = scheduledThreadPool.scheduleAtFixedRate(task, httpClientIdleScanPeriod, httpClientIdleScanPeriod, TimeUnit.MILLISECONDS);
+            task.setFuture(future);
+         }
+      }
+
+      @Override
+      public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
+         if (task != null) {
+            task.close();
+         }
+
+         super.channelInactive(ctx);
+      }
+
+      @Override
       public void channelRead(final ChannelHandlerContext ctx, final Object msg) throws Exception {
          FullHttpResponse response = (FullHttpResponse) msg;
          if (httpRequiresSessionId && !active) {
@@ -1157,12 +1193,12 @@ public class NettyConnector extends AbstractConnector {
             active = true;
             handShakeFuture.run();
          }
+         waitingGet = false;
          ctx.fireChannelRead(response.content());
       }
 
       @Override
       public void write(final ChannelHandlerContext ctx, final Object msg, ChannelPromise promise) throws Exception {
-         Object toSend = msg;
          if (msg instanceof ByteBuf buf) {
             if (httpRequiresSessionId && !active) {
                if (handshaking) {
@@ -1182,9 +1218,48 @@ public class NettyConnector extends AbstractConnector {
                httpRequest.headers().add(HttpHeaderNames.COOKIE, cookie);
             }
             httpRequest.headers().add(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(buf.readableBytes()));
-            toSend = httpRequest;
+            ctx.write(httpRequest, promise);
+            lastSendTime = System.currentTimeMillis();
+         } else {
+            ctx.write(msg, promise);
+            lastSendTime = System.currentTimeMillis();
          }
-         ctx.write(toSend, promise);
+      }
+
+      private class HttpIdleTimer implements Runnable {
+
+         private boolean closed = false;
+
+         private java.util.concurrent.Future<?> future;
+
+         @Override
+         public synchronized void run() {
+            if (closed) {
+               return;
+            }
+
+            if (!waitingGet && System.currentTimeMillis() > lastSendTime + httpMaxClientIdleTime) {
+               FullHttpRequest httpRequest = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, url);
+               httpRequest.headers().add(HttpHeaderNames.HOST, String.format("%s:%d", host, port));
+               for (Map.Entry<String, String> header : headers.entrySet()) {
+                  httpRequest.headers().add(header.getKey(), header.getValue());
+               }
+               waitingGet = true;
+               channel.writeAndFlush(httpRequest);
+            }
+         }
+
+         public synchronized void setFuture(final java.util.concurrent.Future<?> future) {
+            this.future = future;
+         }
+
+         public void close() {
+            if (future != null) {
+               future.cancel(false);
+            }
+
+            closed = true;
+         }
       }
    }
 

--- a/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
+++ b/artemis-core-client/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/TransportConstants.java
@@ -48,18 +48,14 @@ public class TransportConstants {
 
    public static final String HTTP_ENABLED_PROP_NAME = "httpEnabled";
 
-   @Deprecated(forRemoval = true)
    public static final String HTTP_CLIENT_IDLE_PROP_NAME = "httpClientIdleTime";
 
-   @Deprecated(forRemoval = true)
    public static final String HTTP_CLIENT_IDLE_SCAN_PERIOD = "httpClientIdleScanPeriod";
 
    public static final String NETTY_HTTP_HEADER_PREFIX = "nettyHttpHeader.";
 
-   @Deprecated(forRemoval = true)
    public static final String HTTP_RESPONSE_TIME_PROP_NAME = "httpResponseTime";
 
-   @Deprecated(forRemoval = true)
    public static final String HTTP_SERVER_SCAN_PERIOD_PROP_NAME = "httpServerScanPeriod";
 
    public static final String HTTP_REQUIRES_SESSION_ID = "httpRequiresSessionId";

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
@@ -33,6 +33,7 @@ import io.netty.channel.ChannelPipeline;
 import io.netty.handler.codec.ByteToMessageDecoder;
 import io.netty.handler.codec.http.DefaultFullHttpResponse;
 import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.HttpHeaderNames;
 import io.netty.handler.codec.http.HttpHeaders;
 import io.netty.handler.codec.http.HttpObjectAggregator;
 import io.netty.handler.codec.http.HttpRequestDecoder;
@@ -154,7 +155,7 @@ public class ProtocolHandler {
       public void channelRead(ChannelHandlerContext ctx, Object msg) throws Exception {
          if (msg instanceof FullHttpRequest httpRequest) {
             HttpHeaders headers = httpRequest.headers();
-            String upgrade = headers.get("upgrade");
+            String upgrade = headers.get(HttpHeaderNames.UPGRADE);
 
             if (upgrade != null && upgrade.equalsIgnoreCase("websocket")) {
                int stompMaxFramePayloadLength = ConfigurationHelper.getIntProperty(TransportConstants.STOMP_MAX_FRAME_PAYLOAD_LENGTH, -1, nettyAcceptor.getConfiguration());

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/protocol/ProtocolHandler.java
@@ -20,6 +20,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
@@ -42,6 +43,7 @@ import org.apache.activemq.artemis.core.buffers.impl.ChannelBufferWrapper;
 import org.apache.activemq.artemis.core.remoting.impl.netty.ConnectionCreator;
 import org.apache.activemq.artemis.core.remoting.impl.netty.HAProxyMessageEnforcer;
 import org.apache.activemq.artemis.core.remoting.impl.netty.HttpAcceptorHandler;
+import org.apache.activemq.artemis.core.remoting.impl.netty.HttpKeepAliveRunnable;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettyConnector;
 import org.apache.activemq.artemis.core.remoting.impl.netty.NettySNIHostnameHandler;
@@ -66,6 +68,8 @@ public class ProtocolHandler {
 
    private ScheduledExecutorService scheduledThreadPool;
 
+   private HttpKeepAliveRunnable httpKeepAliveRunnable;
+
    private final List<String> websocketSubprotocolIds;
 
    public ProtocolHandler(Map<String, ProtocolManager> protocolMap,
@@ -89,6 +93,16 @@ public class ProtocolHandler {
 
    public ChannelHandler getProtocolDecoder() {
       return new ProtocolDecoder(true, false);
+   }
+
+   public HttpKeepAliveRunnable getHttpKeepAliveRunnable() {
+      return httpKeepAliveRunnable;
+   }
+
+   public void close() {
+      if (httpKeepAliveRunnable != null) {
+         httpKeepAliveRunnable.close();
+      }
    }
 
    public ProtocolManager getProtocol(String name) {
@@ -274,8 +288,16 @@ public class ProtocolHandler {
          p.addLast("http-decoder", new HttpRequestDecoder());
          p.addLast("http-aggregator", new HttpObjectAggregator(Integer.MAX_VALUE));
          p.addLast("http-encoder", new HttpResponseEncoder());
-         HttpAcceptorHandler httpHandler = new HttpAcceptorHandler(ctx.channel());
-         p.addLast(HTTP_HANDLER, httpHandler);
+         //create it lazily if and when we need it
+         if (httpKeepAliveRunnable == null) {
+            long httpServerScanPeriod = ConfigurationHelper.getLongProperty(TransportConstants.HTTP_SERVER_SCAN_PERIOD_PROP_NAME, TransportConstants.DEFAULT_HTTP_SERVER_SCAN_PERIOD, nettyAcceptor.getConfiguration());
+            httpKeepAliveRunnable = new HttpKeepAliveRunnable();
+            Future<?> future = scheduledThreadPool.scheduleAtFixedRate(httpKeepAliveRunnable, httpServerScanPeriod, httpServerScanPeriod, TimeUnit.MILLISECONDS);
+            httpKeepAliveRunnable.setFuture(future);
+         }
+         long httpResponseTime = ConfigurationHelper.getLongProperty(TransportConstants.HTTP_RESPONSE_TIME_PROP_NAME, TransportConstants.DEFAULT_HTTP_RESPONSE_TIME, nettyAcceptor.getConfiguration());
+         HttpAcceptorHandler httpHandler = new HttpAcceptorHandler(httpKeepAliveRunnable, httpResponseTime, ctx.channel());
+         ctx.pipeline().addLast(HTTP_HANDLER, httpHandler);
          p.addLast(new ProtocolDecoder(false, true));
          p.remove(this);
       }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandler.java
@@ -23,6 +23,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.Channel;
 import io.netty.channel.ChannelDuplexHandler;
 import io.netty.channel.ChannelHandlerContext;
@@ -41,24 +42,37 @@ import io.netty.util.ReferenceCountUtil;
  */
 public class HttpAcceptorHandler extends ChannelDuplexHandler {
 
-   private final BlockingQueue<FullHttpResponse> responses = new LinkedBlockingQueue<>();
+   private final BlockingQueue<ResponseHolder> responses = new LinkedBlockingQueue<>();
 
    private final BlockingQueue<Runnable> delayedResponses = new LinkedBlockingQueue<>();
 
    private final ExecutorService executor = new ThreadPoolExecutor(1, 1, 0, TimeUnit.SECONDS, delayedResponses);
 
+   private final HttpKeepAliveRunnable httpKeepAliveTask;
+
+   private final long responseTime;
+
    private Channel channel;
 
-   public HttpAcceptorHandler(Channel channel) {
+   public HttpAcceptorHandler(final HttpKeepAliveRunnable httpKeepAliveTask, final long responseTime, Channel channel) {
       super();
+      this.responseTime = responseTime;
+      this.httpKeepAliveTask = httpKeepAliveTask;
       this.channel = channel;
+      httpKeepAliveTask.registerKeepAliveHandler(this);
    }
 
    @Override
    public void channelInactive(final ChannelHandlerContext ctx) throws Exception {
       super.channelInactive(ctx);
-      shutdown();
+      httpKeepAliveTask.unregisterKeepAliveHandler(this);
       channel = null;
+   }
+
+   @Override
+   public void handlerRemoved(ChannelHandlerContext ctx) throws Exception {
+      super.handlerRemoved(ctx);
+      httpKeepAliveTask.unregisterKeepAliveHandler(this);
    }
 
    @Override
@@ -69,7 +83,7 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
       if (method.equals(HttpMethod.POST)) {
          ctx.fireChannelRead(ReferenceCountUtil.retain(((FullHttpRequest) msg).content()));
          // add a new response
-         responses.put(new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK));
+         responses.put(new ResponseHolder(System.currentTimeMillis() + responseTime, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
          ReferenceCountUtil.release(msg);
          return;
       }
@@ -83,6 +97,21 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
          executor.execute(new ResponseRunner(buf, promise));
       } else {
          ctx.write(msg, promise);
+      }
+   }
+
+   public void keepAlive(final long time) {
+      // send some responses to catch up thus avoiding any timeout.
+      int lateResponses = 0;
+      for (ResponseHolder response : responses) {
+         if (response.timeReceived < time) {
+            lateResponses++;
+         } else {
+            break;
+         }
+      }
+      for (int i = 0; i < lateResponses; i++) {
+         executor.execute(new ResponseRunner());
       }
    }
 
@@ -103,12 +132,18 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
          this.promise = promise;
       }
 
+      ResponseRunner() {
+         bogusResponse = true;
+         buffer = Unpooled.buffer(0);
+         promise = channel.newPromise();
+      }
+
       @Override
       public void run() {
-         FullHttpResponse response = null;
+         ResponseHolder responseHolder = null;
          do {
             try {
-               response = responses.take();
+               responseHolder = responses.take();
             } catch (InterruptedException e) {
                if (executor.isShutdown()) {
                   return;
@@ -116,14 +151,14 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
                // otherwise ignore, we'll just try again
             }
          }
-         while (response == null);
+         while (responseHolder == null);
          if (!bogusResponse) {
-            piggyBackResponses(response.content());
+            piggyBackResponses(responseHolder.response.content());
          } else {
-            response.content().writeBytes(buffer);
+            responseHolder.response.content().writeBytes(buffer);
          }
-         response.headers().set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(response.content().readableBytes()));
-         channel.writeAndFlush(response, promise);
+         responseHolder.response.headers().set(HttpHeaderNames.CONTENT_LENGTH, String.valueOf(responseHolder.response.content().readableBytes()));
+         channel.writeAndFlush(responseHolder.response, promise);
 
          buffer.release();
 
@@ -165,4 +200,20 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
       }
       responses.clear();
    }
+
+   /**
+    * a holder class so we know what time  the request first arrived
+    */
+   private static final class ResponseHolder {
+
+      final FullHttpResponse response;
+
+      final long timeReceived;
+
+      private ResponseHolder(final long timeReceived, final FullHttpResponse response) {
+         this.timeReceived = timeReceived;
+         this.response = response;
+      }
+   }
+
 }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandler.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandler.java
@@ -86,6 +86,15 @@ public class HttpAcceptorHandler extends ChannelDuplexHandler {
          responses.put(new ResponseHolder(System.currentTimeMillis() + responseTime, new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
          ReferenceCountUtil.release(msg);
          return;
+      } else if (method.equals(HttpMethod.GET) && !request.headers().contains(HttpHeaderNames.UPGRADE)) {
+         // HTTP tunnel poll for a pending response; do not consume protocol Upgrade GETs (e.g. WebSocket).
+         if (responses.isEmpty()) {
+            responses.put(new ResponseHolder(System.currentTimeMillis() + responseTime,
+               new DefaultFullHttpResponse(HttpVersion.HTTP_1_1, HttpResponseStatus.OK)));
+         }
+         // Consumed here (not forwarded), so release; unlike POST we keep no content, so no retain.
+         ReferenceCountUtil.release(msg);
+         return;
       }
       super.channelRead(ctx, msg);
    }

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpKeepAliveRunnable.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpKeepAliveRunnable.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.remoting.impl.netty;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Future;
+
+/**
+ * A simple Runnable to allow {@link HttpAcceptorHandler}s to be called intermittently.
+ */
+public class HttpKeepAliveRunnable implements Runnable {
+
+   private final List<HttpAcceptorHandler> handlers = new ArrayList<>();
+
+   private boolean closed = false;
+
+   private Future<?> future;
+
+   @Override
+   public synchronized void run() {
+      if (closed) {
+         return;
+      }
+
+      long time = System.currentTimeMillis();
+      for (HttpAcceptorHandler handler : handlers) {
+         handler.keepAlive(time);
+      }
+   }
+
+   public List<HttpAcceptorHandler> getHandlers() {
+      return Collections.unmodifiableList(handlers);
+   }
+
+   public synchronized void registerKeepAliveHandler(final HttpAcceptorHandler httpAcceptorHandler) {
+      handlers.add(httpAcceptorHandler);
+   }
+
+   public synchronized void unregisterKeepAliveHandler(final HttpAcceptorHandler httpAcceptorHandler) {
+      handlers.remove(httpAcceptorHandler);
+      httpAcceptorHandler.shutdown();
+   }
+
+   public void close() {
+      for (HttpAcceptorHandler handler : handlers) {
+         handler.shutdown();
+      }
+      if (future != null) {
+         future.cancel(true);
+      }
+
+      closed = true;
+   }
+
+   public synchronized void setFuture(final Future<?> future) {
+      this.future = future;
+   }
+}

--- a/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
+++ b/artemis-server/src/main/java/org/apache/activemq/artemis/core/remoting/impl/netty/NettyAcceptor.java
@@ -836,6 +836,10 @@ public class NettyAcceptor extends AbstractAcceptor {
       }
       try {
 
+         if (protocolHandler != null) {
+            protocolHandler.close();
+         }
+
          if (batchFlusherFuture != null) {
             batchFlusherFuture.cancel(false);
 

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandlerTest.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements. See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.activemq.artemis.core.remoting.impl.netty;
+
+import io.netty.channel.embedded.EmbeddedChannel;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.spy;
+
+@ExtendWith(MockitoExtension.class)
+public class HttpAcceptorHandlerTest {
+
+   private static final String HTTP_HANDLER = "http-handler";
+
+   private HttpKeepAliveRunnable spy;
+
+   @BeforeEach
+   public void setUp() throws Exception {
+      spy = spy(new HttpKeepAliveRunnable());
+   }
+
+   @Test
+   public void testUnregisterIsCalledTwiceWhenChannelIsInactive() {
+      EmbeddedChannel channel = new EmbeddedChannel();
+
+      HttpAcceptorHandler httpHandler = new HttpAcceptorHandler(spy, 1000, channel);
+      channel.pipeline().addLast(HTTP_HANDLER, httpHandler);
+
+      channel.close();
+
+      Mockito.verify(spy, Mockito.times(2)).unregisterKeepAliveHandler(httpHandler);
+   }
+
+   @Test
+   public void testUnregisterIsCalledWhenHandlerIsRemovedFromPipeline() {
+      EmbeddedChannel channel = new EmbeddedChannel();
+
+      HttpAcceptorHandler httpHandler = new HttpAcceptorHandler(spy, 1000, channel);
+      channel.pipeline().addLast(HTTP_HANDLER, httpHandler);
+
+      channel.pipeline().remove(HTTP_HANDLER);
+
+      Mockito.verify(spy).unregisterKeepAliveHandler(httpHandler);
+   }
+}

--- a/artemis-server/src/test/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandlerTest.java
+++ b/artemis-server/src/test/java/org/apache/activemq/artemis/core/remoting/impl/netty/HttpAcceptorHandlerTest.java
@@ -16,13 +16,28 @@
  */
 package org.apache.activemq.artemis.core.remoting.impl.netty;
 
+import io.netty.buffer.ByteBuf;
+import io.netty.buffer.Unpooled;
 import io.netty.channel.embedded.EmbeddedChannel;
+import io.netty.handler.codec.http.DefaultFullHttpRequest;
+import io.netty.handler.codec.http.FullHttpRequest;
+import io.netty.handler.codec.http.FullHttpResponse;
+import io.netty.handler.codec.http.HttpHeaderNames;
+import io.netty.handler.codec.http.HttpMethod;
+import io.netty.handler.codec.http.HttpVersion;
+import org.apache.activemq.artemis.utils.Wait;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mockito;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.spy;
 
 @ExtendWith(MockitoExtension.class)
@@ -59,5 +74,132 @@ public class HttpAcceptorHandlerTest {
       channel.pipeline().remove(HTTP_HANDLER);
 
       Mockito.verify(spy).unregisterKeepAliveHandler(httpHandler);
+   }
+
+   @Test
+   public void testGetWithoutUpgradeIsConsumedAndReleased() {
+      EmbeddedChannel channel = new EmbeddedChannel();
+      channel.pipeline().addLast(HTTP_HANDLER, new HttpAcceptorHandler(spy, 1000, channel));
+
+      FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+      channel.writeInbound(request);
+
+      assertNull(channel.readInbound());
+      assertEquals(0, request.refCnt());
+
+      channel.finishAndReleaseAll();
+   }
+
+   @Test
+   public void testGetWithUpgradeIsForwarded() {
+      EmbeddedChannel channel = new EmbeddedChannel();
+      channel.pipeline().addLast(HTTP_HANDLER, new HttpAcceptorHandler(spy, 1000, channel));
+
+      FullHttpRequest request = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+      request.headers().set(HttpHeaderNames.UPGRADE, "websocket");
+      channel.writeInbound(request);
+
+      assertSame(request, channel.readInbound());
+      assertEquals(1, request.refCnt());
+      request.release();
+
+      channel.finishAndReleaseAll();
+   }
+
+   /**
+    * Regression for ARTEMIS-6172: an async server write can consume the only HTTP response
+    * slot from a prior POST. A subsequent client GET must enqueue a new slot so the
+    * request reply is not starved.
+    */
+   @Test
+   public void testGetUnblocksReplyAfterAsyncPacketConsumesResponseSlot() throws Exception {
+      EmbeddedChannel channel = new EmbeddedChannel();
+      channel.pipeline().addLast(HTTP_HANDLER, new HttpAcceptorHandler(spy, 1000, channel));
+
+      FullHttpRequest post = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/",
+         Unpooled.wrappedBuffer(new byte[]{1}));
+      assertTrue(channel.writeInbound(post));
+      ByteBuf inbound = channel.readInbound();
+      assertNotNull(inbound);
+      inbound.release();
+
+      // Server-initiated / async packet consumes the only response slot.
+      channel.writeOutbound(Unpooled.wrappedBuffer(new byte[]{0xA}));
+      FullHttpResponse asyncResponse = awaitOutboundHttpResponse(channel);
+      assertEquals(1, asyncResponse.content().readableBytes());
+      assertEquals(0xA, asyncResponse.content().getByte(asyncResponse.content().readerIndex()));
+      asyncResponse.release();
+
+      // Request reply has no remaining slot and must not flush yet.
+      channel.writeOutbound(Unpooled.wrappedBuffer(new byte[]{0xB}));
+      assertFalse(Wait.waitFor(() -> {
+         channel.runPendingTasks();
+         return channel.outboundMessages().peek() != null;
+      }, 200, 20));
+
+      // Idle GET polls for pending server data when the response queue is empty.
+      FullHttpRequest get = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+      channel.writeInbound(get);
+      assertNull(channel.readInbound());
+      assertEquals(0, get.refCnt());
+
+      FullHttpResponse replyResponse = awaitOutboundHttpResponse(channel);
+      assertEquals(1, replyResponse.content().readableBytes());
+      assertEquals(0xB, replyResponse.content().getByte(replyResponse.content().readerIndex()));
+      replyResponse.release();
+
+      channel.finishAndReleaseAll();
+   }
+
+   @Test
+   public void testGetDoesNotEnqueueExtraSlotWhenResponsesAlreadyQueued() throws Exception {
+      EmbeddedChannel channel = new EmbeddedChannel();
+      channel.pipeline().addLast(HTTP_HANDLER, new HttpAcceptorHandler(spy, 1000, channel));
+
+      FullHttpRequest post = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.POST, "/",
+         Unpooled.wrappedBuffer(new byte[]{1}));
+      assertTrue(channel.writeInbound(post));
+      ByteBuf inbound = channel.readInbound();
+      assertNotNull(inbound);
+      inbound.release();
+
+      // Response slot already exists from the POST; GET must not add another.
+      FullHttpRequest get = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+      channel.writeInbound(get);
+      assertNull(channel.readInbound());
+      assertEquals(0, get.refCnt());
+
+      channel.writeOutbound(Unpooled.wrappedBuffer(new byte[]{0xA}));
+      FullHttpResponse first = awaitOutboundHttpResponse(channel);
+      assertEquals(0xA, first.content().getByte(first.content().readerIndex()));
+      first.release();
+
+      // Only one slot was available; a second write stays blocked without another request.
+      channel.writeOutbound(Unpooled.wrappedBuffer(new byte[]{0xB}));
+      assertFalse(Wait.waitFor(() -> {
+         channel.runPendingTasks();
+         return channel.outboundMessages().peek() != null;
+      }, 200, 20));
+
+      FullHttpRequest getForReply = new DefaultFullHttpRequest(HttpVersion.HTTP_1_1, HttpMethod.GET, "/");
+      channel.writeInbound(getForReply);
+      assertEquals(0, getForReply.refCnt());
+
+      FullHttpResponse second = awaitOutboundHttpResponse(channel);
+      assertEquals(0xB, second.content().getByte(second.content().readerIndex()));
+      second.release();
+
+      channel.finishAndReleaseAll();
+   }
+
+   private static FullHttpResponse awaitOutboundHttpResponse(EmbeddedChannel channel) throws Exception {
+      Wait.assertTrue(() -> {
+         channel.runPendingTasks();
+         return channel.outboundMessages().peek() != null;
+      }, 5000, 10);
+      Object outbound = channel.readOutbound();
+      assertNotNull(outbound);
+      assertTrue(outbound instanceof FullHttpResponse, "unexpected outbound: " + outbound);
+      return (FullHttpResponse) outbound;
    }
 }

--- a/docs/user-manual/configuring-transports.adoc
+++ b/docs/user-manual/configuring-transports.adoc
@@ -528,9 +528,21 @@ Activates HTTP on the client.
 This is not needed on the broker.
 With single port support the broker will now automatically detect if HTTP is being used and configure itself.
 
+httpClientIdleTime::
+How long a client can be idle before sending an empty HTTP request to keep the connection alive
+
+httpClientIdleScanPeriod::
+How often, in milliseconds, to scan for idle clients
+
+httpResponseTime::
+How long the server can wait before sending an empty HTTP response to keep the connection alive
+
+httpServerScanPeriod::
+How often, in milliseconds, to scan for clients needing responses
+
 httpRequiresSessionId::
 If `true` the client will wait after the first call to receive a session id.
-Used when the HTTP connector is connecting to servlet acceptor (not recommended).
+Used the HTTP connector is connecting to servlet acceptor (not recommended)
 
 === Configuring Netty SOCKS Proxy
 

--- a/docs/user-manual/versions.adoc
+++ b/docs/user-manual/versions.adoc
@@ -26,6 +26,8 @@ https://issues.apache.org/jira/secure/ReleaseNote.jspa?projectId=12315920&versio
 === Upgrading from 2.55.0
 
 * Due to https://issues.apache.org/jira/browse/ARTEMIS-6128[ARTEMIS-6128] the `Alder32` and `fileAlder32` properties have been deprecated in favor of `Adler32` and `fileAdler32` respectively.
+* Due to https://issues.apache.org/jira/browse/ARTEMIS-6172[ARTEMIS-6172] the HTTP-specific transport parameters deprecated by https://issues.apache.org/jira/browse/ARTEMIS-5819[ARTEMIS-5819] (`httpClientIdleTime`, `httpClientIdleScanPeriod`, `httpResponseTime`, `httpServerScanPeriod`) are restored.
+These are required so HTTP-tunneled Core connections can create response slots for server-initiated packets (for example cluster topology updates) without starving replies to client requests.
 
 == Version 2.55.0
 

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/WebSocketConnectionTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/amqp/WebSocketConnectionTest.java
@@ -16,6 +16,9 @@
  */
 package org.apache.activemq.artemis.tests.integration.amqp;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
 import javax.jms.JMSException;
 import javax.jms.Message;
 import javax.jms.MessageConsumer;
@@ -23,11 +26,10 @@ import javax.jms.MessageProducer;
 import javax.jms.Queue;
 import javax.jms.Session;
 
+import org.apache.activemq.artemis.core.remoting.impl.netty.NettyAcceptor;
 import org.apache.qpid.jms.JmsConnection;
 import org.apache.qpid.jms.JmsConnectionFactory;
 import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 /**
  * Test connections can be established to remote peers via WebSockets
@@ -44,6 +46,8 @@ public class WebSocketConnectionTest extends JMSClientTestSupport {
       JmsConnectionFactory factory = new JmsConnectionFactory(getBrokerQpidJMSConnectionURI());
 
       produceAndConsumeInNewConnection(factory);
+
+      assertKeepAliveCounterIsZero();
    }
 
    @Test
@@ -55,6 +59,8 @@ public class WebSocketConnectionTest extends JMSClientTestSupport {
       produceAndConsumeInNewConnection(factory);
       produceAndConsumeInNewConnection(factory);
       produceAndConsumeInNewConnection(factory);
+
+      assertKeepAliveCounterIsZero();
    }
 
    private void produceAndConsumeInNewConnection(JmsConnectionFactory factory) throws JMSException {
@@ -77,5 +83,13 @@ public class WebSocketConnectionTest extends JMSClientTestSupport {
       } finally {
          connection.close();
       }
+   }
+
+   private void assertKeepAliveCounterIsZero() {
+      NettyAcceptor nettyAcceptor = (NettyAcceptor) server.getRemotingService().getAcceptor(NETTY_ACCEPTOR);
+
+      int httpAcceptorHandlerCount = nettyAcceptor.getProtocolHandler().getHttpKeepAliveRunnable().getHandlers().size();
+
+      assertEquals(0, httpAcceptorHandlerCount);
    }
 }

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/CoreClientOverHttpTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/CoreClientOverHttpTest.java
@@ -55,7 +55,7 @@ public class CoreClientOverHttpTest extends ActiveMQTestBase {
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.HTTP_ENABLED_PROP_NAME, true);
 
-      conf = createDefaultInVMConfig().clearAcceptorConfigurations().addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY));
+      conf = createDefaultInVMConfig().clearAcceptorConfigurations().addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
 
       server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
       server.start();

--- a/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/CoreClientOverHttpTest.java
+++ b/tests/integration-tests/src/test/java/org/apache/activemq/artemis/tests/integration/http/CoreClientOverHttpTest.java
@@ -18,6 +18,7 @@ package org.apache.activemq.artemis.tests.integration.http;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.activemq.artemis.api.core.QueueConfiguration;
 import org.apache.activemq.artemis.api.core.SimpleString;
@@ -28,22 +29,31 @@ import org.apache.activemq.artemis.api.core.client.ClientMessage;
 import org.apache.activemq.artemis.api.core.client.ClientProducer;
 import org.apache.activemq.artemis.api.core.client.ClientSession;
 import org.apache.activemq.artemis.api.core.client.ClientSessionFactory;
+import org.apache.activemq.artemis.api.core.client.ClusterTopologyListener;
 import org.apache.activemq.artemis.api.core.client.ServerLocator;
+import org.apache.activemq.artemis.api.core.client.TopologyMember;
+import org.apache.activemq.artemis.core.client.impl.Topology;
+import org.apache.activemq.artemis.core.client.impl.TopologyMemberImpl;
 import org.apache.activemq.artemis.core.config.Configuration;
 import org.apache.activemq.artemis.core.remoting.impl.netty.TransportConstants;
 import org.apache.activemq.artemis.core.server.ActiveMQServer;
 import org.apache.activemq.artemis.core.server.ActiveMQServers;
+import org.apache.activemq.artemis.core.server.cluster.ClusterConnection;
 import org.apache.activemq.artemis.jms.client.ActiveMQTextMessage;
 import org.apache.activemq.artemis.tests.util.ActiveMQTestBase;
 import org.apache.activemq.artemis.utils.RandomUtil;
+import org.apache.activemq.artemis.utils.Wait;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 public class CoreClientOverHttpTest extends ActiveMQTestBase {
 
    private static final SimpleString QUEUE = SimpleString.of("CoreClientOverHttpTestQueue");
+   private static final String CONNECTOR_NAME = "http-connector";
    private Configuration conf;
    private ActiveMQServer server;
    private ServerLocator locator;
@@ -54,12 +64,21 @@ public class CoreClientOverHttpTest extends ActiveMQTestBase {
       super.setUp();
       Map<String, Object> params = new HashMap<>();
       params.put(TransportConstants.HTTP_ENABLED_PROP_NAME, true);
+      // Keep idle GET scans aggressive so HTTP response slots can be replenished quickly.
+      params.put(TransportConstants.HTTP_CLIENT_IDLE_PROP_NAME, 100L);
+      params.put(TransportConstants.HTTP_CLIENT_IDLE_SCAN_PERIOD, 50L);
 
-      conf = createDefaultInVMConfig().clearAcceptorConfigurations().addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params));
+      TransportConfiguration connectorConfig = new TransportConfiguration(NETTY_CONNECTOR_FACTORY, params, CONNECTOR_NAME);
+      conf = createDefaultInVMConfig()
+         .clearAcceptorConfigurations()
+         .addAcceptorConfiguration(new TransportConfiguration(NETTY_ACCEPTOR_FACTORY, params))
+         .addConnectorConfiguration(CONNECTOR_NAME, connectorConfig)
+         .addClusterConfiguration(basicClusterConnectionConfig(CONNECTOR_NAME));
 
       server = addServer(ActiveMQServers.newActiveMQServer(conf, false));
       server.start();
-      locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(new TransportConfiguration(NETTY_CONNECTOR_FACTORY, params)));
+      locator = addServerLocator(ActiveMQClient.createServerLocatorWithoutHA(connectorConfig));
+      locator.setCallTimeout(5000);
    }
 
    @Test
@@ -141,6 +160,68 @@ public class CoreClientOverHttpTest extends ActiveMQTestBase {
 
          message2.acknowledge();
       }
+
+      session.close();
+   }
+
+   /**
+    * ARTEMIS-6172: server-initiated ClusterTopology packets consume HTTP response slots.
+    * Idle GET polling must replenish slots so request/reply traffic is not starved.
+    */
+   @Test
+   public void testClusterTopologyDoesNotStarveHttpRequestReplies() throws Exception {
+      AtomicInteger topologyEvents = new AtomicInteger();
+      locator.addClusterTopologyListener(new ClusterTopologyListener() {
+         @Override
+         public void nodeUP(TopologyMember topologyMember, boolean last) {
+            topologyEvents.incrementAndGet();
+         }
+
+         @Override
+         public void nodeDown(long uniqueEventID, String nodeID) {
+            topologyEvents.incrementAndGet();
+         }
+      });
+
+      ClientSessionFactory sf = createSessionFactory(locator);
+      ClientSession session = sf.createSession(false, true, true);
+
+      ClusterConnection clusterConnection = server.getClusterManager().getClusterConnection("cluster1");
+      assertNotNull(clusterConnection);
+      Topology topology = clusterConnection.getTopology();
+
+      final int topologyUpdates = 50;
+      final int topologyEventsBeforeFlood = topologyEvents.get();
+      final long uniqueEventIDBase = System.currentTimeMillis();
+      for (int i = 0; i < topologyUpdates; i++) {
+         Map<String, Object> memberParams = new HashMap<>();
+         memberParams.put(TransportConstants.HOST_PROP_NAME, "127.0.0.1");
+         memberParams.put(TransportConstants.PORT_PROP_NAME, 17000 + i);
+         TransportConfiguration memberConnector = new TransportConfiguration(NETTY_CONNECTOR_FACTORY, memberParams);
+         // Use backup-only members so ClusterConnectionImpl does not attempt bridges to fake nodes,
+         // while still emitting ClusterTopology packets on the HTTP client connection.
+         String nodeId = "http-topo-" + i;
+         TopologyMemberImpl member = new TopologyMemberImpl(nodeId, null, null, null, memberConnector);
+         assertTrue(topology.updateMember(uniqueEventIDBase + i, nodeId, member));
+      }
+
+      Wait.assertTrue(() -> topologyEvents.get() >= topologyEventsBeforeFlood + topologyUpdates, 5_000, 50);
+
+      // Synchronous Core requests must still complete after async topology consumed HTTP slots.
+      SimpleString starvationQueue = SimpleString.of("HttpTopologyStarvationQueue");
+      session.createQueue(QueueConfiguration.of(starvationQueue).setDurable(false));
+
+      ClientProducer producer = session.createProducer(starvationQueue);
+      ClientMessage message = session.createMessage(false);
+      message.getBodyBuffer().writeString("topology-http");
+      producer.send(message);
+
+      ClientConsumer consumer = session.createConsumer(starvationQueue);
+      session.start();
+      ClientMessage received = consumer.receive(5_000);
+      assertNotNull(received);
+      assertEquals("topology-http", received.getBodyBuffer().readString());
+      received.acknowledge();
 
       session.close();
    }


### PR DESCRIPTION
With httpEnabled=true, Core packets are tunneled over HTTP. HttpAcceptorHandler pairs each client POST with one queued HTTP response slot; every server outbound ByteBuf must take a slot before it can be flushed.
Server-initiated / async packets (e.g. ClusterTopologyChangeMessage) also consume those slots. When they drain the queue, replies to the client’s own requests block on responses.take() until another HTTP request arrives. The client is often waiting for that reply, so the connection stalls.

After ARTEMIS-5819
- NoHttpKeepAliveRunnable→ response slots tend to accumulate and are not flushed when the broker has nothing to say.
- No idle GET → no way to create a new response slot when the queue is empty and async traffic already consumed capacity.

Proposed fix

1. Revert ARTEMIS-5819(restoreHttpKeepAliveRunnable/HttpIdleTimerand related config).
2. Fix GET handlinginHttpAcceptorHandler: on HTTP GET fromHttpIdleTimer,enqueue a new response when responses is empty(do not forward GET as a Core packet). That gives pendingResponseRunners (including replies blocked behind async packets) a slot to flush into.
3. Keep POST behavior for real traffic; empty keep-alive responses remain for the “more requests than replies” side.